### PR TITLE
Exchange of user profiles during contact establishment

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,16 +17,13 @@ members = [
 ]
 
 [workspace.dependencies]
-tls_codec = { version = "0.3.0", features = ["derive", "serde", "mls"] }
+tls_codec = { version = "0.4.0", features = ["derive", "serde", "mls"] }
 reqwest = { version = "^0.11", features = [
     "json",
     "rustls-tls-webpki-roots",
     "rustls",
     "brotli",
 ], default-features = false }
-
-[patch.crates-io]
-tls_codec = { git = 'https://github.com/RustCrypto/formats.git', rev = '3e65c66f4af19f22952200e3c5da3f035efe8e7a' }
 
 [profile.production]
 inherits = "release"

--- a/apiclient/src/as_api/mod.rs
+++ b/apiclient/src/as_api/mod.rs
@@ -79,7 +79,7 @@ impl ApiClient {
                         let ds_proc_res_bytes =
                             res.bytes().await.map_err(|_| AsRequestError::BadResponse)?;
                         let ds_proc_res =
-                            AsProcessResponseIn::tls_deserialize_exact(&ds_proc_res_bytes)
+                            AsProcessResponseIn::tls_deserialize_exact_bytes(&ds_proc_res_bytes)
                                 .map_err(|_| AsRequestError::BadResponse)?;
                         Ok(ds_proc_res)
                     }
@@ -88,7 +88,7 @@ impl ApiClient {
                         let ds_proc_err_bytes =
                             res.bytes().await.map_err(|_| AsRequestError::BadResponse)?;
                         let ds_proc_err =
-                            AsProcessingError::tls_deserialize_exact(&ds_proc_err_bytes)
+                            AsProcessingError::tls_deserialize_exact_bytes(&ds_proc_err_bytes)
                                 .map_err(|_| AsRequestError::BadResponse)?;
                         Err(AsRequestError::AsError(ds_proc_err))
                     }

