### PR TITLE
fix: deadlock when replacing logging stream sink

### DIFF
--- a/applogic/src/api/mobile_logging.rs
+++ b/applogic/src/api/mobile_logging.rs
@@ -79,14 +79,13 @@ pub struct SendToDartLogger {
 
 impl SendToDartLogger {
     pub fn set_stream_sink(stream_sink: StreamSink<LogEntry>) {
-        let mut guard = SEND_TO_DART_LOGGER_STREAM_SINK.write().unwrap();
-        let overriding = guard.is_some();
-
-        *guard = Some(stream_sink);
-
-        drop(guard);
-
-        if overriding {
+        let prev_stream_sink = {
+            let mut guard = SEND_TO_DART_LOGGER_STREAM_SINK.write().expect("poisoned");
+            // Note: previous stream sink MUST NOT be dropped before the `guard` is released.
+            // On drop, it will log and because the `RwLock` is not reentrant, this will deadlock.
+            guard.replace(stream_sink)
+        };
+        if prev_stream_sink.is_some() {
             warn!(
                 "SendToDartLogger::set_stream_sink but already exist a sink, thus overriding. \
                 (This may or may not be a problem. It will happen normally if hot-reload Flutter app.)"

--- a/applogic/src/api/mobile_logging.rs
+++ b/applogic/src/api/mobile_logging.rs
@@ -81,8 +81,9 @@ impl SendToDartLogger {
     pub fn set_stream_sink(stream_sink: StreamSink<LogEntry>) {
         let prev_stream_sink = {
             let mut guard = SEND_TO_DART_LOGGER_STREAM_SINK.write().expect("poisoned");
-            // Note: previous stream sink MUST NOT be dropped before the `guard` is released.
-            // On drop, it will log and because the `RwLock` is not reentrant, this will deadlock.
+            // Note: The previous stream sink MUST NOT be dropped before the `guard` is released.
+            // On drop, it will log a message, and therefore lock the sink for reading. Because the
+            // `RwLock` is not reentrant, this will deadlock.
             guard.replace(stream_sink)
         };
         if prev_stream_sink.is_some() {


### PR DESCRIPTION
When setting a new stream sink in `SendToDartLogger`, we lock the global
rw lock for writing. However, if the lock already contained a sink, it
was droppen at the same line when replacing it. A stream sink logs a
message on drop, and therefore `SendToDartLogger` tries to lock the
global rw lock again, this time for reading. The lock is not reentrant,
so it deadlocks.

This makes sure we drop the previous sink *after* unlocking the rw lock.

In particular, this fixes hot restart in Flutter.

Fixes https://github.com/phnx-im/infra/issues/225