### PR TITLE
(Partially) Implement MIMI Content format

### DIFF
--- a/apiclient/src/ds_api/mod.rs
+++ b/apiclient/src/ds_api/mod.rs
@@ -39,6 +39,7 @@ use phnxtypes::{
         },
         welcome_attribution_info::EncryptedWelcomeAttributionInfo,
     },
+    time::TimeStamp,
 };
 
 use tls_codec::DeserializeBytes;
@@ -173,7 +174,7 @@ impl ApiClient {
         payload: AddUsersParamsOut,
         group_state_ear_key: &GroupStateEarKey,
         signing_key: &UserAuthSigningKey,
-    ) -> Result<(), DsRequestError> {
+    ) -> Result<TimeStamp, DsRequestError> {
         self.prepare_and_send_ds_group_message(
             DsRequestParamsOut::AddUsers(payload),
             signing_key,
@@ -182,8 +183,8 @@ impl ApiClient {
         .await
         // Check if the response is what we expected it to be.
         .and_then(|response| {
-            if matches!(response, DsProcessResponseIn::Ok) {
-                Ok(())
+            if let DsProcessResponseIn::FanoutTimestamp(ts) = response {
+                Ok(ts)
             } else {
                 Err(DsRequestError::UnexpectedResponse)
             }
@@ -196,7 +197,7 @@ impl ApiClient {
         params: RemoveUsersParamsOut,
         group_state_ear_key: &GroupStateEarKey,
         signing_key: &UserAuthSigningKey,
-    ) -> Result<(), DsRequestError> {
+    ) -> Result<TimeStamp, DsRequestError> {
         self.prepare_and_send_ds_group_message(
             DsRequestParamsOut::RemoveUsers(params),
             signing_key,
@@ -205,8 +206,8 @@ impl ApiClient {
         .await
         // Check if the response is what we expected it to be.
         .and_then(|response| {
-            if matches!(response, DsProcessResponseIn::Ok) {
-                Ok(())
+            if let DsProcessResponseIn::FanoutTimestamp(ts) = response {
+                Ok(ts)
             } else {
                 Err(DsRequestError::UnexpectedResponse)
             }
@@ -299,7 +300,7 @@ impl ApiClient {
         params: UpdateClientParamsOut,
         group_state_ear_key: &GroupStateEarKey,
         signing_key: &InfraCredentialSigningKey,
-    ) -> Result<(), DsRequestError> {
+    ) -> Result<TimeStamp, DsRequestError> {
         self.prepare_and_send_ds_group_message(
             DsRequestParamsOut::UpdateClient(params),
             signing_key,
@@ -308,8 +309,8 @@ impl ApiClient {
         .await
         // Check if the response is what we expected it to be.
         .and_then(|response| {
-            if matches!(response, DsProcessResponseIn::Ok) {
-                Ok(())
+            if let DsProcessResponseIn::FanoutTimestamp(ts) = response {
+                Ok(ts)
             } else {
                 Err(DsRequestError::UnexpectedResponse)
             }
@@ -323,7 +324,7 @@ impl ApiClient {
         qs_client_reference: QsClientReference,
         signing_key: &UserAuthSigningKey,
         group_state_ear_key: &GroupStateEarKey,
-    ) -> Result<(), DsRequestError> {
+    ) -> Result<TimeStamp, DsRequestError> {
         let payload = JoinGroupParamsOut {
             sender: signing_key.verifying_key().hash(),
             external_commit,
@@ -337,8 +338,8 @@ impl ApiClient {
         .await
         // Check if the response is what we expected it to be.
         .and_then(|response| {
-            if matches!(response, DsProcessResponseIn::Ok) {
-                Ok(())
+            if let DsProcessResponseIn::FanoutTimestamp(ts) = response {
+                Ok(ts)
             } else {
                 Err(DsRequestError::UnexpectedResponse)
             }
@@ -353,7 +354,7 @@ impl ApiClient {
         qs_client_reference: QsClientReference,
         signing_key: &UserAuthSigningKey,
         group_state_ear_key: &GroupStateEarKey,
-    ) -> Result<(), DsRequestError> {
+    ) -> Result<TimeStamp, DsRequestError> {
         let external_commit = AssistedMessageOut {
             mls_message: commit,
             group_info_option: Some(AssistedGroupInfo::Full(group_info)),
@@ -371,8 +372,8 @@ impl ApiClient {
         .await
         // Check if the response is what we expected it to be.
         .and_then(|response| {
-            if matches!(response, DsProcessResponseIn::Ok) {
-                Ok(())
+            if let DsProcessResponseIn::FanoutTimestamp(ts) = response {
+                Ok(ts)
             } else {
                 Err(DsRequestError::UnexpectedResponse)
             }
@@ -387,7 +388,7 @@ impl ApiClient {
         encrypted_welcome_attribution_infos: Vec<EncryptedWelcomeAttributionInfo>,
         signing_key: &UserAuthSigningKey,
         group_state_ear_key: &GroupStateEarKey,
-    ) -> Result<(), DsRequestError> {
+    ) -> Result<TimeStamp, DsRequestError> {
         let payload = AddClientsParamsOut {
             sender: signing_key.verifying_key().hash(),
             commit,
@@ -402,8 +403,8 @@ impl ApiClient {
         .await
         // Check if the response is what we expected it to be.
         .and_then(|response| {
-            if matches!(response, DsProcessResponseIn::Ok) {
-                Ok(())
+            if let DsProcessResponseIn::FanoutTimestamp(ts) = response {
+                Ok(ts)
             } else {
                 Err(DsRequestError::UnexpectedResponse)
             }
@@ -417,7 +418,7 @@ impl ApiClient {
         new_auth_key: UserAuthVerifyingKey,
         signing_key: &UserAuthSigningKey,
         group_state_ear_key: &GroupStateEarKey,
-    ) -> Result<(), DsRequestError> {
+    ) -> Result<TimeStamp, DsRequestError> {
         let payload = RemoveClientsParamsOut {
             commit,
             sender: signing_key.verifying_key().hash(),
@@ -431,8 +432,8 @@ impl ApiClient {
         .await
         // Check if the response is what we expected it to be.
         .and_then(|response| {
-            if matches!(response, DsProcessResponseIn::Ok) {
-                Ok(())
+            if let DsProcessResponseIn::FanoutTimestamp(ts) = response {
+                Ok(ts)
             } else {
                 Err(DsRequestError::UnexpectedResponse)
             }
@@ -445,7 +446,7 @@ impl ApiClient {
         external_commit: AssistedMessageOut,
         signing_key: &UserAuthSigningKey,
         group_state_ear_key: &GroupStateEarKey,
-    ) -> Result<(), DsRequestError> {
+    ) -> Result<TimeStamp, DsRequestError> {
         let payload = ResyncClientParamsOut {
             external_commit,
             sender: signing_key.verifying_key().hash(),
@@ -458,8 +459,8 @@ impl ApiClient {
         .await
         // Check if the response is what we expected it to be.
         .and_then(|response| {
-            if matches!(response, DsProcessResponseIn::Ok) {
-                Ok(())
+            if let DsProcessResponseIn::FanoutTimestamp(ts) = response {
+                Ok(ts)
             } else {
                 Err(DsRequestError::UnexpectedResponse)
             }
@@ -472,7 +473,7 @@ impl ApiClient {
         params: SelfRemoveClientParamsOut,
         signing_key: &UserAuthSigningKey,
         group_state_ear_key: &GroupStateEarKey,
-    ) -> Result<(), DsRequestError> {
+    ) -> Result<TimeStamp, DsRequestError> {
         self.prepare_and_send_ds_group_message(
             DsRequestParamsOut::SelfRemoveClient(params),
             signing_key,
@@ -481,8 +482,8 @@ impl ApiClient {
         .await
         // Check if the response is what we expected it to be.
         .and_then(|response| {
-            if matches!(response, DsProcessResponseIn::Ok) {
-                Ok(())
+            if let DsProcessResponseIn::FanoutTimestamp(ts) = response {
+                Ok(ts)
             } else {
                 Err(DsRequestError::UnexpectedResponse)
             }
@@ -495,7 +496,7 @@ impl ApiClient {
         params: SendMessageParamsOut,
         signing_key: &InfraCredentialSigningKey,
         group_state_ear_key: &GroupStateEarKey,
-    ) -> Result<(), DsRequestError> {
+    ) -> Result<TimeStamp, DsRequestError> {
         self.prepare_and_send_ds_group_message(
             DsRequestParamsOut::SendMessage(params),
             signing_key,
@@ -504,8 +505,8 @@ impl ApiClient {
         .await
         // Check if the response is what we expected it to be.
         .and_then(|response| {
-            if matches!(response, DsProcessResponseIn::Ok) {
-                Ok(())
+            if let DsProcessResponseIn::FanoutTimestamp(ts) = response {
+                Ok(ts)
             } else {
                 Err(DsRequestError::UnexpectedResponse)
             }
@@ -518,7 +519,7 @@ impl ApiClient {
         params: DeleteGroupParamsOut,
         signing_key: &UserAuthSigningKey,
         group_state_ear_key: &GroupStateEarKey,
-    ) -> Result<(), DsRequestError> {
+    ) -> Result<TimeStamp, DsRequestError> {
         self.prepare_and_send_ds_group_message(
             DsRequestParamsOut::DeleteGroup(params),
             signing_key,
@@ -527,8 +528,8 @@ impl ApiClient {
         .await
         // Check if the response is what we expected it to be.
         .and_then(|response| {
-            if matches!(response, DsProcessResponseIn::Ok) {
-                Ok(())
+            if let DsProcessResponseIn::FanoutTimestamp(ts) = response {
+                Ok(ts)
             } else {
                 Err(DsRequestError::UnexpectedResponse)
             }

--- a/applogic/src/dart_api.rs
+++ b/applogic/src/dart_api.rs
@@ -17,7 +17,7 @@ pub use crate::types::{UiConversation, UiConversationMessage, UiNotificationType
 use crate::{
     app_state::AppState,
     notifications::{Notifiable, NotificationHub},
-    types::{ConversationIdBytes, UiContact, UiMimiContent},
+    types::{ConversationIdBytes, UiContact},
 };
 use phnxcoreclient::{
     users::{process::ProcessQsMessageResult, store::ClientRecord, SelfUser},

--- a/applogic/src/dart_api.rs
+++ b/applogic/src/dart_api.rs
@@ -13,17 +13,15 @@ use phnxtypes::{
     time::TimeStamp,
 };
 
-pub use crate::types::{
-    UiConversation, UiConversationMessage, UiMessageContentType, UiNotificationType,
-};
+pub use crate::types::{UiConversation, UiConversationMessage, UiNotificationType};
 use crate::{
     app_state::AppState,
     notifications::{Notifiable, NotificationHub},
-    types::{ConversationIdBytes, UiContact},
+    types::{ConversationIdBytes, UiContact, UiMimiContent},
 };
 use phnxcoreclient::{
     users::{process::ProcessQsMessageResult, store::ClientRecord, SelfUser},
-    ConversationId, ConversationMessage, NotificationType,
+    ConversationId, ConversationMessage, MimiContent, NotificationType,
 };
 
 #[cfg(any(target_os = "macos", target_os = "linux", target_os = "windows"))]
@@ -335,10 +333,11 @@ impl RustUser {
     pub async fn send_message(
         &self,
         conversation_id: ConversationIdBytes,
-        message: UiMessageContentType,
+        message: String,
     ) -> Result<UiConversationMessage> {
         let mut user = self.user.lock().unwrap();
-        user.send_message(conversation_id.into(), message.into())
+        let content = MimiContent::simple_markdown_message(user.user_name().domain(), message);
+        user.send_message(conversation_id.into(), content)
             .await
             .map(|m| m.into())
     }

--- a/applogic/src/types/mod.rs
+++ b/applogic/src/types/mod.rs
@@ -229,31 +229,23 @@ pub struct UiMimiContent {
 
 impl From<MimiContent> for UiMimiContent {
     fn from(mimi_content: MimiContent) -> Self {
+        let body = mimi_content.string_rendering();
         Self {
-            id: UiMessageId::from(mimi_content.id()),
-            timestamp: mimi_content.timestamp().as_u64(),
-            replaces: mimi_content.replaces().map(|r| UiMessageId {
-                id: UuidBytes::from(r.as_uuid()),
-                domain: r.sender_domain().to_string(),
-            }),
-            topic_id: mimi_content.topic_id().map(|t| t.id().to_vec()),
-            expires: mimi_content.expires().map(|e| e.as_u64()),
-            in_reply_to: mimi_content.in_reply_to().map(|i| UiReplyToInfo {
-                message_id: UiMessageId {
-                    id: UuidBytes::from(i.message_id().as_uuid()),
-                    domain: i.message_id().sender_domain().to_string(),
-                },
-                hash: i.hash().to_vec(),
+            id: UiMessageId::from(mimi_content.id().clone()),
+            timestamp: mimi_content.timestamp.as_u64(),
+            replaces: mimi_content.replaces.map(|r| UiMessageId::from(r)),
+            topic_id: mimi_content.topic_id.map(|t| t.id.to_vec()),
+            expires: mimi_content.expires.map(|e| e.as_u64()),
+            in_reply_to: mimi_content.in_reply_to.map(|i| UiReplyToInfo {
+                message_id: UiMessageId::from(i.message_id),
+                hash: i.hash.hash,
             }),
             last_seen: mimi_content
-                .last_seen()
-                .iter()
-                .map(|m| UiMessageId {
-                    id: UuidBytes::from(m.as_uuid()),
-                    domain: m.sender_domain().to_string(),
-                })
+                .last_seen
+                .into_iter()
+                .map(|m| UiMessageId::from(m))
                 .collect(),
-            body: mimi_content.body().to_string(),
+            body,
         }
     }
 }
@@ -268,7 +260,7 @@ impl From<ContentMessage> for UiContentMessage {
     fn from(content_message: ContentMessage) -> Self {
         Self {
             sender: content_message.sender().to_string(),
-            content: UiMimiContent::from(content_message.content()),
+            content: UiMimiContent::from(content_message.serialized_content().clone()),
         }
     }
 }

--- a/applogic/src/types/mod.rs
+++ b/applogic/src/types/mod.rs
@@ -260,7 +260,7 @@ impl From<ContentMessage> for UiContentMessage {
     fn from(content_message: ContentMessage) -> Self {
         Self {
             sender: content_message.sender().to_string(),
-            content: UiMimiContent::from(content_message.serialized_content().clone()),
+            content: UiMimiContent::from(content_message.content().clone()),
         }
     }
 }

--- a/backend/src/ds/add_users.rs
+++ b/backend/src/ds/add_users.rs
@@ -6,9 +6,9 @@ use std::collections::HashMap;
 
 use mls_assist::{
     group::ProcessedAssistedMessage,
-    openmls::prelude::Extension,
+    messages::SerializedMlsMessage,
     openmls::prelude::{
-        KeyPackage, KeyPackageRef, OpenMlsProvider, ProcessedMessageContent, Sender,
+        Extension, KeyPackage, KeyPackageRef, OpenMlsProvider, ProcessedMessageContent, Sender,
     },
     openmls_rust_crypto::OpenMlsRustCrypto,
 };
@@ -45,7 +45,7 @@ impl DsGroupState {
         params: AddUsersParams,
         group_state_ear_key: &GroupStateEarKey,
         qs_provider: &Q,
-    ) -> Result<(DsFanOutPayload, Vec<DsFanOutMessage>), AddUsersError> {
+    ) -> Result<(SerializedMlsMessage, Vec<DsFanOutMessage>), AddUsersError> {
         // Process message (but don't apply it yet). This performs mls-assist-level validations.
         let processed_assisted_message_plus = self
             .group()
@@ -311,10 +311,9 @@ impl DsGroupState {
         }
 
         // Finally, we create the message for distribution.
-        let c2c_message = processed_assisted_message_plus
-            .serialized_mls_message
-            .into();
-
-        Ok((c2c_message, fan_out_messages))
+        Ok((
+            processed_assisted_message_plus.serialized_mls_message,
+            fan_out_messages,
+        ))
     }
 }

--- a/backend/src/ds/delete_group.rs
+++ b/backend/src/ds/delete_group.rs
@@ -4,11 +4,10 @@
 
 use mls_assist::{
     group::ProcessedAssistedMessage,
+    messages::SerializedMlsMessage,
     openmls::prelude::{ProcessedMessageContent, Sender},
 };
 use phnxtypes::{errors::GroupDeletionError, messages::client_ds::DeleteGroupParams};
-
-use crate::messages::intra_backend::DsFanOutPayload;
 
 use super::group_state::DsGroupState;
 
@@ -16,7 +15,7 @@ impl DsGroupState {
     pub(crate) fn delete_group(
         &mut self,
         params: DeleteGroupParams,
-    ) -> Result<DsFanOutPayload, GroupDeletionError> {
+    ) -> Result<SerializedMlsMessage, GroupDeletionError> {
         // Process message (but don't apply it yet). This performs mls-assist-level validations.
         let processed_assisted_message_plus = self
             .group()
@@ -91,11 +90,6 @@ impl DsGroupState {
         // No need to do anything else here, since the group is getting deleted
         // anyway.
 
-        // Finally, we create the message for distribution.
-        let c2c_message = processed_assisted_message_plus
-            .serialized_mls_message
-            .into();
-
-        Ok(c2c_message)
+        Ok(processed_assisted_message_plus.serialized_mls_message)
     }
 }

--- a/backend/src/ds/join_connection_group.rs
+++ b/backend/src/ds/join_connection_group.rs
@@ -2,15 +2,16 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-use mls_assist::{group::ProcessedAssistedMessage, openmls::prelude::ProcessedMessageContent};
+use mls_assist::{
+    group::ProcessedAssistedMessage, messages::SerializedMlsMessage,
+    openmls::prelude::ProcessedMessageContent,
+};
 use phnxtypes::{
     errors::JoinConnectionGroupError,
     messages::client_ds::{InfraAadMessage, InfraAadPayload, JoinConnectionGroupParams},
     time::{Duration, TimeStamp},
 };
 use tls_codec::DeserializeBytes;
-
-use crate::messages::intra_backend::DsFanOutPayload;
 
 use super::{
     api::USER_EXPIRATION_DAYS,
@@ -21,7 +22,7 @@ impl DsGroupState {
     pub(super) fn join_connection_group(
         &mut self,
         params: JoinConnectionGroupParams,
-    ) -> Result<DsFanOutPayload, JoinConnectionGroupError> {
+    ) -> Result<SerializedMlsMessage, JoinConnectionGroupError> {
         // Process message (but don't apply it yet). This performs mls-assist-level validations.
         let processed_assisted_message_plus = self
             .group()
@@ -122,10 +123,6 @@ impl DsGroupState {
         }
 
         // Finally, we create the message for distribution.
-        let payload = processed_assisted_message_plus
-            .serialized_mls_message
-            .into();
-
-        Ok(payload)
+        Ok(processed_assisted_message_plus.serialized_mls_message)
     }
 }

--- a/backend/src/ds/join_group.rs
+++ b/backend/src/ds/join_group.rs
@@ -2,15 +2,16 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-use mls_assist::{group::ProcessedAssistedMessage, openmls::prelude::ProcessedMessageContent};
+use mls_assist::{
+    group::ProcessedAssistedMessage, messages::SerializedMlsMessage,
+    openmls::prelude::ProcessedMessageContent,
+};
 use phnxtypes::{
     errors::JoinGroupError,
     messages::client_ds::{InfraAadMessage, InfraAadPayload, JoinGroupParams},
     time::{Duration, TimeStamp},
 };
 use tls_codec::DeserializeBytes;
-
-use crate::messages::intra_backend::DsFanOutPayload;
 
 use super::{
     api::USER_EXPIRATION_DAYS,
@@ -21,7 +22,7 @@ impl DsGroupState {
     pub(super) fn join_group(
         &mut self,
         params: JoinGroupParams,
-    ) -> Result<DsFanOutPayload, JoinGroupError> {
+    ) -> Result<SerializedMlsMessage, JoinGroupError> {
         // Process message (but don't apply it yet). This performs mls-assist-level validations.
         let processed_assisted_message_plus = self
             .group()
@@ -113,11 +114,6 @@ impl DsGroupState {
         };
         self.client_profiles.insert(sender, client_profile);
 
-        // Finally, we create the message for distribution.
-        let payload = processed_assisted_message_plus
-            .serialized_mls_message
-            .into();
-
-        Ok(payload)
+        Ok(processed_assisted_message_plus.serialized_mls_message)
     }
 }

--- a/backend/src/ds/remove_clients.rs
+++ b/backend/src/ds/remove_clients.rs
@@ -4,13 +4,12 @@
 
 use mls_assist::{
     group::ProcessedAssistedMessage,
+    messages::SerializedMlsMessage,
     openmls::prelude::{LeafNodeIndex, ProcessedMessageContent, Sender},
 };
 use phnxtypes::{
     errors::ClientRemovalError, messages::client_ds::RemoveClientsParams, time::Duration,
 };
-
-use crate::messages::intra_backend::DsFanOutPayload;
 
 use super::api::USER_EXPIRATION_DAYS;
 
@@ -20,7 +19,7 @@ impl DsGroupState {
     pub(crate) fn remove_clients(
         &mut self,
         params: RemoveClientsParams,
-    ) -> Result<DsFanOutPayload, ClientRemovalError> {
+    ) -> Result<SerializedMlsMessage, ClientRemovalError> {
         // Process message (but don't apply it yet). This performs mls-assist-level validations.
         let processed_assisted_message_plus = self
             .group()
@@ -138,10 +137,6 @@ impl DsGroupState {
         }
 
         // Finally, we create the message for distribution.
-        let payload = processed_assisted_message_plus
-            .serialized_mls_message
-            .into();
-
-        Ok(payload)
+        Ok(processed_assisted_message_plus.serialized_mls_message)
     }
 }

--- a/backend/src/ds/remove_users.rs
+++ b/backend/src/ds/remove_users.rs
@@ -6,14 +6,13 @@ use std::collections::HashSet;
 
 use mls_assist::{
     group::ProcessedAssistedMessage,
+    messages::SerializedMlsMessage,
     openmls::prelude::{LeafNodeIndex, ProcessedMessageContent, Sender},
 };
 use phnxtypes::{
     crypto::signatures::keys::UserKeyHash, errors::UserRemovalError,
     messages::client_ds::RemoveUsersParams, time::Duration,
 };
-
-use crate::messages::intra_backend::DsFanOutPayload;
 
 use super::api::USER_EXPIRATION_DAYS;
 
@@ -23,7 +22,7 @@ impl DsGroupState {
     pub(crate) fn remove_users(
         &mut self,
         params: RemoveUsersParams,
-    ) -> Result<DsFanOutPayload, UserRemovalError> {
+    ) -> Result<SerializedMlsMessage, UserRemovalError> {
         // Process message (but don't apply it yet). This performs mls-assist-level validations.
         let processed_assisted_message_plus = self
             .group()
@@ -157,11 +156,6 @@ impl DsGroupState {
             Duration::days(USER_EXPIRATION_DAYS),
         );
 
-        // Finally, we create the message for distribution.
-        let payload = processed_assisted_message_plus
-            .serialized_mls_message
-            .into();
-
-        Ok(payload)
+        Ok(processed_assisted_message_plus.serialized_mls_message)
     }
 }

--- a/backend/src/ds/resync_client.rs
+++ b/backend/src/ds/resync_client.rs
@@ -4,13 +4,12 @@
 
 use mls_assist::{
     group::ProcessedAssistedMessage,
+    messages::SerializedMlsMessage,
     openmls::prelude::{ProcessedMessageContent, Sender},
 };
 use phnxtypes::{
     errors::ResyncClientError, messages::client_ds::ResyncClientParams, time::Duration,
 };
-
-use crate::messages::intra_backend::DsFanOutPayload;
 
 use super::api::USER_EXPIRATION_DAYS;
 
@@ -20,7 +19,7 @@ impl DsGroupState {
     pub(crate) fn resync_client(
         &mut self,
         params: ResyncClientParams,
-    ) -> Result<DsFanOutPayload, ResyncClientError> {
+    ) -> Result<SerializedMlsMessage, ResyncClientError> {
         // Process message (but don't apply it yet). This performs mls-assist-level validations.
         let processed_assisted_message_plus = self
             .group()
@@ -93,11 +92,6 @@ impl DsGroupState {
         // No need to update the client profile either, since all data (leaf
         // index, credential, qs client ref, etc.) remains the same.
 
-        // Finally, we create the message for distribution.
-        let payload = processed_assisted_message_plus
-            .serialized_mls_message
-            .into();
-
-        Ok(payload)
+        Ok(processed_assisted_message_plus.serialized_mls_message)
     }
 }

--- a/backend/src/ds/self_remove_client.rs
+++ b/backend/src/ds/self_remove_client.rs
@@ -4,13 +4,12 @@
 
 use mls_assist::{
     group::ProcessedAssistedMessage,
+    messages::SerializedMlsMessage,
     openmls::prelude::{ProcessedMessageContent, Proposal, Sender},
 };
 use phnxtypes::{
     errors::ClientSelfRemovalError, messages::client_ds::SelfRemoveClientParams, time::Duration,
 };
-
-use crate::messages::intra_backend::DsFanOutPayload;
 
 use super::api::USER_EXPIRATION_DAYS;
 
@@ -20,7 +19,7 @@ impl DsGroupState {
     pub(crate) fn self_remove_client(
         &mut self,
         params: SelfRemoveClientParams,
-    ) -> Result<DsFanOutPayload, ClientSelfRemovalError> {
+    ) -> Result<SerializedMlsMessage, ClientSelfRemovalError> {
         // Process message (but don't apply it yet). This performs
         // mls-assist-level validations and puts the proposal into mls-assist's
         // proposal store.
@@ -86,10 +85,6 @@ impl DsGroupState {
         // We remove the user and client profile only when the proposal is committed.
 
         // Finally, we create the message for distribution.
-        let payload = processed_assisted_message_plus
-            .serialized_mls_message
-            .into();
-
-        Ok(payload)
+        Ok(processed_assisted_message_plus.serialized_mls_message)
     }
 }

--- a/backend/src/ds/update_client.rs
+++ b/backend/src/ds/update_client.rs
@@ -4,6 +4,7 @@
 
 use mls_assist::{
     group::ProcessedAssistedMessage,
+    messages::SerializedMlsMessage,
     openmls::prelude::{ProcessedMessageContent, Sender},
 };
 use phnxtypes::{
@@ -12,8 +13,6 @@ use phnxtypes::{
     time::Duration,
 };
 use tls_codec::DeserializeBytes;
-
-use crate::messages::intra_backend::DsFanOutPayload;
 
 use super::{
     api::USER_EXPIRATION_DAYS,
@@ -24,7 +23,7 @@ impl DsGroupState {
     pub(super) fn update_client(
         &mut self,
         params: UpdateClientParams,
-    ) -> Result<DsFanOutPayload, ClientUpdateError> {
+    ) -> Result<SerializedMlsMessage, ClientUpdateError> {
         // Process message (but don't apply it yet). This performs mls-assist-level validations.
         let processed_assisted_message_plus = self
             .group()
@@ -163,11 +162,6 @@ impl DsGroupState {
             }
         }
 
-        // Finally, we create the message for distribution.
-        let payload = processed_assisted_message_plus
-            .serialized_mls_message
-            .into();
-
-        Ok(payload)
+        Ok(processed_assisted_message_plus.serialized_mls_message)
     }
 }

--- a/backend/src/messages/intra_backend.rs
+++ b/backend/src/messages/intra_backend.rs
@@ -5,7 +5,6 @@
 //! This module contains structs and enums that represent messages that are
 //! passed internally within the backend.
 
-use mls_assist::messages::SerializedMlsMessage;
 use phnxtypes::{
     identifiers::QsClientReference,
     messages::client_ds::{EventMessage, QsQueueMessagePayload},
@@ -27,10 +26,4 @@ pub struct DsFanOutMessage {
 pub enum DsFanOutPayload {
     QueueMessage(QsQueueMessagePayload),
     EventMessage(EventMessage),
-}
-
-impl From<SerializedMlsMessage> for DsFanOutPayload {
-    fn from(value: SerializedMlsMessage) -> Self {
-        Self::QueueMessage(value.into())
-    }
 }

--- a/coreclient/src/groups/client_information.rs
+++ b/coreclient/src/groups/client_information.rs
@@ -174,3 +174,13 @@ impl<T: Serialize + DeserializeOwned> StagedClientInformationDiff<T> {
         self.client_information.get(&index)
     }
 }
+
+impl StagedClientInformationDiff<ClientAuthInfo> {
+    pub(super) fn get_user_name(&self, index: usize) -> Option<Option<UserName>> {
+        self.client_information.get(&index).map(|client_info| {
+            client_info
+                .as_ref()
+                .map(|client_info| client_info.client_credential().identity().user_name())
+        })
+    }
+}

--- a/coreclient/src/groups/store.rs
+++ b/coreclient/src/groups/store.rs
@@ -120,10 +120,11 @@ impl PersistableGroup<'_> {
         &mut self,
         provider: &impl OpenMlsProvider<KeyStoreProvider = PhnxOpenMlsProvider<'a>>,
         staged_commit_option: impl Into<Option<StagedCommit>>,
-    ) -> Result<Vec<GroupMessage>> {
-        let result = self
-            .payload
-            .merge_pending_commit(provider, staged_commit_option)?;
+        ds_timestamp: TimeStamp,
+    ) -> Result<Vec<TimestampedMessage>> {
+        let result =
+            self.payload
+                .merge_pending_commit(provider, staged_commit_option, ds_timestamp)?;
         self.persist()?;
         Ok(result)
     }
@@ -141,9 +142,9 @@ impl PersistableGroup<'_> {
     pub fn create_message<'a>(
         &mut self,
         provider: &impl OpenMlsProvider<KeyStoreProvider = PhnxOpenMlsProvider<'a>>,
-        msg: MessageContentType,
-    ) -> Result<(SendMessageParamsOut, GroupMessage), GroupOperationError> {
-        let result = self.payload.create_message(provider, msg)?;
+        content: MimiContent,
+    ) -> Result<(SendMessageParamsOut, Message), GroupOperationError> {
+        let result = self.payload.create_message(provider, content)?;
         self.persist()?;
         Ok(result)
     }

--- a/coreclient/src/lib.rs
+++ b/coreclient/src/lib.rs
@@ -8,6 +8,7 @@ mod contacts;
 mod conversations;
 mod groups;
 mod key_stores;
+mod mimi_content;
 mod providers;
 pub mod users;
 mod utils;
@@ -21,12 +22,12 @@ pub use crate::{
     conversations::{
         messages::{
             ContentMessage, ConversationMessage, DisplayMessage, DisplayMessageType, ErrorMessage,
-            Knock, Message, MessageContentType, NotificationType, SystemMessage, TextMessage,
+            Message, NotificationType, SystemMessage,
         },
         Conversation, ConversationAttributes, ConversationId, ConversationStatus, ConversationType,
         InactiveConversation,
     },
-    groups::GroupMessage,
+    mimi_content::{MessageId, MimiContent, ReplyToInfo, TopicId},
 };
 
 pub use crate::utils::persistence::delete_databases;

--- a/coreclient/src/mimi_content/builder.rs
+++ b/coreclient/src/mimi_content/builder.rs
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: 2023 Phoenix R&D GmbH <hello@phnx.im>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+use phnxtypes::{identifiers::Fqdn, time::TimeStamp};
+
+use super::{MessageId, MimiContent, NestablePart, ReplyToInfo, TopicId};
+
+pub(super) struct MimiContentBuilder {
+    content: MimiContent,
+}
+
+impl MimiContentBuilder {
+    pub(super) fn new(sender_domain: Fqdn, nestable_part: NestablePart) -> Self {
+        let content = MimiContent {
+            id: MessageId::new(sender_domain),
+            timestamp: TimeStamp::now(),
+            replaces: None,
+            topic_id: None,
+            expires: None,
+            in_reply_to: None,
+            last_seen: Vec::new(),
+            body: nestable_part,
+        };
+        Self { content }
+    }
+
+    pub(super) fn with_replaces(mut self, replaces: MessageId) -> Self {
+        self.content.replaces = Some(replaces);
+        self
+    }
+
+    pub(super) fn with_topic_id(mut self, id: Vec<u8>) -> Self {
+        self.content.topic_id = Some(TopicId { id });
+        self
+    }
+
+    pub(super) fn with_expires(mut self, expires: TimeStamp) -> Self {
+        self.content.expires = Some(expires);
+        self
+    }
+
+    pub(super) fn with_in_reply_to(mut self, in_reply_to: ReplyToInfo) -> Self {
+        self.content.in_reply_to = Some(in_reply_to);
+        self
+    }
+
+    pub(super) fn with_last_seen(mut self, last_seen: Vec<MessageId>) -> Self {
+        self.content.last_seen = last_seen;
+        self
+    }
+
+    pub(super) fn build(self) -> MimiContent {
+        self.content
+    }
+}

--- a/coreclient/src/mimi_content/builder.rs
+++ b/coreclient/src/mimi_content/builder.rs
@@ -10,6 +10,7 @@ pub(super) struct MimiContentBuilder {
     content: MimiContent,
 }
 
+#[allow(dead_code)]
 impl MimiContentBuilder {
     pub(super) fn new(sender_domain: Fqdn, nestable_part: NestablePart) -> Self {
         let content = MimiContent {

--- a/coreclient/src/mimi_content/codec.rs
+++ b/coreclient/src/mimi_content/codec.rs
@@ -1,0 +1,176 @@
+// SPDX-FileCopyrightText: 2023 Phoenix R&D GmbH <hello@phnx.im>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+use std::str::FromStr;
+
+use phnxtypes::identifiers::Fqdn;
+use tls_codec::{DeserializeBytes, Serialize, Size};
+use url::Url;
+use uuid::Uuid;
+
+use super::{ContentType, ExternalPartUrl, MessageId, SinglePart, TlsStr, TlsStrOwned};
+
+impl<'a> Size for TlsStr<'a> {
+    fn tls_serialized_len(&self) -> usize {
+        self.value.as_bytes().tls_serialized_len()
+    }
+}
+
+impl<'a> Serialize for TlsStr<'a> {
+    fn tls_serialize<W: std::io::prelude::Write>(
+        &self,
+        writer: &mut W,
+    ) -> Result<usize, tls_codec::Error> {
+        self.value.as_bytes().tls_serialize(writer)
+    }
+}
+
+impl Size for TlsStrOwned {
+    fn tls_serialized_len(&self) -> usize {
+        TlsStr::from(self.value.as_str()).tls_serialized_len()
+    }
+}
+
+impl Serialize for TlsStrOwned {
+    fn tls_serialize<W: std::io::prelude::Write>(
+        &self,
+        writer: &mut W,
+    ) -> Result<usize, tls_codec::Error> {
+        TlsStr::from(self.value.as_str()).tls_serialize(writer)
+    }
+}
+
+impl DeserializeBytes for TlsStrOwned {
+    fn tls_deserialize_bytes(buffer: &[u8]) -> Result<(Self, &[u8]), tls_codec::Error> {
+        let (value_bytes, buffer) = Vec::<u8>::tls_deserialize_bytes(buffer)?;
+        let value = String::from_utf8(value_bytes)
+            .map_err(|e| tls_codec::Error::DecodingError(format!("Invalid UTF-8: {}", e)))?;
+        Ok((Self { value }, buffer))
+    }
+}
+
+impl Size for MessageId {
+    fn tls_serialized_len(&self) -> usize {
+        // Uuid is 16 bytes
+        16 + self.domain.tls_serialized_len()
+    }
+}
+
+impl Serialize for MessageId {
+    fn tls_serialize<W: std::io::prelude::Write>(
+        &self,
+        writer: &mut W,
+    ) -> Result<usize, tls_codec::Error> {
+        let mut written = writer.write(self.id.as_bytes())?;
+        written += self.domain.tls_serialize(writer)?;
+        Ok(written)
+    }
+}
+
+impl DeserializeBytes for MessageId {
+    fn tls_deserialize_bytes(buffer: &[u8]) -> Result<(Self, &[u8]), tls_codec::Error> {
+        let (id_bytes, buffer) = <[u8; 16]>::tls_deserialize_bytes(buffer)?;
+        let id = Uuid::from_bytes(id_bytes);
+        let (domain, buffer) = Fqdn::tls_deserialize_bytes(buffer)?;
+        Ok((Self { id, domain }, buffer))
+    }
+}
+
+impl Size for ExternalPartUrl {
+    fn tls_serialized_len(&self) -> usize {
+        TlsStr::from(self.url.as_str()).tls_serialized_len()
+    }
+}
+
+impl Serialize for ExternalPartUrl {
+    fn tls_serialize<W: std::io::prelude::Write>(
+        &self,
+        writer: &mut W,
+    ) -> Result<usize, tls_codec::Error> {
+        TlsStr::from(self.url.as_str()).tls_serialize(writer)
+    }
+}
+
+impl DeserializeBytes for ExternalPartUrl {
+    fn tls_deserialize_bytes(buffer: &[u8]) -> Result<(Self, &[u8]), tls_codec::Error> {
+        let (url, buffer) = TlsStrOwned::tls_deserialize_bytes(buffer)?;
+        Ok((
+            Self {
+                url: Url::from_str(&url.value)
+                    .map_err(|e| tls_codec::Error::DecodingError(format!("Invalid URL: {}", e)))?,
+            },
+            buffer,
+        ))
+    }
+}
+
+impl Size for ContentType {
+    fn tls_serialized_len(&self) -> usize {
+        match self {
+            ContentType::TextMarkdown => TlsStr::from("text/markdown").tls_serialized_len(),
+        }
+    }
+}
+
+impl Serialize for ContentType {
+    fn tls_serialize<W: std::io::prelude::Write>(
+        &self,
+        writer: &mut W,
+    ) -> Result<usize, tls_codec::Error> {
+        match self {
+            ContentType::TextMarkdown => TlsStr::from("text/markdown").tls_serialize(writer),
+        }
+    }
+}
+
+impl DeserializeBytes for ContentType {
+    fn tls_deserialize_bytes(buffer: &[u8]) -> Result<(Self, &[u8]), tls_codec::Error> {
+        let (value, buffer) = TlsStrOwned::tls_deserialize_bytes(buffer)?;
+        match value.value.as_str() {
+            "text/markdown" => Ok((ContentType::TextMarkdown, buffer)),
+            _ => Err(tls_codec::Error::DecodingError(format!(
+                "Unknown content type: {}",
+                value.value
+            ))),
+        }
+    }
+}
+
+impl Size for SinglePart {
+    fn tls_serialized_len(&self) -> usize {
+        match self {
+            SinglePart::TextMarkdown(content) => {
+                ContentType::TextMarkdown.tls_serialized_len()
+                    + content.as_bytes().tls_serialized_len()
+            }
+        }
+    }
+}
+
+impl Serialize for SinglePart {
+    fn tls_serialize<W: std::io::prelude::Write>(
+        &self,
+        writer: &mut W,
+    ) -> Result<usize, tls_codec::Error> {
+        match self {
+            SinglePart::TextMarkdown(content) => {
+                let mut written = ContentType::TextMarkdown.tls_serialize(writer)?;
+                written += content.as_bytes().tls_serialize(writer)?;
+                Ok(written)
+            }
+        }
+    }
+}
+
+impl DeserializeBytes for SinglePart {
+    fn tls_deserialize_bytes(buffer: &[u8]) -> Result<(Self, &[u8]), tls_codec::Error> {
+        let (content_type, buffer) = ContentType::tls_deserialize_bytes(buffer)?;
+        match content_type {
+            ContentType::TextMarkdown => {
+                let (content, buffer) = TlsStrOwned::tls_deserialize_bytes(buffer)?;
+                Ok((SinglePart::TextMarkdown(content.value), buffer))
+            }
+        }
+    }
+}

--- a/coreclient/src/mimi_content/mod.rs
+++ b/coreclient/src/mimi_content/mod.rs
@@ -68,7 +68,7 @@ impl MessageId {
     PartialEq, Debug, Clone, Serialize, Deserialize, TlsSize, TlsSerialize, TlsDeserializeBytes,
 )]
 pub struct TopicId {
-    id: Vec<u8>,
+    pub id: Vec<u8>,
 }
 
 #[derive(
@@ -84,16 +84,16 @@ pub enum HashAlg {
     PartialEq, Debug, Clone, Serialize, Deserialize, TlsSize, TlsSerialize, TlsDeserializeBytes,
 )]
 pub struct ReplyToHash {
-    hash_alg: HashAlg,
-    hash: Vec<u8>,
+    pub hash_alg: HashAlg,
+    pub hash: Vec<u8>,
 }
 
 #[derive(
     PartialEq, Debug, Clone, Serialize, Deserialize, TlsSize, TlsSerialize, TlsDeserializeBytes,
 )]
 pub struct ReplyToInfo {
-    message_id: MessageId,
-    hash: ReplyToHash,
+    pub message_id: MessageId,
+    pub hash: ReplyToHash,
 }
 
 /// IANA Media Type
@@ -108,14 +108,6 @@ enum ContentType {
 enum SinglePart {
     TextMarkdown(String),
     // Add more as needed
-}
-
-impl SinglePart {
-    fn template(&self) -> String {
-        match self {
-            SinglePart::TextMarkdown(_) => "text/markdown".to_string(),
-        }
-    }
 }
 
 #[derive(PartialEq, Debug, Clone, Serialize, Deserialize)]
@@ -240,15 +232,15 @@ struct MessageDerivedValues {
     PartialEq, Debug, Clone, Serialize, Deserialize, TlsSize, TlsSerialize, TlsDeserializeBytes,
 )]
 pub struct MimiContent {
-    id: MessageId,
-    timestamp: TimeStamp,
-    replaces: Option<MessageId>,
-    topic_id: Option<TopicId>,
+    pub id: MessageId,
+    pub timestamp: TimeStamp,
+    pub replaces: Option<MessageId>,
+    pub topic_id: Option<TopicId>,
     // The point in time when the message expires. If None, the message never
     // expires.
-    expires: Option<TimeStamp>, // This is actually a u32 and needs to be parsed as such. 0 means no expiration, i.e. None.
-    in_reply_to: Option<ReplyToInfo>,
-    last_seen: Vec<MessageId>,
+    pub expires: Option<TimeStamp>, // This is actually a u32 and needs to be parsed as such. 0 means no expiration, i.e. None.
+    pub in_reply_to: Option<ReplyToInfo>,
+    pub last_seen: Vec<MessageId>,
     body: NestablePart,
 }
 
@@ -266,7 +258,7 @@ impl MimiContent {
         MimiContentBuilder::new(sender_domain, nestable_part).build()
     }
 
-    pub(crate) fn string_rendering(&self) -> String {
+    pub fn string_rendering(&self) -> String {
         // For now, we only support SingleParts that contain markdown messages.
         match &self.body.part {
             Part::SinglePart(single_part) => match single_part {

--- a/coreclient/src/mimi_content/mod.rs
+++ b/coreclient/src/mimi_content/mod.rs
@@ -1,0 +1,282 @@
+// SPDX-FileCopyrightText: 2023 Phoenix R&D GmbH <hello@phnx.im>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+use openmls::group::GroupId;
+use phnxtypes::{
+    identifiers::{AsClientId, Fqdn, UserName},
+    time::TimeStamp,
+};
+use serde::{Deserialize, Serialize};
+use tls_codec::{TlsDeserializeBytes, TlsSerialize, TlsSize};
+use url::Url;
+use uuid::Uuid;
+
+use self::builder::MimiContentBuilder;
+
+mod builder;
+mod codec;
+
+// A TLS encoded byte string that contains a UTF-8 encoded string.
+#[derive(PartialEq, Debug, Clone, Serialize, Deserialize)]
+struct TlsStr<'a> {
+    value: &'a str,
+}
+
+impl<'a> From<&'a str> for TlsStr<'a> {
+    fn from(value: &'a str) -> Self {
+        Self { value }
+    }
+}
+
+#[derive(PartialEq, Debug, Clone, Serialize, Deserialize)]
+struct TlsStrOwned {
+    value: String,
+}
+
+/// A domain-scoped message id.
+///
+/// This is only pub(super), because we add such an id for event message also.
+#[derive(PartialEq, Debug, Clone, Serialize, Deserialize)]
+pub struct MessageId {
+    id: Uuid,
+    domain: Fqdn,
+}
+
+impl MessageId {
+    pub(crate) fn new(domain: Fqdn) -> Self {
+        Self {
+            id: Uuid::new_v4(),
+            domain,
+        }
+    }
+
+    pub fn id(&self) -> Uuid {
+        self.id
+    }
+
+    pub(super) fn id_ref(&self) -> &Uuid {
+        &self.id
+    }
+
+    pub fn domain(&self) -> &Fqdn {
+        &self.domain
+    }
+}
+
+#[derive(
+    PartialEq, Debug, Clone, Serialize, Deserialize, TlsSize, TlsSerialize, TlsDeserializeBytes,
+)]
+pub struct TopicId {
+    id: Vec<u8>,
+}
+
+#[derive(
+    PartialEq, Debug, Clone, Serialize, Deserialize, TlsSize, TlsSerialize, TlsDeserializeBytes,
+)]
+#[repr(u8)]
+pub enum HashAlg {
+    None,
+    Sha256,
+}
+
+#[derive(
+    PartialEq, Debug, Clone, Serialize, Deserialize, TlsSize, TlsSerialize, TlsDeserializeBytes,
+)]
+pub struct ReplyToHash {
+    hash_alg: HashAlg,
+    hash: Vec<u8>,
+}
+
+#[derive(
+    PartialEq, Debug, Clone, Serialize, Deserialize, TlsSize, TlsSerialize, TlsDeserializeBytes,
+)]
+pub struct ReplyToInfo {
+    message_id: MessageId,
+    hash: ReplyToHash,
+}
+
+/// IANA Media Type
+#[derive(PartialEq, Debug, Clone, Serialize, Deserialize)]
+enum ContentType {
+    TextMarkdown,
+    // Add more as needed
+}
+
+/// These are the (IANA) content types we support at the moment.
+#[derive(PartialEq, Debug, Clone, Serialize, Deserialize)]
+enum SinglePart {
+    TextMarkdown(String),
+    // Add more as needed
+}
+
+impl SinglePart {
+    fn template(&self) -> String {
+        match self {
+            SinglePart::TextMarkdown(_) => "text/markdown".to_string(),
+        }
+    }
+}
+
+#[derive(PartialEq, Debug, Clone, Serialize, Deserialize)]
+struct ExternalPartUrl {
+    url: Url,
+}
+
+// This is a placeholder for the actual IANA registered AEAD algorithm.
+#[derive(
+    PartialEq, Debug, Clone, Serialize, Deserialize, TlsSize, TlsSerialize, TlsDeserializeBytes,
+)]
+#[repr(u16)]
+enum AeadAlg {
+    // This is just a placeholder.
+    None,
+}
+
+#[derive(
+    PartialEq, Debug, Clone, Serialize, Deserialize, TlsSize, TlsSerialize, TlsDeserializeBytes,
+)]
+struct ExternalPart {
+    content_type: ContentType,  // An IANA media type {10}
+    url: ExternalPartUrl,       // A URL where the content can be fetched
+    expires: Option<TimeStamp>, // This is actually a u32 and needs to be parsed as such. 0 means no expiration, i.e. None.
+    size: u64,                  // size of content in octets
+    aead_alg: AeadAlg,          // An IANA AEAD Algorithm number, or zero
+    // TODO: Key and nonce need their own types.
+    key: Vec<u8>,             // AEAD key
+    nonce: Vec<u8>,           // AEAD nonce
+    aad: Vec<u8>,             // AEAD additional authentiation data
+    description: TlsStrOwned, // an optional text description
+}
+
+#[derive(
+    PartialEq, Debug, Clone, Serialize, Deserialize, TlsSize, TlsSerialize, TlsDeserializeBytes,
+)]
+struct MultiParts {
+    pars: Vec<NestablePart>,
+}
+
+#[derive(
+    PartialEq, Debug, Clone, Serialize, Deserialize, TlsSize, TlsSerialize, TlsDeserializeBytes,
+)]
+#[repr(u16)]
+enum PartSemantics {
+    NullPart,
+    SinglePart,
+    ChooseOne,
+    SingleUnit,
+    ProcessAll,
+}
+
+#[derive(
+    PartialEq, Debug, Clone, Serialize, Deserialize, TlsSize, TlsSerialize, TlsDeserializeBytes,
+)]
+#[repr(u16)]
+enum Part {
+    NullPart,
+    SinglePart(SinglePart),
+    ExternalPart(ExternalPart),
+    MultiParts(MultiParts),
+}
+
+#[derive(
+    PartialEq, Debug, Clone, Serialize, Deserialize, TlsSize, TlsSerialize, TlsDeserializeBytes,
+)]
+#[repr(u16)]
+enum Disposition {
+    Unspecified,
+    Render,
+    Reaction,
+    Profile,
+    Inline,
+    Icon,
+    Attachment,
+    Session,
+    Preview,
+}
+
+#[derive(
+    PartialEq, Debug, Clone, Serialize, Deserialize, TlsSize, TlsSerialize, TlsDeserializeBytes,
+)]
+struct Language {
+    language: TlsStrOwned,
+}
+
+#[derive(
+    PartialEq, Debug, Clone, Serialize, Deserialize, TlsSize, TlsSerialize, TlsDeserializeBytes,
+)]
+struct NestablePart {
+    disposition: Disposition,
+    languages: Vec<Language>,
+    part_index: u16,
+    part_semantic: PartSemantics,
+    part: Part,
+}
+
+impl Default for NestablePart {
+    fn default() -> Self {
+        Self {
+            disposition: Disposition::Unspecified,
+            languages: Vec::new(),
+            part_index: 0,
+            part_semantic: PartSemantics::NullPart,
+            part: Part::NullPart,
+        }
+    }
+}
+
+#[derive(
+    PartialEq, Debug, Clone, Serialize, Deserialize, TlsSize, TlsSerialize, TlsDeserializeBytes,
+)]
+struct MessageDerivedValues {
+    mls_group_id: GroupId,
+    sender_leaf_index: u32,
+    sender_client_id: AsClientId,
+    sender_user_id: UserName,
+    group_name: TlsStrOwned,
+}
+
+#[derive(
+    PartialEq, Debug, Clone, Serialize, Deserialize, TlsSize, TlsSerialize, TlsDeserializeBytes,
+)]
+pub struct MimiContent {
+    id: MessageId,
+    timestamp: TimeStamp,
+    replaces: Option<MessageId>,
+    topic_id: Option<TopicId>,
+    // The point in time when the message expires. If None, the message never
+    // expires.
+    expires: Option<TimeStamp>, // This is actually a u32 and needs to be parsed as such. 0 means no expiration, i.e. None.
+    in_reply_to: Option<ReplyToInfo>,
+    last_seen: Vec<MessageId>,
+    body: NestablePart,
+}
+
+impl MimiContent {
+    pub fn simple_markdown_message(sender_domain: Fqdn, markdown_text: String) -> Self {
+        // For now, we just encode text as markdown.
+        let single_part = SinglePart::TextMarkdown(markdown_text);
+        let nestable_part = NestablePart {
+            disposition: Disposition::Render,
+            languages: Vec::new(),
+            part_index: 0,
+            part_semantic: PartSemantics::SinglePart,
+            part: Part::SinglePart(single_part),
+        };
+        MimiContentBuilder::new(sender_domain, nestable_part).build()
+    }
+
+    pub(crate) fn string_rendering(&self) -> String {
+        // For now, we only support SingleParts that contain markdown messages.
+        match &self.body.part {
+            Part::SinglePart(single_part) => match single_part {
+                SinglePart::TextMarkdown(text) => text.clone(),
+            },
+            _ => "Unsupported content type".to_string(),
+        }
+    }
+
+    pub fn id(&self) -> &MessageId {
+        &self.id
+    }
+}

--- a/server/tests/mod.rs
+++ b/server/tests/mod.rs
@@ -6,10 +6,10 @@ mod qs;
 
 use std::fs;
 
-use opaque_ke::rand::{rngs::OsRng, Rng};
+use opaque_ke::rand::{distributions::Alphanumeric, rngs::OsRng, Rng};
 use phnxapiclient::ApiClient;
 
-use phnxcoreclient::{users::SelfUser, MessageContentType};
+use phnxcoreclient::{users::SelfUser, MimiContent};
 use phnxserver::network_provider::MockNetworkProvider;
 use phnxserver_test_harness::utils::{setup::TestBackend, spawn_app};
 use phnxtypes::identifiers::{Fqdn, SafeTryInto};
@@ -429,8 +429,13 @@ async fn retrieve_conversation_messages() {
     let number_of_messages = 10;
     let mut messages_sent = vec![];
     for _ in 0..number_of_messages {
-        let message: Vec<u8> = OsRng.gen::<[u8; 32]>().to_vec();
-        let message_content = MessageContentType::Text(phnxcoreclient::TextMessage::new(message));
+        let message: String = OsRng
+            .sample_iter(&Alphanumeric)
+            .take(32)
+            .map(char::from)
+            .collect();
+        let message_content =
+            MimiContent::simple_markdown_message(alice.user_name().domain(), message);
         let message = alice
             .send_message(conversation_id, message_content)
             .await
@@ -470,8 +475,13 @@ async fn mark_as_read() {
     let number_of_messages = 10;
     let mut messages_sent = vec![];
     for _ in 0..number_of_messages {
-        let message: Vec<u8> = OsRng.gen::<[u8; 32]>().to_vec();
-        let message_content = MessageContentType::Text(phnxcoreclient::TextMessage::new(message));
+        let message: String = OsRng
+            .sample_iter(&Alphanumeric)
+            .take(32)
+            .map(char::from)
+            .collect();
+        let message_content =
+            MimiContent::simple_markdown_message(alice.user_name().domain(), message);
         let message = alice
             .send_message(conversation_id, message_content)
             .await

--- a/test_harness/src/utils/setup.rs
+++ b/test_harness/src/utils/setup.rs
@@ -462,10 +462,10 @@ impl TestBackend {
 
             assert_eq!(
                 messages.last().unwrap().message(),
-                &Message::Content(ContentMessage {
-                    sender: sender_user_name.to_string(),
-                    content: orig_message.clone()
-                })
+                &Message::Content(ContentMessage::new(
+                    sender_user_name.to_string(),
+                    orig_message.clone()
+                ))
             );
         }
     }

--- a/types/src/crypto/ratchet/tests.rs
+++ b/types/src/crypto/ratchet/tests.rs
@@ -2,7 +2,10 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-use crate::messages::client_ds::{QsQueueMessagePayload, QsQueueMessageType};
+use crate::{
+    messages::client_ds::{QsQueueMessagePayload, QsQueueMessageType},
+    time::TimeStamp,
+};
 
 use super::*;
 
@@ -13,6 +16,7 @@ fn test_ratchet() {
     let mut sender_ratchet = QueueRatchet::try_from(ratchet_secret.clone()).unwrap();
     let mut receiver_ratchtet = QueueRatchet::try_from(ratchet_secret).unwrap();
     let message = QsQueueMessagePayload {
+        timestamp: TimeStamp::now(),
         message_type: QsQueueMessageType::MlsMessage,
         payload: vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
     };

--- a/types/src/messages/client_ds.rs
+++ b/types/src/messages/client_ds.rs
@@ -42,6 +42,7 @@ use crate::{
     },
     identifiers::QsClientReference,
     keypackage_batch::{KeyPackageBatch, UNVERIFIED},
+    time::TimeStamp,
 };
 
 use super::{
@@ -78,13 +79,14 @@ pub enum QsQueueMessageType {
     Debug, PartialEq, TlsSerialize, TlsDeserializeBytes, TlsSize, Clone, Serialize, Deserialize,
 )]
 pub struct QsQueueMessagePayload {
+    pub timestamp: TimeStamp,
     pub message_type: QsQueueMessageType,
     pub payload: Vec<u8>,
 }
 
 impl QsQueueMessagePayload {
-    pub fn extract(self) -> Result<ExtractedQsQueueMessagePayload, tls_codec::Error> {
-        let message = match self.message_type {
+    pub fn extract(self) -> Result<ExtractedQsQueueMessage, tls_codec::Error> {
+        let payload = match self.message_type {
             QsQueueMessageType::WelcomeBundle => {
                 let wb = WelcomeBundle::tls_deserialize_exact_bytes(&self.payload)?;
                 ExtractedQsQueueMessagePayload::WelcomeBundle(wb)
@@ -95,8 +97,17 @@ impl QsQueueMessagePayload {
                 ExtractedQsQueueMessagePayload::MlsMessage(message)
             }
         };
-        Ok(message)
+        Ok(ExtractedQsQueueMessage {
+            timestamp: self.timestamp,
+            payload,
+        })
     }
+}
+
+#[derive(Debug)]
+pub struct ExtractedQsQueueMessage {
+    pub timestamp: TimeStamp,
+    pub payload: ExtractedQsQueueMessagePayload,
 }
 
 #[derive(Debug)]
@@ -111,6 +122,7 @@ impl TryFrom<WelcomeBundle> for QsQueueMessagePayload {
     fn try_from(welcome_bundle: WelcomeBundle) -> Result<Self, Self::Error> {
         let payload = welcome_bundle.tls_serialize_detached()?;
         Ok(Self {
+            timestamp: TimeStamp::now(),
             message_type: QsQueueMessageType::WelcomeBundle,
             payload,
         })
@@ -120,6 +132,7 @@ impl TryFrom<WelcomeBundle> for QsQueueMessagePayload {
 impl From<SerializedMlsMessage> for QsQueueMessagePayload {
     fn from(value: SerializedMlsMessage) -> Self {
         Self {
+            timestamp: TimeStamp::now(),
             message_type: QsQueueMessageType::MlsMessage,
             payload: value.0,
         }
@@ -184,6 +197,8 @@ pub struct EventMessage {
     pub group_id: GroupId,
     pub sender_index: LeafNodeIndex,
     pub epoch: GroupEpoch,
+    // Timestamp set by the DS at the time of processing the message.
+    pub timestamp: TimeStamp,
     pub payload: Vec<u8>,
 }
 

--- a/types/src/messages/client_ds_out.rs
+++ b/types/src/messages/client_ds_out.rs
@@ -29,6 +29,7 @@ use crate::{
     },
     identifiers::QsClientReference,
     keypackage_batch::{KeyPackageBatch, VERIFIED},
+    time::TimeStamp,
 };
 
 use super::{
@@ -51,6 +52,7 @@ pub struct ExternalCommitInfoIn {
 #[repr(u8)]
 pub enum DsProcessResponseIn {
     Ok,
+    FanoutTimestamp(TimeStamp),
     WelcomeInfo(RatchetTreeIn),
     ExternalCommitInfo(ExternalCommitInfoIn),
     GroupId(GroupId),

--- a/types/src/time.rs
+++ b/types/src/time.rs
@@ -33,7 +33,7 @@ impl TryFrom<i64> for TimeStamp {
     fn try_from(time: i64) -> Result<Self, Self::Error> {
         let time_result = Utc.timestamp_millis_opt(time);
         match time_result {
-            chrono::LocalResult::Single(time) => Ok(Self { time }),
+            chrono::LocalResult::Single(time) => Ok(time.into()),
             chrono::LocalResult::None | chrono::LocalResult::Ambiguous(_, _) => {
                 Err(TimeStampError::InvalidInput)
             }
@@ -91,7 +91,7 @@ impl TimeStamp {
     pub fn now() -> Self {
         // We round the subseconds to 3 digits, because we don't need more
         // precision.
-        Utc::now().round_subsecs(3).into()
+        Utc::now().into()
     }
 
     pub fn in_days(days_in_the_future: i64) -> Self {

--- a/types/src/time.rs
+++ b/types/src/time.rs
@@ -2,12 +2,13 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-use chrono::{DateTime, NaiveDateTime, Utc};
+use chrono::{DateTime, TimeZone, Utc};
 
 use super::*;
 
 pub use chrono::Duration;
 
+/// A time stamp that can be used to represent a point in time.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Eq, Hash, Copy)]
 pub struct TimeStamp {
     time: DateTime<Utc>,
@@ -16,6 +17,26 @@ pub struct TimeStamp {
 impl From<DateTime<Utc>> for TimeStamp {
     fn from(time: DateTime<Utc>) -> Self {
         Self { time }
+    }
+}
+
+impl From<TimeStamp> for i64 {
+    fn from(time: TimeStamp) -> Self {
+        time.time.timestamp_micros()
+    }
+}
+
+impl TryFrom<i64> for TimeStamp {
+    type Error = TimeStampError;
+
+    fn try_from(time: i64) -> Result<Self, Self::Error> {
+        let time_result = Utc.timestamp_micros(time);
+        match time_result {
+            chrono::LocalResult::Single(time) => Ok(Self { time }),
+            chrono::LocalResult::None | chrono::LocalResult::Ambiguous(_, _) => {
+                Err(TimeStampError::InvalidInput)
+            }
+        }
     }
 }
 
@@ -30,12 +51,7 @@ impl TryFrom<u64> for TimeStamp {
     type Error = TimeStampError;
 
     fn try_from(time: u64) -> Result<Self, Self::Error> {
-        let time = DateTime::<Utc>::from_naive_utc_and_offset(
-            NaiveDateTime::from_timestamp_millis(time as i64)
-                .ok_or(TimeStampError::InvalidInput)?,
-            Utc,
-        );
-        Ok(Self { time })
+        Self::try_from(time as i64)
     }
 }
 
@@ -47,10 +63,8 @@ impl Size for TimeStamp {
 
 impl TlsSerializeTrait for TimeStamp {
     fn tls_serialize<W: std::io::Write>(&self, writer: &mut W) -> Result<usize, tls_codec::Error> {
-        self.time
-            .timestamp_millis()
-            .to_be_bytes()
-            .tls_serialize(writer)
+        let time_i64: i64 = (*self).into();
+        time_i64.to_be_bytes().tls_serialize(writer)
     }
 }
 
@@ -59,24 +73,21 @@ impl TlsDeserializeBytesTrait for TimeStamp {
     where
         Self: Sized,
     {
-        let millis_bytes: [u8; 8] = bytes
+        let time_i64_bytes: [u8; 8] = bytes
             .get(..8)
             .ok_or(tls_codec::Error::EndOfStream)?
             .try_into()
             .map_err(|_| tls_codec::Error::EndOfStream)?;
-        let millis = i64::from_be_bytes(millis_bytes);
-        let time = DateTime::<Utc>::from_naive_utc_and_offset(
-            NaiveDateTime::from_timestamp_millis(millis).ok_or(tls_codec::Error::InvalidInput)?,
-            Utc,
-        );
-        Ok((Self { time }, &bytes[8..]))
+        let time_i64 = i64::from_be_bytes(time_i64_bytes);
+        let time = TimeStamp::try_from(time_i64)
+            .map_err(|_| tls_codec::Error::DecodingError(format!("Invalid timestamp")))?;
+        Ok((time, &bytes[8..]))
     }
 }
 
 impl TimeStamp {
     pub fn now() -> Self {
-        let time = Utc::now();
-        Self { time }
+        Utc::now().into()
     }
 
     pub fn in_days(days_in_the_future: i64) -> Self {
@@ -86,7 +97,8 @@ impl TimeStamp {
 
     /// Checks if this time stamp is more than `expiration_days` in the past.
     pub fn has_expired(&self, expiration_days: i64) -> bool {
-        Utc::now() - Duration::days(expiration_days) >= self.time
+        let time_left = Utc::now() - Duration::days(expiration_days);
+        Self::from(time_left).time >= self.time
     }
 
     pub fn is_between(&self, start: &Self, end: &Self) -> bool {
@@ -102,7 +114,21 @@ impl TimeStamp {
     }
 
     pub fn as_u64(&self) -> u64 {
-        self.time.timestamp_millis() as u64
+        let time_i64: i64 = (*self).into();
+        time_i64 as u64
+    }
+}
+
+#[cfg(test)]
+mod timestamp_conversion {
+    use super::*;
+
+    #[test]
+    fn timestamp_conversion() {
+        let time = TimeStamp::now();
+        let time_u64 = time.as_u64();
+        let time_converted = TimeStamp::try_from(time_u64).unwrap();
+        assert_eq!(time, time_converted);
     }
 }
 


### PR DESCRIPTION
This PR ...
- partially implements the MIMI Content scheme as defined [here](https://datatracker.ietf.org/doc/draft-ietf-mimi-content/)
- changes the protocol s.t. the DS now attaches a timestamp to every message it fans out. That same timestamp is also returned to the sender of the message.
- The applogic interface is simplified to take a String as input when sending a message
- Generation of event messages is unified into one function (just refactoring)
- Refactoring of Timestamps 
- Timestamps are now reduced to millisecond precision.
