### PR TITLE
Check for existing DB before creating a new one.

### DIFF
--- a/server/.sqlx/query-98a7c1eb916f19befa1b8afcc8c5b0c135d28651554ca8e6410d29759449d1cd.json
+++ b/server/.sqlx/query-98a7c1eb916f19befa1b8afcc8c5b0c135d28651554ca8e6410d29759449d1cd.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "select exists (\n            SELECT datname FROM pg_catalog.pg_database WHERE datname = $1\n        )",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "exists",
+        "type_info": "Bool"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Name"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "98a7c1eb916f19befa1b8afcc8c5b0c135d28651554ca8e6410d29759449d1cd"
+}

--- a/server/src/storage_provider/postgres/auth_service.rs
+++ b/server/src/storage_provider/postgres/auth_service.rs
@@ -28,9 +28,11 @@ use privacypass::{
 };
 use sqlx::{
     types::{BigDecimal, Uuid},
-    Connection, Executor, PgConnection, PgPool,
+    PgPool,
 };
 use thiserror::Error;
+
+use super::connect_to_database;
 
 pub struct PostgresAsStorage {
     pool: PgPool,
@@ -42,20 +44,9 @@ impl PostgresAsStorage {
         signature_scheme: SignatureScheme,
         settings: &DatabaseSettings,
     ) -> Result<Self, CreateAsStorageError> {
-        // Create database
-        let mut connection =
-            PgConnection::connect(&settings.connection_string_without_database()).await?;
-        // TODO: For now, we ignore the error if the database already exists.
-        let _ = connection
-            .execute(format!(r#"CREATE DATABASE "{}";"#, settings.database_name).as_str())
-            .await;
-        // Migrate database
-        let connection_pool = PgPool::connect(&settings.connection_string()).await?;
-        sqlx::migrate!("./migrations").run(&connection_pool).await?;
+        let pool = connect_to_database(settings).await?;
 
-        let provider = Self {
-            pool: connection_pool,
-        };
+        let provider = Self { pool };
 
         // Check if the database has been initialized.
         let (as_creds, _as_inter_creds, _) = provider.load_as_credentials().await?;

--- a/server/src/storage_provider/postgres/auth_service.rs
+++ b/server/src/storage_provider/postgres/auth_service.rs
@@ -45,9 +45,10 @@ impl PostgresAsStorage {
         // Create database
         let mut connection =
             PgConnection::connect(&settings.connection_string_without_database()).await?;
-        connection
+        // TODO: For now, we ignore the error if the database already exists.
+        let _ = connection
             .execute(format!(r#"CREATE DATABASE "{}";"#, settings.database_name).as_str())
-            .await?;
+            .await;
         // Migrate database
         let connection_pool = PgPool::connect(&settings.connection_string()).await?;
         sqlx::migrate!("./migrations").run(&connection_pool).await?;

--- a/server/src/storage_provider/postgres/ds.rs
+++ b/server/src/storage_provider/postgres/ds.rs
@@ -29,9 +29,10 @@ impl PostgresDsStorage {
         // Create database
         let mut connection = PgConnection::connect(&settings.connection_string_without_database())
             .await?;
-        connection
+        // TODO: For now, we ignore the error if the database already exists.
+        let _ = connection
             .execute(format!(r#"CREATE DATABASE "{}";"#, settings.database_name).as_str())
-            .await?;
+            .await;
         // Migrate database
         let connection_pool = PgPool::connect(&settings.connection_string())
             .await?;

--- a/server/src/storage_provider/postgres/mod.rs
+++ b/server/src/storage_provider/postgres/mod.rs
@@ -2,9 +2,35 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+use sqlx::{Connection, Executor, PgConnection, PgPool};
+
+use crate::configurations::DatabaseSettings;
+
 pub mod auth_service;
 pub mod ds;
 pub mod qs;
 
 #[cfg(test)]
 pub mod tests;
+
+async fn connect_to_database(settings: &DatabaseSettings) -> Result<PgPool, sqlx::Error> {
+    let mut connection =
+        PgConnection::connect(&settings.connection_string_without_database()).await?;
+    let db_exists = sqlx::query!(
+        "select exists (
+            SELECT datname FROM pg_catalog.pg_database WHERE datname = $1
+        )",
+        settings.database_name
+    )
+    .fetch_one(&mut connection)
+    .await?;
+    if !db_exists.exists.unwrap_or(false) {
+        connection
+            .execute(format!(r#"CREATE DATABASE "{}";"#, settings.database_name).as_str())
+            .await?;
+    }
+    // Migrate database
+    let connection_pool = PgPool::connect(&settings.connection_string()).await?;
+    sqlx::migrate!("./migrations").run(&connection_pool).await?;
+    Ok(connection_pool)
+}

--- a/server/src/storage_provider/postgres/qs.rs
+++ b/server/src/storage_provider/postgres/qs.rs
@@ -33,9 +33,10 @@ impl PostgresQsStorage {
         // Create database
         let mut connection = PgConnection::connect(&settings.connection_string_without_database())
             .await?;
-        connection
+        // TODO: For now, we ignore the error if the database already exists.
+        let _ = connection
             .execute(format!(r#"CREATE DATABASE "{}";"#, settings.database_name).as_str())
-            .await?;
+            .await;
         // Migrate database
         let connection_pool = PgPool::connect(&settings.connection_string())
             .await?;

--- a/server/src/storage_provider/postgres/qs.rs
+++ b/server/src/storage_provider/postgres/qs.rs
@@ -60,8 +60,8 @@ impl PostgresQsStorage {
     // TODO: All the functions below use two queries. This can probably be optimized.
 
     async fn generate_fresh_signing_key(&self) -> Result<(), GenerateKeyError> {
-        // Delete the existing key.
-        sqlx::query!( "DELETE FROM qs_signing_key")
+        // Delete the existing key. 
+        sqlx::query!("DELETE FROM qs_signing_key")
         .execute(&self.pool)
         .await?;
 

--- a/server/tests/database_initialization.rs
+++ b/server/tests/database_initialization.rs
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: 2023 Phoenix R&D GmbH <hello@phnx.im>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+use phnxserver_test_harness::docker::run_server_restart_test;
+
+#[actix_rt::test]
+#[ignore]
+#[tracing::instrument(name = "Server restart test", skip_all)]
+async fn skip_db_creation() {
+    run_server_restart_test().await
+}

--- a/test_harness/src/docker.rs
+++ b/test_harness/src/docker.rs
@@ -388,12 +388,6 @@ pub async fn run_server_restart_test() {
         false,
     );
 
-    //let server_domain_fqdn = Fqdn::from(server_domain);
-    //let server_domains = vec![server_domain_fqdn.clone()]
-    //    .into_iter()
-    //    .collect::<HashSet<_>>();
-    //wait_until_servers_are_up(server_domains).await;
-
     sleep(Duration::from_secs(3));
 
     tracing::info!("All servers are up, stopping server.");

--- a/test_harness/src/docker.rs
+++ b/test_harness/src/docker.rs
@@ -5,12 +5,15 @@
 use std::{
     collections::{HashMap, HashSet},
     process::{Child, Command, Stdio},
+    thread::sleep,
+    time::Duration,
 };
 
+use once_cell::sync::Lazy;
 use phnxapiclient::ApiClient;
 use phnxtypes::{identifiers::Fqdn, DEFAULT_PORT_HTTP};
 
-use crate::test_scenarios::FederationTestScenario;
+use crate::{test_scenarios::FederationTestScenario, TRACING};
 
 pub(crate) struct DockerTestBed {
     // (server, db)
@@ -306,4 +309,126 @@ fn assert_docker_is_running() {
     {
         panic!("Docker is not running. Please start docker and try again.");
     }
+}
+
+pub async fn run_server_restart_test() {
+    Lazy::force(&TRACING);
+
+    // Make sure that Docker is actually running
+    assert_docker_is_running();
+
+    let server_domain = "example.com";
+    let network_name = "server_restart_network";
+    // Create docker network
+    create_network(network_name);
+
+    // Start server and db container
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    std::env::set_current_dir(manifest_dir.to_owned() + "/..").unwrap();
+
+    let db_image_name = "postgres";
+    let db_container_name = format!("{server_domain}_db_container");
+    let db_domain = format!("db.{server_domain}");
+    let db_user = "postgres";
+    let db_password = "password";
+    let db_name = "phnx_server_db";
+    let db_port = "5432";
+
+    let db_domain_env_variable = format!("PHNX_DB_DOMAIN={db_domain}");
+    let db_user_env_variable = format!("POSTGRES_USER={db_user}");
+    let db_password_env_variable = format!("POSTGRES_PASSWORD={db_password}");
+    let db_name_env_variable = format!("POSTGRES_DB={db_name}");
+
+    let _db = run_docker_container(
+        &db_image_name,
+        &db_container_name,
+        &[
+            db_domain_env_variable,
+            db_user_env_variable,
+            db_password_env_variable,
+            db_name_env_variable,
+        ],
+        Some(&db_domain),
+        Some(network_name),
+        Some(db_port),
+        &["-N".to_string(), "1000".to_string(), "-i".to_string()],
+        false,
+    );
+
+    let server_image_name = "phnxserver_image";
+    let server_container_name = format!("{server_domain}_server_container");
+
+    build_docker_image("server/Dockerfile", &server_image_name);
+
+    let server_domain_env_variable = format!("PHNX_APPLICATION_DOMAIN={}", server_domain);
+    let server_db_user_env_variable = format!("PHNX_DATABASE_USERNAME={}", db_user);
+    let server_db_password_env_variable = format!("PHNX_DATABASE_PASSWORD={}", db_password);
+    let server_db_port_env_variable = format!("PHNX_DATABASE_PORT={}", db_port);
+    let server_host_env_variable = format!("PHNX_DATABASE_HOST={}", db_domain);
+    let server_db_name_env_variable = format!("PHNX_DATABASE_DATABASE_NAME={}", db_name);
+    let server_sqlx_offline_env_variable = format!("SQLX_OFFLINE=true");
+
+    tracing::info!("Starting phnx server");
+    let _server = run_docker_container(
+        &server_image_name,
+        &server_container_name,
+        &[
+            server_domain_env_variable.clone(),
+            server_host_env_variable.clone(),
+            server_db_name_env_variable.clone(),
+            server_db_user_env_variable.clone(),
+            server_db_password_env_variable.clone(),
+            server_db_port_env_variable.clone(),
+            server_sqlx_offline_env_variable.clone(),
+        ],
+        Some(&server_domain.to_string()),
+        Some(network_name),
+        None,
+        &[],
+        false,
+    );
+
+    //let server_domain_fqdn = Fqdn::from(server_domain);
+    //let server_domains = vec![server_domain_fqdn.clone()]
+    //    .into_iter()
+    //    .collect::<HashSet<_>>();
+    //wait_until_servers_are_up(server_domains).await;
+
+    sleep(Duration::from_secs(3));
+
+    tracing::info!("All servers are up, stopping server.");
+
+    // Stop server container
+    stop_docker_container(&server_container_name);
+
+    sleep(Duration::from_secs(3));
+
+    tracing::info!("Waited three seconds, starting server again.");
+
+    // Start server container again
+    let _server = run_docker_container(
+        &server_image_name,
+        &server_container_name,
+        &[
+            server_domain_env_variable,
+            server_host_env_variable,
+            server_db_name_env_variable,
+            server_db_user_env_variable,
+            server_db_password_env_variable,
+            server_db_port_env_variable,
+            server_sqlx_offline_env_variable,
+        ],
+        Some(&server_domain.to_string()),
+        Some(network_name),
+        None,
+        &[],
+        false,
+    );
+
+    sleep(Duration::from_secs(3));
+
+    stop_docker_container(&server_container_name);
+    stop_docker_container(&db_container_name);
+
+    tracing::info!("Done running server restart test");
 }


### PR DESCRIPTION
This PR adds a check at server startup that ensures that the AS/DS/QS databases are only created if they aren't already present.