--- a/apiclient/src/ds_api/mod.rs
+++ b/apiclient/src/ds_api/mod.rs
@@ -91,7 +91,7 @@ impl ApiClient {
                         let ds_proc_res_bytes =
                             res.bytes().await.map_err(|_| DsRequestError::BadResponse)?;
                         let ds_proc_res =
-                            DsProcessResponseIn::tls_deserialize_exact(&ds_proc_res_bytes)
+                            DsProcessResponseIn::tls_deserialize_exact_bytes(&ds_proc_res_bytes)
                                 .map_err(|e| {
                                     log::warn!("Couldn't deserialize OK response body: {:?}", e);
                                     DsRequestError::BadResponse
@@ -104,13 +104,12 @@ impl ApiClient {
                             log::warn!("No body in DS-error response.");
                             DsRequestError::BadResponse
                         })?;
-                        let ds_proc_err = DsProcessingError::tls_deserialize_exact(
-                            &ds_proc_err_bytes,
-                        )
-                        .map_err(|_| {
-                            log::warn!("Couldn't deserialize DS-error response body.");
-                            DsRequestError::BadResponse
-                        })?;
+                        let ds_proc_err =
+                            DsProcessingError::tls_deserialize_exact_bytes(&ds_proc_err_bytes)
+                                .map_err(|_| {
+                                    log::warn!("Couldn't deserialize DS-error response body.");
+                                    DsRequestError::BadResponse
+                                })?;
                         Err(DsRequestError::DsError(ds_proc_err))
                     }
                     // All other errors

--- a/apiclient/src/qs_api/mod.rs
+++ b/apiclient/src/qs_api/mod.rs
@@ -95,7 +95,7 @@ impl ApiClient {
                         let ds_proc_res_bytes =
                             res.bytes().await.map_err(|_| QsRequestError::BadResponse)?;
                         let ds_proc_res =
-                            QsProcessResponseIn::tls_deserialize_exact(&ds_proc_res_bytes)
+                            QsProcessResponseIn::tls_deserialize_exact_bytes(&ds_proc_res_bytes)
                                 .map_err(|_| QsRequestError::BadResponse)?;
                         Ok(ds_proc_res)
                     }
@@ -103,8 +103,9 @@ impl ApiClient {
                     418 => {
                         let ds_proc_err_bytes =
                             res.bytes().await.map_err(|_| QsRequestError::BadResponse)?;
-                        let ds_proc_err = QsProcessError::tls_deserialize_exact(&ds_proc_err_bytes)
-                            .map_err(|_| QsRequestError::BadResponse)?;
+                        let ds_proc_err =
+                            QsProcessError::tls_deserialize_exact_bytes(&ds_proc_err_bytes)
+                                .map_err(|_| QsRequestError::BadResponse)?;
                         Err(QsRequestError::QsError(ds_proc_err))
                     }
                     // All other errors

--- a/applogic/src/dart_api.rs
+++ b/applogic/src/dart_api.rs
@@ -9,7 +9,7 @@ use flutter_rust_bridge::{handler::DefaultHandler, support::lazy_static, RustOpa
 use phnxapiclient::qs_api::ws::WsEvent;
 use phnxtypes::{identifiers::UserName, messages::client_ds::QsWsMessage};
 
-use crate::types::ConversationIdBytes;
+use crate::types::{ConversationIdBytes, UiContact};
 pub use crate::types::{
     UiConversation, UiConversationMessage, UiMessageContentType, UiNotificationType,
 };
@@ -261,12 +261,12 @@ impl RustUser {
         messages
     }
 
-    pub fn get_contacts(&self) -> Vec<String> {
+    pub fn get_contacts(&self) -> Vec<UiContact> {
         let user = self.user.lock().unwrap();
         user.contacts()
             .unwrap_or_default()
             .into_iter()
-            .map(|c| c.user_name.to_string())
+            .map(|c| c.into())
             .collect()
     }
 

--- a/applogic/src/dart_api.rs
+++ b/applogic/src/dart_api.rs
@@ -325,6 +325,7 @@ impl RustUser {
             .collect())
     }
 
+    #[tokio::main(flavor = "current_thread")]
     pub async fn set_user_profile(
         &self,
         display_name: String,

--- a/applogic/src/dart_api.rs
+++ b/applogic/src/dart_api.rs
@@ -324,4 +324,14 @@ impl RustUser {
             .map(|c| c.to_string())
             .collect())
     }
+
+    pub async fn set_user_profile(
+        &self,
+        display_name: String,
+        profile_picture_option: Option<Vec<u8>>,
+    ) -> Result<()> {
+        let user = self.user.lock().unwrap();
+        user.store_user_profile(display_name, profile_picture_option)
+            .await
+    }
 }

--- a/applogic/src/types/mod.rs
+++ b/applogic/src/types/mod.rs
@@ -4,10 +4,10 @@
 
 use openmls::group::GroupId;
 use phnxcoreclient::{
-    ContentMessage, Conversation, ConversationAttributes, ConversationId, ConversationMessage,
-    ConversationStatus, ConversationType, DispatchedConversationMessage, DisplayMessage,
-    DisplayMessageType, ErrorMessage, InactiveConversation, Knock, Message, MessageContentType,
-    NotificationType, SystemMessage, TextMessage,
+    Contact, ContentMessage, Conversation, ConversationAttributes, ConversationId,
+    ConversationMessage, ConversationStatus, ConversationType, DispatchedConversationMessage,
+    DisplayMessage, DisplayMessageType, ErrorMessage, InactiveConversation, Knock, Message,
+    MessageContentType, NotificationType, SystemMessage, TextMessage,
 };
 use uuid::Uuid;
 
@@ -356,6 +356,28 @@ impl From<NotificationType> for UiNotificationType {
                 UiNotificationType::ConversationChange(conversation_id.into())
             }
             NotificationType::Message(message) => UiNotificationType::Message(message.into()),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct UiContact {
+    pub user_name: String,
+    pub display_name: String,
+    pub avatar: Option<Vec<u8>>,
+}
+
+impl From<Contact> for UiContact {
+    fn from(contact: Contact) -> Self {
+        let display_name_string = contact.user_profile().display_name().as_ref().to_string();
+        Self {
+            user_name: contact.user_name().to_string(),
+            display_name: display_name_string,
+            avatar: contact
+                .user_profile()
+                .profile_picture_option()
+                .and_then(|a| a.value())
+                .map(|a| a.to_vec()),
         }
     }
 }

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -21,7 +21,9 @@ uuid = { version = "1.0.0", features = ["v4", "serde"] }
 tracing = { version = "0.1.35", features = ["log"] }
 hex = { version = "0.4" }
 
-opaque-ke = { version = "3.0.0-pre.1", features = ["argon2"] }
+opaque-ke = { version = "3.0.0-pre.4", features = [
+    "argon2",
+], git = "https://github.com/facebook/opaque-ke", branch = "dependabot/cargo/voprf-eq-0.5.0-pre.7" }
 mls-assist = { git = "https://github.com/phnx-im/mls-assist", branch = "konrad/interface_changes" }
 tls_codec = { workspace = true }
 privacypass = { git = "https://github.com/raphaelrobert/privacypass" }

--- a/backend/src/ds/add_clients.rs
+++ b/backend/src/ds/add_clients.rs
@@ -54,7 +54,7 @@ impl DsGroupState {
 
         // Validate that the AAD includes enough encrypted credential chains
         let aad_message =
-            InfraAadMessage::tls_deserialize_exact(processed_message.authenticated_data())
+            InfraAadMessage::tls_deserialize_exact_bytes(processed_message.authenticated_data())
                 .map_err(|_| ClientAdditionError::InvalidMessage)?;
         // TODO: Check version of Aad Message
         let aad_payload =
@@ -152,7 +152,7 @@ impl DsGroupState {
             user_profile.clients.push(leaf_index);
 
             // Create the client profile.
-            let client_queue_config = QsClientReference::tls_deserialize_exact(
+            let client_queue_config = QsClientReference::tls_deserialize_exact_bytes(
                 key_package
                     .extensions()
                     .iter()

--- a/backend/src/ds/add_users.rs
+++ b/backend/src/ds/add_users.rs
@@ -69,7 +69,7 @@ impl DsGroupState {
 
         // Validate that the AAD includes enough encrypted credential chains
         let aad_message =
-            InfraAadMessage::tls_deserialize_exact(processed_message.authenticated_data())
+            InfraAadMessage::tls_deserialize_exact_bytes(processed_message.authenticated_data())
                 .map_err(|_| AddUsersError::InvalidMessage)?;
         // TODO: Check version of Aad Message
         let aad_payload = if let InfraAadPayload::AddUsers(aad) = aad_message.into_payload() {
@@ -234,7 +234,7 @@ impl DsGroupState {
                     .find(|m| m.signature_key == key_package.leaf_node().signature_key().as_slice())
                     .ok_or(AddUsersError::InvalidMessage)?;
                 let leaf_index = member.index;
-                let client_queue_config = QsClientReference::tls_deserialize_exact(
+                let client_queue_config = QsClientReference::tls_deserialize_exact_bytes(
                     key_package
                         .leaf_node()
                         .extensions()
@@ -268,7 +268,7 @@ impl DsGroupState {
         let mut fan_out_messages: Vec<DsFanOutMessage> = vec![];
         for (add_packages, attribution_info) in added_users.into_iter() {
             for (key_package, _) in add_packages {
-                let client_queue_config = QsClientReference::tls_deserialize_exact(
+                let client_queue_config = QsClientReference::tls_deserialize_exact_bytes(
                     key_package
                         .leaf_node()
                         .extensions()

--- a/backend/src/ds/join_connection_group.rs
+++ b/backend/src/ds/join_connection_group.rs
@@ -57,7 +57,7 @@ impl DsGroupState {
         };
 
         let aad_message =
-            InfraAadMessage::tls_deserialize_exact(processed_message.authenticated_data())
+            InfraAadMessage::tls_deserialize_exact_bytes(processed_message.authenticated_data())
                 .map_err(|_| {
                     tracing::warn!("Invalid message: Failed to deserialize AAD.");
                     JoinConnectionGroupError::InvalidMessage

--- a/backend/src/ds/join_group.rs
+++ b/backend/src/ds/join_group.rs
@@ -56,7 +56,7 @@ impl DsGroupState {
 
         // If there is an AAD, we might have to update the client profile later.
         let aad_message =
-            InfraAadMessage::tls_deserialize_exact(processed_message.authenticated_data())
+            InfraAadMessage::tls_deserialize_exact_bytes(processed_message.authenticated_data())
                 .map_err(|_| JoinGroupError::InvalidMessage)?;
         // TODO: Check version of Aad Message
         let aad_payload = if let InfraAadPayload::JoinGroup(aad) = aad_message.into_payload() {

--- a/backend/src/ds/update_client.rs
+++ b/backend/src/ds/update_client.rs
@@ -80,7 +80,7 @@ impl DsGroupState {
 
         // If there is an AAD, we might have to update the client profile later.
         let aad_message =
-            InfraAadMessage::tls_deserialize_exact(processed_message.authenticated_data())
+            InfraAadMessage::tls_deserialize_exact_bytes(processed_message.authenticated_data())
                 .map_err(|_| {
                     tracing::warn!("Error deserializing AAD payload");
                     ClientUpdateError::InvalidMessage

--- a/coreclient/Cargo.toml
+++ b/coreclient/Cargo.toml
@@ -27,7 +27,9 @@ pretty_env_logger = "0.5"
 uuid = { version = "1", features = ["v4", "serde"] }
 phnxapiclient = { path = "../apiclient" }
 phnxtypes = { path = "../types" }
-opaque-ke = { version = "3.0.0-pre.1", features = ["argon2"] }
+opaque-ke = { version = "3.0.0-pre.4", features = [
+    "argon2",
+], git = "https://github.com/facebook/opaque-ke", branch = "dependabot/cargo/voprf-eq-0.5.0-pre.7" }
 futures = { version = "0.3.28", features = ["executor"] }
 anyhow = { version = "1.0", features = ["backtrace"] }
 # TODO: Replace this with a CSPRNG

--- a/coreclient/src/contacts/mod.rs
+++ b/coreclient/src/contacts/mod.rs
@@ -49,6 +49,11 @@ pub(crate) struct ContactAddInfos {
 }
 
 impl Contact {
+    /// Get the user name of this contact.
+    pub fn user_name(&self) -> &UserName {
+        &self.user_name
+    }
+
     pub(crate) fn client_credential(&self, client_id: &AsClientId) -> Option<&ClientCredential> {
         self.client_credentials
             .iter()

--- a/coreclient/src/contacts/mod.rs
+++ b/coreclient/src/contacts/mod.rs
@@ -11,10 +11,10 @@ use phnxtypes::{
     },
     identifiers::{AsClientId, UserName},
     keypackage_batch::{KeyPackageBatch, VERIFIED},
-    messages::{client_as::FriendshipPackage, FriendshipToken},
+    messages::FriendshipToken,
 };
 
-use crate::ConversationId;
+use crate::{users::user_profile::UserProfile, ConversationId};
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 
@@ -39,6 +39,7 @@ pub struct Contact {
     pub(crate) signature_ear_key_wrapper_key: SignatureEarKeyWrapperKey,
     // ID of the connection conversation with this contact.
     pub(crate) conversation_id: ConversationId,
+    pub(crate) user_profile: UserProfile,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -66,6 +67,10 @@ impl Contact {
 
     pub(crate) fn wai_ear_key(&self) -> &WelcomeAttributionInfoEarKey {
         &self.wai_ear_key
+    }
+
+    pub fn user_profile(&self) -> &UserProfile {
+        &self.user_profile
     }
 }
 

--- a/coreclient/src/contacts/store.rs
+++ b/coreclient/src/contacts/store.rs
@@ -11,7 +11,7 @@ use rusqlite::Connection;
 
 use crate::{
     key_stores::qs_verifying_keys::QsVerifyingKeyStore,
-    users::api_clients::ApiClients,
+    users::{api_clients::ApiClients, connection_establishment::FriendshipPackage},
     utils::persistence::{DataType, Persistable, PersistableStruct, PersistenceError, SqlKey},
     ConversationId,
 };
@@ -189,6 +189,7 @@ impl PersistableStruct<'_, PartialContact> {
             client_credential_ear_key: friendship_package.client_credential_ear_key,
             signature_ear_key_wrapper_key: friendship_package.signature_ear_key_wrapper_key,
             conversation_id: self.payload.conversation_id,
+            user_profile: friendship_package.user_profile,
         };
         let persistable_contact =
             PersistableStruct::from_connection_and_payload(self.connection, payload);

--- a/coreclient/src/conversations/messages.rs
+++ b/coreclient/src/conversations/messages.rs
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-use tls_codec::{TlsDeserialize, TlsSerialize, TlsSize};
+use tls_codec::{TlsDeserializeBytes, TlsSerialize, TlsSize};
 
 use crate::GroupMessage;
 
@@ -44,7 +44,7 @@ pub struct ContentMessage {
 }
 
 #[derive(
-    PartialEq, Debug, Clone, TlsSerialize, TlsDeserialize, TlsSize, Serialize, Deserialize,
+    PartialEq, Debug, Clone, TlsSerialize, TlsDeserializeBytes, TlsSize, Serialize, Deserialize,
 )]
 #[repr(u16)]
 pub enum MessageContentType {
@@ -53,7 +53,7 @@ pub enum MessageContentType {
 }
 
 #[derive(
-    PartialEq, Debug, Clone, TlsSerialize, TlsDeserialize, TlsSize, Serialize, Deserialize,
+    PartialEq, Debug, Clone, TlsSerialize, TlsDeserializeBytes, TlsSize, Serialize, Deserialize,
 )]
 pub struct TextMessage {
     message: Vec<u8>,
@@ -70,7 +70,7 @@ impl TextMessage {
 }
 
 #[derive(
-    PartialEq, Debug, Clone, TlsSerialize, TlsDeserialize, TlsSize, Serialize, Deserialize,
+    PartialEq, Debug, Clone, TlsSerialize, TlsDeserializeBytes, TlsSize, Serialize, Deserialize,
 )]
 pub struct Knock {}
 

--- a/coreclient/src/conversations/mod.rs
+++ b/coreclient/src/conversations/mod.rs
@@ -43,7 +43,7 @@ impl TryFrom<GroupId> for ConversationId {
     type Error = tls_codec::Error;
 
     fn try_from(value: GroupId) -> Result<Self, Self::Error> {
-        let qgid = QualifiedGroupId::tls_deserialize_exact(value.as_slice())?;
+        let qgid = QualifiedGroupId::tls_deserialize_exact_bytes(value.as_slice())?;
         let conversation_id = Self {
             uuid: Uuid::from_bytes(qgid.group_id),
         };
@@ -53,7 +53,7 @@ impl TryFrom<GroupId> for ConversationId {
 
 impl SqlKey for GroupId {
     fn to_sql_key(&self) -> String {
-        let qgid = QualifiedGroupId::tls_deserialize_exact(self.as_slice()).unwrap();
+        let qgid = QualifiedGroupId::tls_deserialize_exact_bytes(self.as_slice()).unwrap();
         let conversation_id = ConversationId {
             uuid: Uuid::from_bytes(qgid.group_id),
         };

--- a/coreclient/src/conversations/store.rs
+++ b/coreclient/src/conversations/store.rs
@@ -57,7 +57,8 @@ impl Conversation {
     }
 
     pub(crate) fn owner_domain(&self) -> Fqdn {
-        let qgid = QualifiedGroupId::tls_deserialize_exact(&self.group_id.as_slice()).unwrap();
+        let qgid =
+            QualifiedGroupId::tls_deserialize_exact_bytes(&self.group_id.as_slice()).unwrap();
         qgid.owning_domain
     }
 

--- a/coreclient/src/groups/mod.rs
+++ b/coreclient/src/groups/mod.rs
@@ -82,6 +82,14 @@ pub const REQUIRED_EXTENSION_TYPES: [ExtensionType; 0] = [];
 pub const REQUIRED_PROPOSAL_TYPES: [ProposalType; 0] = [];
 pub const REQUIRED_CREDENTIAL_TYPES: [CredentialType; 1] = [CredentialType::Infra];
 
+fn default_required_capabilities() -> RequiredCapabilitiesExtension {
+    RequiredCapabilitiesExtension::new(
+        &REQUIRED_EXTENSION_TYPES,
+        &REQUIRED_PROPOSAL_TYPES,
+        &REQUIRED_CREDENTIAL_TYPES,
+    )
+}
+
 // Default capabilities for every leaf node we create.
 pub const SUPPORTED_PROTOCOL_VERSIONS: [ProtocolVersion; 1] = [ProtocolVersion::Mls10];
 pub const SUPPORTED_CIPHERSUITES: [Ciphersuite; 1] =
@@ -93,6 +101,16 @@ pub const SUPPORTED_EXTENSIONS: [ExtensionType; 2] = [
 pub const SUPPORTED_PROPOSALS: [ProposalType; 1] =
     [ProposalType::Unknown(FRIENDSHIP_PACKAGE_PROPOSAL_TYPE)];
 pub const SUPPORTED_CREDENTIALS: [CredentialType; 1] = [CredentialType::Infra];
+
+fn default_capabilities() -> Capabilities {
+    Capabilities::new(
+        Some(&SUPPORTED_PROTOCOL_VERSIONS),
+        Some(&SUPPORTED_CIPHERSUITES),
+        Some(&SUPPORTED_EXTENSIONS),
+        Some(&SUPPORTED_PROPOSALS),
+        Some(&SUPPORTED_CREDENTIALS),
+    )
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct ClientAuthInfo {
@@ -210,26 +228,12 @@ impl Group {
         &self.mls_group
     }
 
-    fn default_mls_group_config() -> MlsGroupConfig {
-        let required_capabilities = RequiredCapabilitiesExtension::new(
-            &REQUIRED_EXTENSION_TYPES,
-            &REQUIRED_PROPOSAL_TYPES,
-            &REQUIRED_CREDENTIAL_TYPES,
-        );
-
-        MlsGroupConfig::builder()
+    fn default_mls_group_join_config() -> MlsGroupJoinConfig {
+        MlsGroupJoinConfig::builder()
             // This is turned on for now, as it makes OpenMLS return GroupInfos
             // with every commit. At some point, there should be a dedicated
             // config flag for this.
-            .leaf_node_capabilities(Capabilities::new(
-                Some(&SUPPORTED_PROTOCOL_VERSIONS),
-                Some(&SUPPORTED_CIPHERSUITES),
-                Some(&SUPPORTED_EXTENSIONS),
-                Some(&SUPPORTED_PROPOSALS),
-                Some(&SUPPORTED_CREDENTIALS),
-            ))
             .use_ratchet_tree_extension(true)
-            .required_capabilities(required_capabilities)
             .wire_format_policy(PURE_PLAINTEXT_WIRE_FORMAT_POLICY)
             .build()
     }
@@ -248,21 +252,27 @@ impl Group {
         let signature_ear_key = SignatureEarKey::random()?;
         let leaf_signer = InfraCredentialSigningKey::generate(signer, &signature_ear_key);
 
-        let mls_group_config = Self::default_mls_group_config();
+        let required_capabilities =
+            Extension::RequiredCapabilities(default_required_capabilities());
+        let leaf_node_capabilities = default_capabilities();
 
         let credential_with_key = CredentialWithKey {
             credential: Credential::from(leaf_signer.credential().clone()),
             signature_key: leaf_signer.credential().verifying_key().clone(),
         };
+        let gc_extensions = Extensions::single(required_capabilities);
 
-        let mls_group = MlsGroup::new_with_group_id(
-            provider,
-            &leaf_signer,
-            &mls_group_config,
-            group_id.clone(),
-            credential_with_key,
-        )
-        .map_err(|e| anyhow!("Error while creating group: {:?}", e))?;
+        let mls_group = MlsGroup::builder()
+            .with_group_id(group_id.clone())
+            // This is turned on for now, as it makes OpenMLS return GroupInfos
+            // with every commit. At some point, there should be a dedicated
+            // config flag for this.
+            .with_capabilities(leaf_node_capabilities)
+            .use_ratchet_tree_extension(true)
+            .with_group_context_extensions(gc_extensions)?
+            .with_wire_format_policy(PURE_PLAINTEXT_WIRE_FORMAT_POLICY)
+            .build(provider, &leaf_signer, credential_with_key)
+            .map_err(|e| anyhow!("Error while creating group: {:?}", e))?;
 
         let encrypted_signature_ear_key =
             signature_ear_key.encrypt(&signature_ear_key_wrapper_key)?;
@@ -305,7 +315,7 @@ impl Group {
     ) -> Result<Self> {
         let serialized_welcome = welcome_bundle.welcome.tls_serialize_detached()?;
 
-        let mls_group_config = Self::default_mls_group_config();
+        let mls_group_config = Self::default_mls_group_join_config();
 
         // Decrypt encrypted credentials s.t. we can afterwards consume the welcome.
         let key_package: KeyPackage = welcome_bundle
@@ -419,7 +429,7 @@ impl Group {
         // TODO: We set the ratchet tree extension for now, as it is the only
         // way to make OpenMLS return a GroupInfo. This should change in the
         // future.
-        let mls_group_config = Self::default_mls_group_config();
+        let mls_group_config = Self::default_mls_group_join_config();
         let credential_with_key = CredentialWithKey {
             credential: leaf_signer.credential().clone().into(),
             signature_key: leaf_signer.credential().verifying_key().clone(),
@@ -503,295 +513,295 @@ impl Group {
         // Will be set to true if we were removed (or the group was deleted).
         let mut we_were_removed = false;
         let mut diff = GroupDiff::new(self);
-        let sender_index = match processed_message.content() {
-            // For now, we only care about commits.
-            ProcessedMessageContent::ExternalJoinProposalMessage(_) => {
-                bail!("Unsupported message type")
-            }
-            ProcessedMessageContent::ApplicationMessage(_) => {
-                let ClientAuthInfo {
-                    client_credential: sender_credential,
-                    ..
-                } = if let Sender::Member(index) = processed_message.sender() {
-                    self.client_information
-                        .get(index.usize())
-                        .ok_or(anyhow!("Unknown sender"))?
-                } else {
-                    bail!("Invalid sender type.")
-                };
-                return Ok((processed_message, false, sender_credential.clone()));
-            }
-            ProcessedMessageContent::ProposalMessage(_proposal) => {
-                // Proposals are just returned and can then be added to the
-                // proposal store after the caller has inspected them.
-                let sender_index = if let Sender::Member(index) = processed_message.sender() {
-                    index.usize()
-                } else {
-                    bail!("Invalid sender type.")
-                };
-                sender_index
-            }
-            ProcessedMessageContent::StagedCommitMessage(staged_commit) => {
-                // Before we process the AAD payload, we first process the
-                // proposals by value. Currently only removes are allowed.
-                for remove_proposal in staged_commit.remove_proposals() {
-                    let removed_member = remove_proposal.remove_proposal().removed();
-                    diff.remove_client_credential(removed_member);
-                    if removed_member == self.mls_group().own_leaf_index() {
-                        we_were_removed = true;
-                    }
+        let sender_index =
+            match processed_message.content() {
+                // For now, we only care about commits.
+                ProcessedMessageContent::ExternalJoinProposalMessage(_) => {
+                    bail!("Unsupported message type")
                 }
-                // Let's figure out which operation this is meant to be.
-                let aad_payload =
-                    InfraAadMessage::tls_deserialize_exact(processed_message.authenticated_data())?
-                        .into_payload();
-                let sender_index = match processed_message.sender() {
-                    Sender::Member(index) => index.to_owned(),
-                    Sender::NewMemberCommit => {
-                        self.mls_group.ext_commit_sender_index(staged_commit)?
-                    }
-                    Sender::External(_) | Sender::NewMemberProposal => {
+                ProcessedMessageContent::ApplicationMessage(_) => {
+                    let ClientAuthInfo {
+                        client_credential: sender_credential,
+                        ..
+                    } = if let Sender::Member(index) = processed_message.sender() {
+                        self.client_information
+                            .get(index.usize())
+                            .ok_or(anyhow!("Unknown sender"))?
+                    } else {
                         bail!("Invalid sender type.")
-                    }
+                    };
+                    return Ok((processed_message, false, sender_credential.clone()));
                 }
-                .usize();
-                match aad_payload {
-                    InfraAadPayload::AddUsers(add_users_payload) => {
-                        let client_auth_infos = ClientAuthInfo::decrypt_and_verify_all(
-                            &self.credential_ear_key,
-                            &self.signature_ear_key_wrapper_key,
-                            as_credential_store,
-                            add_users_payload.encrypted_credential_information,
-                        )
-                        .await?;
-
-                        // TODO: Validation:
-                        // * Check that this commit only contains (inline) add proposals
-                        // * Check that the leaf credential is not changed in the path
-                        //   (or maybe if it is, check that it's valid).
-                        // * User names MUST be unique within the group (check both new
-                        //   and existing credentials for duplicates).
-                        // * Client IDs MUST be unique within the group (only need to
-                        //   check new credentials, as client IDs are scoped to user
-                        //   names).
-                        // * Once we do RBAC, check that the adder has sufficient
-                        //   permissions.
-                        // * Maybe check sender type (only Members can add users).
-
-                        // Verify the leaf credentials in all add proposals. We assume
-                        // that leaf credentials are in the same order as client
-                        // credentials.
-                        if staged_commit.add_proposals().count() != client_auth_infos.len() {
-                            bail!("Number of add proposals and client credentials don't match.")
+                ProcessedMessageContent::ProposalMessage(_proposal) => {
+                    // Proposals are just returned and can then be added to the
+                    // proposal store after the caller has inspected them.
+                    let sender_index = if let Sender::Member(index) = processed_message.sender() {
+                        index.usize()
+                    } else {
+                        bail!("Invalid sender type.")
+                    };
+                    sender_index
+                }
+                ProcessedMessageContent::StagedCommitMessage(staged_commit) => {
+                    // Before we process the AAD payload, we first process the
+                    // proposals by value. Currently only removes are allowed.
+                    for remove_proposal in staged_commit.remove_proposals() {
+                        let removed_member = remove_proposal.remove_proposal().removed();
+                        diff.remove_client_credential(removed_member);
+                        if removed_member == self.mls_group().own_leaf_index() {
+                            we_were_removed = true;
                         }
-                        for (proposal, client_auth_info) in
-                            staged_commit.add_proposals().zip(client_auth_infos.iter())
-                        {
-                            client_auth_info.verify_infra_credential(
-                                proposal
-                                    .add_proposal()
-                                    .key_package()
-                                    .leaf_node()
-                                    .credential()
-                                    .mls_credential_type(),
-                            )?;
-                        }
-
-                        // Add the client credentials to the group.
-                        diff.add_client_information(client_auth_infos)
                     }
-                    InfraAadPayload::UpdateClient(update_client_payload) => {
-                        let sender_index = if let Sender::Member(index) = processed_message.sender()
-                        {
-                            index.usize()
-                        } else {
-                            bail!("Unsupported sender type.")
-                        };
-                        // Check if the client has updated its leaf credential.
-                        if let Some(infra_credential) = processed_message
-                            .new_credential_option()
-                            .map(|cred| cred.mls_credential_type())
-                        {
-                            // If so, then there has to be a new signature ear key.
-                            let Some(encrypted_signature_ear_key) =
-                                update_client_payload.option_encrypted_signature_ear_key
-                            else {
-                                bail!("Invalid update client payload.")
-                            };
-                            // Optionally, the client could have updated its
-                            // client credential.
-                            let client_auth_info = if let Some(ecc) =
-                                update_client_payload.option_encrypted_client_credential
+                    // Let's figure out which operation this is meant to be.
+                    let aad_payload = InfraAadMessage::tls_deserialize_exact_bytes(
+                        processed_message.authenticated_data(),
+                    )?
+                    .into_payload();
+                    let sender_index = match processed_message.sender() {
+                        Sender::Member(index) => index.to_owned(),
+                        Sender::NewMemberCommit => {
+                            self.mls_group.ext_commit_sender_index(staged_commit)?
+                        }
+                        Sender::External(_) | Sender::NewMemberProposal => {
+                            bail!("Invalid sender type.")
+                        }
+                    }
+                    .usize();
+                    match aad_payload {
+                        InfraAadPayload::AddUsers(add_users_payload) => {
+                            let client_auth_infos = ClientAuthInfo::decrypt_and_verify_all(
+                                &self.credential_ear_key,
+                                &self.signature_ear_key_wrapper_key,
+                                as_credential_store,
+                                add_users_payload.encrypted_credential_information,
+                            )
+                            .await?;
+
+                            // TODO: Validation:
+                            // * Check that this commit only contains (inline) add proposals
+                            // * Check that the leaf credential is not changed in the path
+                            //   (or maybe if it is, check that it's valid).
+                            // * User names MUST be unique within the group (check both new
+                            //   and existing credentials for duplicates).
+                            // * Client IDs MUST be unique within the group (only need to
+                            //   check new credentials, as client IDs are scoped to user
+                            //   names).
+                            // * Once we do RBAC, check that the adder has sufficient
+                            //   permissions.
+                            // * Maybe check sender type (only Members can add users).
+
+                            // Verify the leaf credentials in all add proposals. We assume
+                            // that leaf credentials are in the same order as client
+                            // credentials.
+                            if staged_commit.add_proposals().count() != client_auth_infos.len() {
+                                bail!("Number of add proposals and client credentials don't match.")
+                            }
+                            for (proposal, client_auth_info) in
+                                staged_commit.add_proposals().zip(client_auth_infos.iter())
                             {
-                                ClientAuthInfo::decrypt_and_verify(
-                                    &self.credential_ear_key,
-                                    &self.signature_ear_key_wrapper_key,
-                                    as_credential_store,
-                                    (ecc, encrypted_signature_ear_key),
-                                )
-                                .await?
-                            } else {
-                                // If not, we decrypt the new EAR key and use
-                                // the existing client credential.
-                                let signature_ear_key = SignatureEarKey::decrypt(
-                                    &self.signature_ear_key_wrapper_key,
-                                    &encrypted_signature_ear_key,
+                                client_auth_info.verify_infra_credential(
+                                    proposal
+                                        .add_proposal()
+                                        .key_package()
+                                        .leaf_node()
+                                        .credential()
+                                        .mls_credential_type(),
                                 )?;
-                                let client_credential = self
-                                    .client_information
-                                    .get(sender_index)
-                                    .ok_or(anyhow!(
-                                        "Can't find sender information in client credentials"
-                                    ))?
-                                    .client_credential()
-                                    .clone();
-                                ClientAuthInfo::new(client_credential, signature_ear_key)
+                            }
+
+                            // Add the client credentials to the group.
+                            diff.add_client_information(client_auth_infos)
+                        }
+                        InfraAadPayload::UpdateClient(update_client_payload) => {
+                            let sender_index =
+                                if let Sender::Member(index) = processed_message.sender() {
+                                    index.usize()
+                                } else {
+                                    bail!("Unsupported sender type.")
+                                };
+                            // Check if the client has updated its leaf credential.
+                            if let Some(infra_credential) = processed_message
+                                .new_credential_option()
+                                .map(|cred| cred.mls_credential_type())
+                            {
+                                // If so, then there has to be a new signature ear key.
+                                let Some(encrypted_signature_ear_key) =
+                                    update_client_payload.option_encrypted_signature_ear_key
+                                else {
+                                    bail!("Invalid update client payload.")
+                                };
+                                // Optionally, the client could have updated its
+                                // client credential.
+                                let client_auth_info = if let Some(ecc) =
+                                    update_client_payload.option_encrypted_client_credential
+                                {
+                                    ClientAuthInfo::decrypt_and_verify(
+                                        &self.credential_ear_key,
+                                        &self.signature_ear_key_wrapper_key,
+                                        as_credential_store,
+                                        (ecc, encrypted_signature_ear_key),
+                                    )
+                                    .await?
+                                } else {
+                                    // If not, we decrypt the new EAR key and use
+                                    // the existing client credential.
+                                    let signature_ear_key = SignatureEarKey::decrypt(
+                                        &self.signature_ear_key_wrapper_key,
+                                        &encrypted_signature_ear_key,
+                                    )?;
+                                    let client_credential = self
+                                        .client_information
+                                        .get(sender_index)
+                                        .ok_or(anyhow!(
+                                            "Can't find sender information in client credentials"
+                                        ))?
+                                        .client_credential()
+                                        .clone();
+                                    ClientAuthInfo::new(client_credential, signature_ear_key)
+                                };
+                                // Verify the leaf credential
+                                client_auth_info.verify_infra_credential(infra_credential)?;
+                                diff.update_client_information(sender_index, client_auth_info);
                             };
-                            // Verify the leaf credential
-                            client_auth_info.verify_infra_credential(infra_credential)?;
-                            diff.update_client_information(sender_index, client_auth_info);
-                        };
-                        // TODO: Validation:
-                        // * Check that the sender type fits.
-                        // * Check that the client id is the same as before.
-                        // * Check that the proposals fit the operation (i.e. in this
-                        //   case that there are no proposals at all).
+                            // TODO: Validation:
+                            // * Check that the sender type fits.
+                            // * Check that the client id is the same as before.
+                            // * Check that the proposals fit the operation (i.e. in this
+                            //   case that there are no proposals at all).
 
-                        // Verify a potential new leaf credential.
-                    }
-                    InfraAadPayload::JoinGroup(join_group_payload) => {
-                        // Decrypt and verify the client credential.
-                        let client_auth_info = ClientAuthInfo::decrypt_and_verify(
-                            &self.credential_ear_key,
-                            &self.signature_ear_key_wrapper_key,
-                            as_credential_store,
-                            join_group_payload.encrypted_client_information,
-                        )
-                        .await?;
-                        // Validate the leaf credential.
-                        client_auth_info.verify_infra_credential(
-                            processed_message.credential().mls_credential_type(),
-                        )?;
-                        // Check that the existing user clients match up.
-                        if self.user_client_indices(
-                            client_auth_info.client_credential().identity().user_name(),
-                        ) != join_group_payload
-                            .existing_user_clients
-                            .into_iter()
-                            .map(|index| index.usize())
-                            .collect::<Vec<_>>()
-                        {
-                            bail!("User clients don't match up.")
-                        };
-                        // TODO: (More) validation:
-                        // * Check that the client id is unique.
-                        // * Check that the proposals fit the operation.
-                        // Insert the client credential into the diff.
-                        diff.add_client_information(vec![client_auth_info]);
-                    }
-                    InfraAadPayload::JoinConnectionGroup(join_connection_group_payload) => {
-                        let client_auth_info = ClientAuthInfo::decrypt_and_verify(
-                            &self.credential_ear_key,
-                            &self.signature_ear_key_wrapper_key,
-                            as_credential_store,
-                            join_connection_group_payload.encrypted_client_information,
-                        )
-                        .await?;
-                        // Validate the leaf credential.
-                        client_auth_info.verify_infra_credential(
-                            processed_message.credential().mls_credential_type(),
-                        )?;
-                        // TODO: (More) validation:
-                        // * Check that the user name is unique.
-                        // * Check that the proposals fit the operation.
-                        // * Check that the sender type fits the operation.
-                        // * Check that this group is indeed a connection group.
-
-                        // Insert the client credential into the diff.
-                        diff.add_client_information(vec![client_auth_info]);
-                    }
-                    InfraAadPayload::AddClients(add_clients_payload) => {
-                        let client_auth_infos = ClientAuthInfo::decrypt_and_verify_all(
-                            &self.credential_ear_key,
-                            &self.signature_ear_key_wrapper_key,
-                            as_credential_store,
-                            add_clients_payload.encrypted_client_information,
-                        )
-                        .await?;
-
-                        // TODO: Validation:
-                        // * Check that this commit only contains (inline) add proposals
-                        // * Check that the leaf credential is not changed in the path
-                        //   (or maybe if it is, check that it's valid).
-                        // * Client IDs MUST be unique within the group.
-                        // * Maybe check sender type (only Members can add users).
-
-                        // Verify the leaf credentials in all add proposals. We assume
-                        // that leaf credentials are in the same order as client
-                        // credentials.
-                        if staged_commit.add_proposals().count() != client_auth_infos.len() {
-                            bail!("Number of add proposals and client credentials don't match.")
+                            // Verify a potential new leaf credential.
                         }
-                        for (proposal, client_auth_info) in
-                            staged_commit.add_proposals().zip(client_auth_infos.iter())
-                        {
+                        InfraAadPayload::JoinGroup(join_group_payload) => {
+                            // Decrypt and verify the client credential.
+                            let client_auth_info = ClientAuthInfo::decrypt_and_verify(
+                                &self.credential_ear_key,
+                                &self.signature_ear_key_wrapper_key,
+                                as_credential_store,
+                                join_group_payload.encrypted_client_information,
+                            )
+                            .await?;
+                            // Validate the leaf credential.
                             client_auth_info.verify_infra_credential(
-                                proposal
-                                    .add_proposal()
-                                    .key_package()
-                                    .leaf_node()
-                                    .credential()
-                                    .mls_credential_type(),
+                                processed_message.credential().mls_credential_type(),
                             )?;
+                            // Check that the existing user clients match up.
+                            if self.user_client_indices(
+                                client_auth_info.client_credential().identity().user_name(),
+                            ) != join_group_payload
+                                .existing_user_clients
+                                .into_iter()
+                                .map(|index| index.usize())
+                                .collect::<Vec<_>>()
+                            {
+                                bail!("User clients don't match up.")
+                            };
+                            // TODO: (More) validation:
+                            // * Check that the client id is unique.
+                            // * Check that the proposals fit the operation.
+                            // Insert the client credential into the diff.
+                            diff.add_client_information(vec![client_auth_info]);
                         }
+                        InfraAadPayload::JoinConnectionGroup(join_connection_group_payload) => {
+                            let client_auth_info = ClientAuthInfo::decrypt_and_verify(
+                                &self.credential_ear_key,
+                                &self.signature_ear_key_wrapper_key,
+                                as_credential_store,
+                                join_connection_group_payload.encrypted_client_information,
+                            )
+                            .await?;
+                            // Validate the leaf credential.
+                            client_auth_info.verify_infra_credential(
+                                processed_message.credential().mls_credential_type(),
+                            )?;
+                            // TODO: (More) validation:
+                            // * Check that the user name is unique.
+                            // * Check that the proposals fit the operation.
+                            // * Check that the sender type fits the operation.
+                            // * Check that this group is indeed a connection group.
 
-                        // Add the client credentials to the group.
-                        diff.add_client_information(client_auth_infos)
-                    }
-                    InfraAadPayload::RemoveUsers | InfraAadPayload::RemoveClients => {
-                        // We already processed remove proposals above, so there is nothing to do here.
-                        // TODO: Validation:
-                        // * Check that this commit only contains (inline) remove proposals
-                        // * Check that the sender type is correct.
-                        // * Check that the leaf credential is not changed in the path
-                        // * Check that the remover has sufficient privileges.
-                    }
-                    InfraAadPayload::ResyncClient => {
-                        // TODO: Validation:
-                        // * Check that this commit contains exactly one remove proposal
-                        // * Check that the sender type is correct (external commit).
+                            // Insert the client credential into the diff.
+                            diff.add_client_information(vec![client_auth_info]);
+                        }
+                        InfraAadPayload::AddClients(add_clients_payload) => {
+                            let client_auth_infos = ClientAuthInfo::decrypt_and_verify_all(
+                                &self.credential_ear_key,
+                                &self.signature_ear_key_wrapper_key,
+                                as_credential_store,
+                                add_clients_payload.encrypted_client_information,
+                            )
+                            .await?;
 
-                        let removed_index = staged_commit
-                            .remove_proposals()
-                            .next()
-                            .ok_or(anyhow!(
-                                "Resync operation did not contain a remove proposal"
-                            ))?
-                            .remove_proposal()
-                            .removed();
-                        let client_auth_info = self
-                            .client_information
-                            .get(removed_index.usize())
-                            .ok_or(anyhow!(
-                            "Could not find client credential of resync sender"
-                        ))?;
-                        // Let's verify the new leaf credential.
-                        client_auth_info.verify_infra_credential(
-                            processed_message.credential().mls_credential_type(),
-                        )?;
+                            // TODO: Validation:
+                            // * Check that this commit only contains (inline) add proposals
+                            // * Check that the leaf credential is not changed in the path
+                            //   (or maybe if it is, check that it's valid).
+                            // * Client IDs MUST be unique within the group.
+                            // * Maybe check sender type (only Members can add users).
 
-                        // Move the client credential to the new index.
-                        diff.remove_client_credential(removed_index);
-                        diff.add_client_information(vec![client_auth_info.clone()]);
-                    }
-                    InfraAadPayload::DeleteGroup => {
-                        we_were_removed = true;
-                        // There is nothing else to do at this point.
-                    }
-                };
-                sender_index
-            }
-        };
+                            // Verify the leaf credentials in all add proposals. We assume
+                            // that leaf credentials are in the same order as client
+                            // credentials.
+                            if staged_commit.add_proposals().count() != client_auth_infos.len() {
+                                bail!("Number of add proposals and client credentials don't match.")
+                            }
+                            for (proposal, client_auth_info) in
+                                staged_commit.add_proposals().zip(client_auth_infos.iter())
+                            {
+                                client_auth_info.verify_infra_credential(
+                                    proposal
+                                        .add_proposal()
+                                        .key_package()
+                                        .leaf_node()
+                                        .credential()
+                                        .mls_credential_type(),
+                                )?;
+                            }
+
+                            // Add the client credentials to the group.
+                            diff.add_client_information(client_auth_infos)
+                        }
+                        InfraAadPayload::RemoveUsers | InfraAadPayload::RemoveClients => {
+                            // We already processed remove proposals above, so there is nothing to do here.
+                            // TODO: Validation:
+                            // * Check that this commit only contains (inline) remove proposals
+                            // * Check that the sender type is correct.
+                            // * Check that the leaf credential is not changed in the path
+                            // * Check that the remover has sufficient privileges.
+                        }
+                        InfraAadPayload::ResyncClient => {
+                            // TODO: Validation:
+                            // * Check that this commit contains exactly one remove proposal
+                            // * Check that the sender type is correct (external commit).
+
+                            let removed_index = staged_commit
+                                .remove_proposals()
+                                .next()
+                                .ok_or(anyhow!(
+                                    "Resync operation did not contain a remove proposal"
+                                ))?
+                                .remove_proposal()
+                                .removed();
+                            let client_auth_info =
+                                self.client_information.get(removed_index.usize()).ok_or(
+                                    anyhow!("Could not find client credential of resync sender"),
+                                )?;
+                            // Let's verify the new leaf credential.
+                            client_auth_info.verify_infra_credential(
+                                processed_message.credential().mls_credential_type(),
+                            )?;
+
+                            // Move the client credential to the new index.
+                            diff.remove_client_credential(removed_index);
+                            diff.add_client_information(vec![client_auth_info.clone()]);
+                        }
+                        InfraAadPayload::DeleteGroup => {
+                            we_were_removed = true;
+                            // There is nothing else to do at this point.
+                        }
+                    };
+                    sender_index
+                }
+            };
         // Get the sender's credential
         let ClientAuthInfo {
             client_credential: sender_credential,
@@ -1393,8 +1403,9 @@ impl GroupMessage {
         sender: &ClientCredential,
         application_message: ApplicationMessage,
     ) -> Result<Self> {
-        let content =
-            MessageContentType::tls_deserialize(&mut application_message.into_bytes().as_slice())?;
+        let content = MessageContentType::tls_deserialize_exact_bytes(
+            &mut application_message.into_bytes().as_slice(),
+        )?;
         let message = Message::Content(ContentMessage {
             sender: sender.identity().user_name().to_string(),
             content,

--- a/coreclient/src/lib.rs
+++ b/coreclient/src/lib.rs
@@ -17,16 +17,19 @@ use std::collections::HashMap;
 
 pub(crate) use crate::errors::*;
 
-pub use crate::conversations::{
-    messages::{
-        ContentMessage, ConversationMessage, DispatchedConversationMessage, DisplayMessage,
-        DisplayMessageType, ErrorMessage, Knock, Message, MessageContentType, NotificationType,
-        SystemMessage, TextMessage,
+pub use crate::{
+    contacts::{Contact, PartialContact},
+    conversations::{
+        messages::{
+            ContentMessage, ConversationMessage, DispatchedConversationMessage, DisplayMessage,
+            DisplayMessageType, ErrorMessage, Knock, Message, MessageContentType, NotificationType,
+            SystemMessage, TextMessage,
+        },
+        Conversation, ConversationAttributes, ConversationId, ConversationStatus, ConversationType,
+        InactiveConversation,
     },
-    Conversation, ConversationAttributes, ConversationId, ConversationStatus, ConversationType,
-    InactiveConversation,
+    groups::GroupMessage,
 };
-pub use crate::groups::GroupMessage;
 
 use notifications::{Notifiable, NotificationHub};
 pub(crate) use openmls::prelude::*;

--- a/coreclient/src/users/connection_establishment.rs
+++ b/coreclient/src/users/connection_establishment.rs
@@ -115,7 +115,7 @@ impl GenericDeserializable for ConnectionEstablishmentPackageIn {
     type Error = tls_codec::Error;
 
     fn deserialize(bytes: &[u8]) -> Result<Self, Self::Error> {
-        Self::tls_deserialize_exact(bytes)
+        Self::tls_deserialize_exact_bytes(bytes)
     }
 }
 
@@ -188,7 +188,7 @@ impl GenericDeserializable for FriendshipPackage {
     type Error = tls_codec::Error;
 
     fn deserialize(bytes: &[u8]) -> Result<Self, Self::Error> {
-        Self::tls_deserialize_exact(bytes)
+        Self::tls_deserialize_exact_bytes(bytes)
     }
 }
 

--- a/coreclient/src/users/connection_establishment.rs
+++ b/coreclient/src/users/connection_establishment.rs
@@ -1,0 +1,160 @@
+// SPDX-FileCopyrightText: 2023 Phoenix R&D GmbH <hello@phnx.im>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+use openmls::group::GroupId;
+use phnxtypes::{
+    credentials::{keys::AsIntermediateVerifyingKey, ClientCredential, VerifiableClientCredential},
+    crypto::{
+        ear::{
+            keys::{
+                ClientCredentialEarKey, FriendshipPackageEarKey, GroupStateEarKey,
+                SignatureEarKeyWrapperKey,
+            },
+            GenericDeserializable, GenericSerializable,
+        },
+        hpke::{HpkeDecryptable, HpkeEncryptable},
+        signatures::signable::{Signable, Signature, SignedStruct, Verifiable, VerifiedStruct},
+        ConnectionDecryptionKey, ConnectionEncryptionKey,
+    },
+    messages::client_as::{EncryptedConnectionEstablishmentPackage, FriendshipPackage},
+};
+use tls_codec::{DeserializeBytes, Serialize, TlsDeserializeBytes, TlsSerialize, TlsSize};
+
+#[derive(Debug, TlsSerialize, TlsSize, Clone)]
+pub struct ConnectionEstablishmentPackageTbs {
+    pub sender_client_credential: ClientCredential,
+    pub connection_group_id: GroupId,
+    pub connection_group_ear_key: GroupStateEarKey,
+    pub connection_group_credential_key: ClientCredentialEarKey,
+    pub connection_group_signature_ear_key_wrapper_key: SignatureEarKeyWrapperKey,
+    pub friendship_package_ear_key: FriendshipPackageEarKey,
+    pub friendship_package: FriendshipPackage,
+}
+
+impl Signable for ConnectionEstablishmentPackageTbs {
+    type SignedOutput = ConnectionEstablishmentPackage;
+
+    fn unsigned_payload(&self) -> Result<Vec<u8>, tls_codec::Error> {
+        self.tls_serialize_detached()
+    }
+
+    fn label(&self) -> &str {
+        "ConnectionEstablishmentPackageTBS"
+    }
+}
+
+#[derive(Debug, TlsSerialize, TlsSize, Clone)]
+pub struct ConnectionEstablishmentPackage {
+    payload: ConnectionEstablishmentPackageTbs,
+    // TBS: All information above signed by the ClientCredential.
+    signature: Signature,
+}
+
+impl GenericSerializable for ConnectionEstablishmentPackage {
+    type Error = tls_codec::Error;
+
+    fn serialize(&self) -> Result<Vec<u8>, Self::Error> {
+        self.tls_serialize_detached()
+    }
+}
+
+impl HpkeEncryptable<ConnectionEncryptionKey, EncryptedConnectionEstablishmentPackage>
+    for ConnectionEstablishmentPackage
+{
+}
+
+impl SignedStruct<ConnectionEstablishmentPackageTbs> for ConnectionEstablishmentPackage {
+    fn from_payload(payload: ConnectionEstablishmentPackageTbs, signature: Signature) -> Self {
+        Self { payload, signature }
+    }
+}
+
+mod private_mod {
+    #[derive(Default)]
+    pub struct Seal;
+}
+
+#[derive(Debug, TlsSerialize, TlsDeserializeBytes, TlsSize, Clone)]
+pub struct ConnectionEstablishmentPackageTbsIn {
+    sender_client_credential: VerifiableClientCredential,
+    connection_group_id: GroupId,
+    connection_group_ear_key: GroupStateEarKey,
+    connection_group_credential_key: ClientCredentialEarKey,
+    connection_group_signature_ear_key_wrapper_key: SignatureEarKeyWrapperKey,
+    pub friendship_package_ear_key: FriendshipPackageEarKey,
+    friendship_package: FriendshipPackage,
+}
+
+impl VerifiedStruct<ConnectionEstablishmentPackageIn> for ConnectionEstablishmentPackageTbsIn {
+    type SealingType = private_mod::Seal;
+
+    fn from_verifiable(
+        verifiable: ConnectionEstablishmentPackageIn,
+        _seal: Self::SealingType,
+    ) -> Self {
+        verifiable.payload
+    }
+}
+
+#[derive(Debug, TlsDeserializeBytes, TlsSize, Clone)]
+pub struct ConnectionEstablishmentPackageIn {
+    payload: ConnectionEstablishmentPackageTbsIn,
+    // TBS: All information above signed by the ClientCredential.
+    signature: Signature,
+}
+
+impl GenericDeserializable for ConnectionEstablishmentPackageIn {
+    type Error = tls_codec::Error;
+
+    fn deserialize(bytes: &[u8]) -> Result<Self, Self::Error> {
+        Self::tls_deserialize_exact(bytes)
+    }
+}
+
+impl ConnectionEstablishmentPackageIn {
+    pub fn sender_credential(&self) -> &VerifiableClientCredential {
+        &self.payload.sender_client_credential
+    }
+
+    pub fn verify(
+        self,
+        verifying_key: &AsIntermediateVerifyingKey,
+    ) -> ConnectionEstablishmentPackageTbs {
+        let sender_client_credential: ClientCredential = self
+            .payload
+            .sender_client_credential
+            .verify(verifying_key)
+            .unwrap();
+        ConnectionEstablishmentPackageTbs {
+            sender_client_credential,
+            connection_group_id: self.payload.connection_group_id,
+            connection_group_ear_key: self.payload.connection_group_ear_key,
+            connection_group_credential_key: self.payload.connection_group_credential_key,
+            connection_group_signature_ear_key_wrapper_key: self
+                .payload
+                .connection_group_signature_ear_key_wrapper_key,
+            friendship_package_ear_key: self.payload.friendship_package_ear_key,
+            friendship_package: self.payload.friendship_package,
+        }
+    }
+}
+
+impl HpkeDecryptable<ConnectionDecryptionKey, EncryptedConnectionEstablishmentPackage>
+    for ConnectionEstablishmentPackageIn
+{
+}
+
+impl Verifiable for ConnectionEstablishmentPackageIn {
+    fn unsigned_payload(&self) -> Result<Vec<u8>, tls_codec::Error> {
+        self.payload.tls_serialize_detached()
+    }
+
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    fn label(&self) -> &str {
+        "ConnectionEstablishmentPackageTBS"
+    }
+}

--- a/coreclient/src/users/mod.rs
+++ b/coreclient/src/users/mod.rs
@@ -36,10 +36,7 @@ use phnxtypes::{
     },
     identifiers::{AsClientId, ClientConfig, QsClientId, QsClientReference, QsUserId, UserName},
     messages::{
-        client_as::{
-            ConnectionEstablishmentPackageTbs, ConnectionPackageTbs, FriendshipPackage,
-            UserConnectionPackagesParams,
-        },
+        client_as::{ConnectionPackageTbs, FriendshipPackage, UserConnectionPackagesParams},
         FriendshipToken, MlsInfraVersion, QueueMessage,
     },
 };
@@ -60,6 +57,7 @@ use crate::{
         qs_verifying_keys::QsVerifyingKeyStore, queue_ratchets::QueueRatchetStore,
         queue_ratchets::QueueType, MemoryUserKeyStore,
     },
+    users::connection_establishment::ConnectionEstablishmentPackageTbs,
     utils::persistence::{open_client_db, open_phnx_db, DataType, Persistable, PersistenceError},
 };
 
@@ -73,6 +71,7 @@ use self::{
 use super::*;
 
 pub(crate) mod api_clients;
+mod connection_establishment;
 mod create_user;
 pub(crate) mod openmls_provider;
 pub mod process;

--- a/coreclient/src/users/process.rs
+++ b/coreclient/src/users/process.rs
@@ -304,6 +304,11 @@ impl<T: Notifiable> SelfUser<T> {
                     let esek = signature_ear_key
                         .encrypt(&cep_tbs.connection_group_signature_ear_key_wrapper_key)?;
 
+                    let user_profile = self
+                        .user_profile_store()
+                        .get()?
+                        .unwrap_or_else(|| UserProfile::from(self.user_name()));
+
                     let encrypted_friendship_package = FriendshipPackage {
                         friendship_token: self.key_store.friendship_token.clone(),
                         add_package_ear_key: self.key_store.add_package_ear_key.clone(),
@@ -313,6 +318,7 @@ impl<T: Notifiable> SelfUser<T> {
                             .signature_ear_key_wrapper_key
                             .clone(),
                         wai_ear_key: self.key_store.wai_ear_key.clone(),
+                        user_profile,
                     }
                     .encrypt(&cep_tbs.friendship_package_ear_key)?;
                     let ecc = self

--- a/coreclient/src/users/process.rs
+++ b/coreclient/src/users/process.rs
@@ -8,7 +8,6 @@ use phnxtypes::{
     identifiers::QualifiedGroupId,
     messages::{
         client_as::ExtractedAsQueueMessagePayload,
-        client_as_out::ConnectionEstablishmentPackageIn,
         client_ds::{
             ExtractedQsQueueMessagePayload, InfraAadMessage, InfraAadPayload,
             JoinConnectionGroupParamsAad,
@@ -21,7 +20,7 @@ use tls_codec::DeserializeBytes;
 
 use crate::conversations::ConversationType;
 
-use super::*;
+use super::{connection_establishment::ConnectionEstablishmentPackageIn, *};
 
 impl<T: Notifiable> SelfUser<T> {
     /// Process received messages by group. This function is meant to be called

--- a/coreclient/src/users/process.rs
+++ b/coreclient/src/users/process.rs
@@ -154,7 +154,8 @@ impl<T: Notifiable> SelfUser<T> {
                                 // friendship package here.
                                 let encrypted_friendship_package =
                                     if let InfraAadPayload::JoinConnectionGroup(payload) =
-                                        InfraAadMessage::tls_deserialize_exact(&aad)?.into_payload()
+                                        InfraAadMessage::tls_deserialize_exact_bytes(&aad)?
+                                            .into_payload()
                                     {
                                         payload.encrypted_friendship_package
                                     } else {
@@ -242,7 +243,7 @@ impl<T: Notifiable> SelfUser<T> {
                 .get(&group_id)?
                 .ok_or(anyhow!("Can't find freshly joined group."))?;
             let params = group.update_user_key(&self.crypto_backend())?;
-            let qgid = QualifiedGroupId::tls_deserialize_exact(group_id.as_slice()).unwrap();
+            let qgid = QualifiedGroupId::tls_deserialize_exact_bytes(group_id.as_slice()).unwrap();
             self.api_clients
                 .get(&qgid.owning_domain)?
                 .ds_update_client(params, group.group_state_ear_key(), group.leaf_signer())
@@ -334,7 +335,7 @@ impl<T: Notifiable> SelfUser<T> {
                     .into();
 
                     // Fetch external commit information.
-                    let qgid = QualifiedGroupId::tls_deserialize_exact(
+                    let qgid = QualifiedGroupId::tls_deserialize_exact_bytes(
                         cep_tbs.connection_group_id.as_slice(),
                     )?;
                     let eci: ExternalCommitInfoIn = self

--- a/coreclient/src/users/user_profile.rs
+++ b/coreclient/src/users/user_profile.rs
@@ -1,0 +1,136 @@
+// SPDX-FileCopyrightText: 2023 Phoenix R&D GmbH <hello@phnx.im>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+use phnxtypes::identifiers::UserName;
+use rusqlite::Connection;
+use serde::{Deserialize, Serialize};
+use tls_codec::{TlsDeserializeBytes, TlsSerialize, TlsSize};
+
+use crate::utils::persistence::{DataType, Persistable, PersistableStruct, PersistenceError};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DisplayName {
+    display_name: String,
+}
+
+impl AsRef<str> for DisplayName {
+    fn as_ref(&self) -> &str {
+        &self.display_name
+    }
+}
+
+impl tls_codec::Size for DisplayName {
+    fn tls_serialized_len(&self) -> usize {
+        self.display_name.as_bytes().tls_serialized_len()
+    }
+}
+
+impl tls_codec::Serialize for DisplayName {
+    fn tls_serialize<W: std::io::Write>(&self, writer: &mut W) -> Result<usize, tls_codec::Error> {
+        self.display_name.as_bytes().tls_serialize(writer)
+    }
+}
+
+impl tls_codec::DeserializeBytes for DisplayName {
+    fn tls_deserialize(bytes: &[u8]) -> Result<(Self, &[u8]), tls_codec::Error> {
+        let (display_name_bytes, bytes): (Vec<u8>, &[u8]) =
+            tls_codec::DeserializeBytes::tls_deserialize(bytes)?;
+        let display_name = String::from_utf8(display_name_bytes.to_vec()).map_err(|_| {
+            tls_codec::Error::DecodingError("Couldn't convert bytes to UTF-8 string".to_string())
+        })?;
+        Ok((DisplayName { display_name }, bytes))
+    }
+}
+
+#[derive(Debug, TlsSerialize, TlsDeserializeBytes, TlsSize, Clone, Serialize, Deserialize)]
+#[repr(u8)]
+pub enum Asset {
+    Value(Vec<u8>),
+    // TODO: Assets by Reference
+}
+
+impl Asset {
+    pub fn value(&self) -> Option<&[u8]> {
+        match self {
+            Asset::Value(value) => Some(value),
+        }
+    }
+}
+
+#[derive(Debug, TlsSerialize, TlsDeserializeBytes, TlsSize, Clone, Serialize, Deserialize)]
+pub struct UserProfile {
+    display_name: DisplayName,
+    profile_picture_option: Option<Asset>,
+}
+
+impl UserProfile {
+    pub(crate) fn new(display_name: String, profile_picture_option: Option<Vec<u8>>) -> Self {
+        let profile_picture_option = profile_picture_option.map(Asset::Value);
+        Self {
+            display_name: DisplayName { display_name },
+            profile_picture_option,
+        }
+    }
+
+    pub fn display_name(&self) -> &DisplayName {
+        &self.display_name
+    }
+
+    pub fn profile_picture_option(&self) -> Option<&Asset> {
+        self.profile_picture_option.as_ref()
+    }
+}
+
+impl From<UserName> for UserProfile {
+    fn from(user_name: UserName) -> Self {
+        Self::new(user_name.to_string(), None)
+    }
+}
+
+impl Persistable for UserProfile {
+    type Key = DataType;
+
+    type SecondaryKey = DataType;
+
+    const DATA_TYPE: DataType = DataType::UserProfile;
+
+    fn key(&self) -> &Self::Key {
+        &Self::DATA_TYPE
+    }
+
+    fn secondary_key(&self) -> &Self::SecondaryKey {
+        &Self::DATA_TYPE
+    }
+}
+
+type PersistableUserProfile<'a> = PersistableStruct<'a, UserProfile>;
+
+impl PersistableUserProfile<'_> {
+    pub(crate) fn into_payload(self) -> UserProfile {
+        self.payload
+    }
+}
+
+pub(crate) struct UserProfileStore<'a> {
+    connection: &'a Connection,
+}
+
+impl<'a> From<&'a Connection> for UserProfileStore<'a> {
+    fn from(connection: &'a Connection) -> Self {
+        Self { connection }
+    }
+}
+
+impl UserProfileStore<'_> {
+    pub(crate) fn store(&self, user_profile: UserProfile) -> Result<(), PersistenceError> {
+        PersistableUserProfile::from_connection_and_payload(self.connection, user_profile).persist()
+    }
+
+    /// Loads the user profile of the user. If the user profile does not exist, returns `None`.
+    pub(crate) fn get(&self) -> Result<Option<UserProfile>, PersistenceError> {
+        let user_profile =
+            PersistableUserProfile::load_one(self.connection, Some(&DataType::UserProfile), None)?;
+        Ok(user_profile.map(|p| p.into_payload()))
+    }
+}

--- a/coreclient/src/users/user_profile.rs
+++ b/coreclient/src/users/user_profile.rs
@@ -33,9 +33,9 @@ impl tls_codec::Serialize for DisplayName {
 }
 
 impl tls_codec::DeserializeBytes for DisplayName {
-    fn tls_deserialize(bytes: &[u8]) -> Result<(Self, &[u8]), tls_codec::Error> {
+    fn tls_deserialize_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), tls_codec::Error> {
         let (display_name_bytes, bytes): (Vec<u8>, &[u8]) =
-            tls_codec::DeserializeBytes::tls_deserialize(bytes)?;
+            tls_codec::DeserializeBytes::tls_deserialize_bytes(bytes)?;
         let display_name = String::from_utf8(display_name_bytes.to_vec()).map_err(|_| {
             tls_codec::Error::DecodingError("Couldn't convert bytes to UTF-8 string".to_string())
         })?;

--- a/coreclient/src/utils/persistence.rs
+++ b/coreclient/src/utils/persistence.rs
@@ -150,6 +150,7 @@ impl<'a, T: Persistable> PersistableStruct<'a, T> {
 #[derive(Debug, Serialize, Deserialize)]
 pub(crate) enum DataType {
     KeyStoreValue,
+    UserProfile,
     Contact,
     PartialContact,
     Conversation,

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -41,7 +41,9 @@ mls-assist = { git = "https://github.com/phnx-im/mls-assist", branch = "konrad/i
 openmls_rust_crypto = { git = "https://github.com/openmls/openmls.git", branch = "konrad/pgi_2" }
 privacypass = { git = "https://github.com/raphaelrobert/privacypass" }
 privacypass-middleware = { git = "https://github.com/phnx-im/pp-middleware" }
-opaque-ke = { version = "3.0.0-pre.1", features = ["argon2"] }
+opaque-ke = { version = "3.0.0-pre.4", features = [
+    "argon2",
+], git = "https://github.com/facebook/opaque-ke", branch = "dependabot/cargo/voprf-eq-0.5.0-pre.7" }
 tls_codec = { workspace = true }
 reqwest = { workspace = true }
 num-traits = "0.2"

--- a/server/src/endpoints/auth_service.rs
+++ b/server/src/endpoints/auth_service.rs
@@ -23,7 +23,7 @@ pub(crate) async fn as_process_message<Asp: AsStorageProvider, Aesp: AsEphemeral
     let storage_provider = as_storage_provider.get_ref();
     let ephemeral_storage_provider = as_ephemeral_storage_provider.get_ref();
     // Create a new group on the DS.
-    let message = match VerifiableClientToAsMessage::tls_deserialize_exact(&message) {
+    let message = match VerifiableClientToAsMessage::tls_deserialize_exact_bytes(&message) {
         Ok(message) => message,
         Err(e) => {
             tracing::warn!("Received invalid message: {:?}", e);

--- a/server/src/endpoints/ds.rs
+++ b/server/src/endpoints/ds.rs
@@ -24,7 +24,7 @@ pub(crate) async fn ds_process_message<Dsp: DsStorageProvider, Qep: QsConnector>
     let storage_provider = ds_storage_provider.get_ref();
     let qs_connector = qs_connector.get_ref();
     // Create a new group on the DS.
-    let message = match DsMessageTypeIn::tls_deserialize_exact(&message) {
+    let message = match DsMessageTypeIn::tls_deserialize_exact_bytes(&message) {
         Ok(message) => message,
         Err(e) => {
             tracing::warn!("Received invalid message: {:?}", e);

--- a/server/src/endpoints/qs/mod.rs
+++ b/server/src/endpoints/qs/mod.rs
@@ -29,7 +29,7 @@ pub(crate) async fn qs_process_message<Qsp: QsStorageProvider>(
     let storage_provider = qs_storage_provider.get_ref();
 
     // Deserialize the message.
-    let message = match VerifiableClientToQsMessage::tls_deserialize_exact(message.as_ref()) {
+    let message = match VerifiableClientToQsMessage::tls_deserialize_exact_bytes(message.as_ref()) {
         Ok(message) => message,
         Err(e) => {
             tracing::warn!("QS received invalid message: {:?}", e);
@@ -64,7 +64,7 @@ pub(crate) async fn qs_process_federated_message<
     message: web::Bytes,
 ) -> impl Responder {
     // Deserialize the message.
-    let message = match QsToQsMessage::tls_deserialize_exact(message.as_ref()) {
+    let message = match QsToQsMessage::tls_deserialize_exact_bytes(message.as_ref()) {
         Ok(message) => message,
         Err(e) => {
             tracing::warn!("QS received invalid federated message: {:?}", e);

--- a/server/src/network_provider.rs
+++ b/server/src/network_provider.rs
@@ -60,7 +60,7 @@ impl NetworkProvider for MockNetworkProvider {
         // Reqwest should resolve the hostname on its own.
         let result = match self.client.post(url).body(bytes).send().await {
             // For now we don't care about the response.
-            Ok(response_bytes) => FederatedProcessingResult::tls_deserialize_exact(
+            Ok(response_bytes) => FederatedProcessingResult::tls_deserialize_exact_bytes(
                 &response_bytes.bytes().await.unwrap(),
             )
             .map_err(|_| MockNetworkError::MalformedResponse)?,

--- a/server/src/storage_provider/postgres/ds.rs
+++ b/server/src/storage_provider/postgres/ds.rs
@@ -57,7 +57,7 @@ impl DsStorageProvider for PostgresDsStorage {
 
     /// Loads the ds group state with the group ID.
     async fn load_group_state(&self, group_id: &GroupId) -> Result<LoadState, Self::StorageError> {
-        let qgid = QualifiedGroupId::tls_deserialize_exact(group_id.as_slice())
+        let qgid = QualifiedGroupId::tls_deserialize_exact_bytes(group_id.as_slice())
             .map_err(|_| PostgresStorageError::InvalidInput)?;
         let group_uuid = Uuid::from_bytes(qgid.group_id);
 
@@ -106,7 +106,7 @@ impl DsStorageProvider for PostgresDsStorage {
         group_id: &GroupId,
         encrypted_group_state: EncryptedDsGroupState,
     ) -> Result<(), Self::StorageError> {
-        let qgid = QualifiedGroupId::tls_deserialize_exact(group_id.as_slice())
+        let qgid = QualifiedGroupId::tls_deserialize_exact_bytes(group_id.as_slice())
             .map_err(|e| { 
                 tracing::warn!("Error parsing group id: {:?}", e);
                 PostgresStorageError::InvalidInput 
@@ -138,7 +138,7 @@ impl DsStorageProvider for PostgresDsStorage {
     ///
     /// Returns false if the group ID is already taken and true otherwise.
     async fn reserve_group_id(&self, group_id: &GroupId) -> Result<bool, Self::StorageError> {
-        let qgid = QualifiedGroupId::tls_deserialize_exact(group_id.as_slice())
+        let qgid = QualifiedGroupId::tls_deserialize_exact_bytes(group_id.as_slice())
             .map_err(|_| PostgresStorageError::InvalidInput)?;
         let group_uuid = Uuid::from_bytes(qgid.group_id);
 

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -20,7 +20,9 @@ hkdf = { version = "0.12" }
 aes-gcm = { version = "0.9.4" }
 ed25519 = { version = "1.5.2", features = ["serde"] }
 secrecy = { version = "0.8", features = ["serde"] }
-opaque-ke = { version = "3.0.0-pre.1", features = ["argon2"] }
+opaque-ke = { version = "3.0.0-pre.4", features = [
+    "argon2",
+], git = "https://github.com/facebook/opaque-ke", branch = "dependabot/cargo/voprf-eq-0.5.0-pre.7" }
 privacypass = { git = "https://github.com/raphaelrobert/privacypass" }
 argon2 = { version = "0.5.0" }
 uuid = { version = "1", features = ["v4", "serde"] }

--- a/types/src/credentials/keys.rs
+++ b/types/src/credentials/keys.rs
@@ -252,7 +252,8 @@ impl InfraCredentialPlaintext {
         ear_key: &SignatureEarKey,
     ) -> Result<Self, InfraCredentialDecryptionError> {
         let encrypted_signature =
-            Ciphertext::tls_deserialize_exact(credential.encrypted_signature().as_slice())?.into();
+            Ciphertext::tls_deserialize_exact_bytes(credential.encrypted_signature().as_slice())?
+                .into();
         let signature = Signature::decrypt(&ear_key, &encrypted_signature)
             .map_err(|_| InfraCredentialDecryptionError::SignatureDecryptionError)?;
         let payload = InfraCredentialTbs {

--- a/types/src/crypto/hpke.rs
+++ b/types/src/crypto/hpke.rs
@@ -162,7 +162,7 @@ impl ClientIdDecryptionKey {
     //        .private_key
     //        .decrypt(&[], &[], &sealed_client_reference.ciphertext)
     //        .map_err(|_| UnsealError::DecryptionError)?;
-    //    ClientConfig::tls_deserialize_exact(&bytes).map_err(|_| UnsealError::CodecError)
+    //    ClientConfig::tls_deserialize_exact_bytes(&bytes).map_err(|_| UnsealError::CodecError)
     //}
 
     pub fn generate() -> Result<Self, RandomnessError> {

--- a/types/src/crypto/opaque/codec.rs
+++ b/types/src/crypto/opaque/codec.rs
@@ -34,7 +34,7 @@ impl tls_codec::Serialize for OpaqueRegistrationRequest {
 }
 
 impl tls_codec::DeserializeBytes for OpaqueRegistrationRequest {
-    fn tls_deserialize(bytes: &[u8]) -> Result<(Self, &[u8]), tls_codec::Error>
+    fn tls_deserialize_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), tls_codec::Error>
     where
         Self: Sized,
     {
@@ -66,7 +66,7 @@ impl tls_codec::Serialize for OpaqueRegistrationResponse {
 }
 
 impl tls_codec::DeserializeBytes for OpaqueRegistrationResponse {
-    fn tls_deserialize(bytes: &[u8]) -> Result<(Self, &[u8]), tls_codec::Error>
+    fn tls_deserialize_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), tls_codec::Error>
     where
         Self: Sized,
     {
@@ -97,7 +97,7 @@ impl tls_codec::Serialize for OpaqueRegistrationRecord {
 }
 
 impl tls_codec::DeserializeBytes for OpaqueRegistrationRecord {
-    fn tls_deserialize(bytes: &[u8]) -> Result<(Self, &[u8]), tls_codec::Error>
+    fn tls_deserialize_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), tls_codec::Error>
     where
         Self: Sized,
     {
@@ -128,7 +128,7 @@ impl tls_codec::Serialize for OpaqueLoginRequest {
 }
 
 impl tls_codec::DeserializeBytes for OpaqueLoginRequest {
-    fn tls_deserialize(bytes: &[u8]) -> Result<(Self, &[u8]), tls_codec::Error>
+    fn tls_deserialize_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), tls_codec::Error>
     where
         Self: Sized,
     {
@@ -159,7 +159,7 @@ impl tls_codec::Serialize for OpaqueLoginResponse {
 }
 
 impl tls_codec::DeserializeBytes for OpaqueLoginResponse {
-    fn tls_deserialize(bytes: &[u8]) -> Result<(Self, &[u8]), tls_codec::Error>
+    fn tls_deserialize_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), tls_codec::Error>
     where
         Self: Sized,
     {
@@ -190,7 +190,7 @@ impl tls_codec::Serialize for OpaqueLoginFinish {
 }
 
 impl tls_codec::DeserializeBytes for OpaqueLoginFinish {
-    fn tls_deserialize(bytes: &[u8]) -> Result<(Self, &[u8]), tls_codec::Error>
+    fn tls_deserialize_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), tls_codec::Error>
     where
         Self: Sized,
     {
@@ -246,5 +246,5 @@ fn test_opaque_codec() {
     let bytes = opaque_registration_record.tls_serialize_detached().unwrap();
 
     assert_eq!(bytes.len(), OPAQUE_REGISTRATION_RECORD_SIZE);
-    let _ = OpaqueRegistrationRecord::tls_deserialize(bytes.as_slice()).unwrap();
+    let _ = OpaqueRegistrationRecord::tls_deserialize_bytes(bytes.as_slice()).unwrap();
 }

--- a/types/src/identifiers.rs
+++ b/types/src/identifiers.rs
@@ -98,7 +98,7 @@ pub struct UserName {
 
 impl From<Vec<u8>> for UserName {
     fn from(value: Vec<u8>) -> Self {
-        Self::tls_deserialize_exact(&value).unwrap()
+        Self::tls_deserialize_exact_bytes(&value).unwrap()
     }
 }
 
@@ -156,12 +156,12 @@ pub struct AsClientId {
 }
 
 impl TlsDeserializeBytesTrait for AsClientId {
-    fn tls_deserialize(bytes: &[u8]) -> Result<(Self, &[u8]), tls_codec::Error>
+    fn tls_deserialize_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), tls_codec::Error>
     where
         Self: Sized,
     {
-        let (user_name, rest) = <UserName>::tls_deserialize(bytes.as_ref())?;
-        let (client_id_bytes, rest) = <[u8; 16]>::tls_deserialize(rest)?;
+        let (user_name, rest) = <UserName>::tls_deserialize_bytes(bytes.as_ref())?;
+        let (client_id_bytes, rest) = <[u8; 16]>::tls_deserialize_bytes(rest)?;
         let client_id = Uuid::from_bytes(client_id_bytes);
         Ok((
             Self {
@@ -280,11 +280,11 @@ impl tls_codec::Serialize for QsClientId {
 }
 
 impl tls_codec::DeserializeBytes for QsClientId {
-    fn tls_deserialize(bytes: &[u8]) -> Result<(Self, &[u8]), tls_codec::Error>
+    fn tls_deserialize_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), tls_codec::Error>
     where
         Self: Sized,
     {
-        let (uuid_bytes, rest) = <[u8; 16]>::tls_deserialize(bytes)?;
+        let (uuid_bytes, rest) = <[u8; 16]>::tls_deserialize_bytes(bytes)?;
         let client_id = Uuid::from_bytes(uuid_bytes);
         Ok((Self { client_id }, rest))
     }
@@ -342,11 +342,11 @@ impl tls_codec::Serialize for QsUserId {
 }
 
 impl tls_codec::DeserializeBytes for QsUserId {
-    fn tls_deserialize(bytes: &[u8]) -> Result<(Self, &[u8]), tls_codec::Error>
+    fn tls_deserialize_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), tls_codec::Error>
     where
         Self: Sized,
     {
-        let (uuid_bytes, rest) = <[u8; 16]>::tls_deserialize(bytes)?;
+        let (uuid_bytes, rest) = <[u8; 16]>::tls_deserialize_bytes(bytes)?;
         let user_id = Uuid::from_bytes(uuid_bytes);
         Ok((Self { user_id }, rest))
     }

--- a/types/src/messages/client_as.rs
+++ b/types/src/messages/client_as.rs
@@ -530,8 +530,9 @@ impl AsQueueMessagePayload {
     pub fn extract(self) -> Result<ExtractedAsQueueMessagePayload, tls_codec::Error> {
         let message = match self.message_type {
             AsQueueMessageType::EncryptedConnectionEstablishmentPackage => {
-                let cep =
-                    EncryptedConnectionEstablishmentPackage::tls_deserialize_exact(&self.payload)?;
+                let cep = EncryptedConnectionEstablishmentPackage::tls_deserialize_exact_bytes(
+                    &self.payload,
+                )?;
                 ExtractedAsQueueMessagePayload::EncryptedConnectionEstablishmentPackage(cep)
             }
         };
@@ -554,7 +555,7 @@ impl GenericDeserializable for AsQueueMessagePayload {
     type Error = tls_codec::Error;
 
     fn deserialize(bytes: &[u8]) -> Result<Self, Self::Error> {
-        Self::tls_deserialize_exact(bytes)
+        Self::tls_deserialize_exact_bytes(bytes)
     }
 }
 
@@ -743,12 +744,12 @@ pub struct IssueTokensParamsTbs {
 }
 
 impl DeserializeBytes for IssueTokensParamsTbs {
-    fn tls_deserialize(bytes: &[u8]) -> Result<(Self, &[u8]), tls_codec::Error>
+    fn tls_deserialize_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), tls_codec::Error>
     where
         Self: Sized,
     {
-        let (client_id, bytes) = AsClientId::tls_deserialize(bytes)?;
-        let (token_type, bytes) = AsTokenType::tls_deserialize(bytes)?;
+        let (client_id, bytes) = AsClientId::tls_deserialize_bytes(bytes)?;
+        let (token_type, bytes) = AsTokenType::tls_deserialize_bytes(bytes)?;
         let mut bytes_reader = bytes;
         let token_request =
             <TokenRequest as tls_codec::Deserialize>::tls_deserialize(&mut bytes_reader)?;
@@ -814,7 +815,7 @@ pub struct IssueTokensResponse {
 }
 
 impl DeserializeBytes for IssueTokensResponse {
-    fn tls_deserialize(bytes: &[u8]) -> Result<(Self, &[u8]), tls_codec::Error>
+    fn tls_deserialize_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), tls_codec::Error>
     where
         Self: Sized,
     {

--- a/types/src/messages/client_as.rs
+++ b/types/src/messages/client_as.rs
@@ -19,11 +19,8 @@ use crate::{
     },
     crypto::{
         ear::{
-            keys::{
-                AddPackageEarKey, ClientCredentialEarKey, FriendshipPackageEarKey, RatchetKey,
-                SignatureEarKeyWrapperKey, WelcomeAttributionInfoEarKey,
-            },
-            Ciphertext, EarDecryptable, EarEncryptable, GenericDeserializable, GenericSerializable,
+            keys::RatchetKey, Ciphertext, EarDecryptable, EarEncryptable, GenericDeserializable,
+            GenericSerializable,
         },
         kdf::keys::RatchetSecret,
         opaque::{
@@ -43,7 +40,7 @@ use super::{
         ConnectionPackageIn, FinishUserRegistrationParamsIn, FinishUserRegistrationParamsTbsIn,
         VerifiableConnectionPackage,
     },
-    AsTokenType, EncryptedAsQueueMessage, FriendshipToken, MlsInfraVersion,
+    AsTokenType, EncryptedAsQueueMessage, MlsInfraVersion,
 };
 
 mod private_mod {
@@ -481,31 +478,6 @@ impl ClientCredentialAuthenticator for AsDequeueMessagesParams {
     const LABEL: &'static str = "Dequeue Messages Parameters";
 }
 
-#[derive(Debug, Clone, TlsDeserializeBytes, TlsSerialize, TlsSize)]
-pub struct FriendshipPackage {
-    pub friendship_token: FriendshipToken,
-    pub add_package_ear_key: AddPackageEarKey,
-    pub client_credential_ear_key: ClientCredentialEarKey,
-    pub signature_ear_key_wrapper_key: SignatureEarKeyWrapperKey,
-    pub wai_ear_key: WelcomeAttributionInfoEarKey,
-}
-
-impl GenericSerializable for FriendshipPackage {
-    type Error = tls_codec::Error;
-
-    fn serialize(&self) -> Result<Vec<u8>, Self::Error> {
-        self.tls_serialize_detached()
-    }
-}
-
-impl GenericDeserializable for FriendshipPackage {
-    type Error = tls_codec::Error;
-
-    fn deserialize(bytes: &[u8]) -> Result<Self, Self::Error> {
-        Self::tls_deserialize_exact(bytes)
-    }
-}
-
 #[derive(TlsSerialize, TlsDeserializeBytes, TlsSize)]
 pub struct EncryptedFriendshipPackage {
     ciphertext: Ciphertext,
@@ -522,9 +494,6 @@ impl From<Ciphertext> for EncryptedFriendshipPackage {
         Self { ciphertext }
     }
 }
-
-impl EarEncryptable<FriendshipPackageEarKey, EncryptedFriendshipPackage> for FriendshipPackage {}
-impl EarDecryptable<FriendshipPackageEarKey, EncryptedFriendshipPackage> for FriendshipPackage {}
 
 #[derive(Debug, TlsDeserializeBytes, TlsSerialize, TlsSize)]
 pub struct EncryptedConnectionEstablishmentPackage {

--- a/types/src/messages/client_ds.rs
+++ b/types/src/messages/client_ds.rs
@@ -86,13 +86,12 @@ impl QsQueueMessagePayload {
     pub fn extract(self) -> Result<ExtractedQsQueueMessagePayload, tls_codec::Error> {
         let message = match self.message_type {
             QsQueueMessageType::WelcomeBundle => {
-                let wb = WelcomeBundle::tls_deserialize_exact(&self.payload)?;
+                let wb = WelcomeBundle::tls_deserialize_exact_bytes(&self.payload)?;
                 ExtractedQsQueueMessagePayload::WelcomeBundle(wb)
             }
             QsQueueMessageType::MlsMessage => {
-                let message = <MlsMessageIn as tls_codec::Deserialize>::tls_deserialize(
-                    &mut self.payload.as_slice(),
-                )?;
+                let message =
+                    MlsMessageIn::tls_deserialize_exact_bytes(&mut self.payload.as_slice())?;
                 ExtractedQsQueueMessagePayload::MlsMessage(message)
             }
         };
@@ -590,11 +589,11 @@ pub struct VerifiableClientToDsMessage {
 }
 
 impl DeserializeBytes for VerifiableClientToDsMessage {
-    fn tls_deserialize(bytes: &[u8]) -> Result<(Self, &[u8]), tls_codec::Error>
+    fn tls_deserialize_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), tls_codec::Error>
     where
         Self: Sized,
     {
-        let (message, remainder) = ClientToDsMessageIn::tls_deserialize(bytes)?;
+        let (message, remainder) = ClientToDsMessageIn::tls_deserialize_bytes(bytes)?;
         // We want the payload to be the TBS bytes, which means we want all the bytes except the signature.
         let serialized_payload = bytes
             .get(..bytes.len() - remainder.len() - message.signature.tls_serialized_len())
@@ -732,7 +731,7 @@ impl GenericDeserializable for DsJoinerInformationIn {
     type Error = tls_codec::Error;
 
     fn deserialize(bytes: &[u8]) -> Result<Self, Self::Error> {
-        Self::tls_deserialize_exact(bytes)
+        Self::tls_deserialize_exact_bytes(bytes)
     }
 }
 

--- a/types/src/time.rs
+++ b/types/src/time.rs
@@ -35,7 +35,7 @@ impl TlsSerializeTrait for TimeStamp {
 }
 
 impl TlsDeserializeBytesTrait for TimeStamp {
-    fn tls_deserialize(bytes: &[u8]) -> Result<(Self, &[u8]), tls_codec::Error>
+    fn tls_deserialize_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), tls_codec::Error>
     where
         Self: Sized,
     {


### PR DESCRIPTION
This PR introduces the notion of user profiles which (for now) contain a display name and a byte string that can contain, for example, a profile picture.

User profiles are exchanged upon connection establishment and can not yet be updated.

This PR updates the dart API to allow (locally) storing/setting the own user profile. It also introduces the notion of a `UIContact`, which includes a contact's user name, display name and profile image bytes.