### PR TITLE
chore: bootstrap justfile

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -26,10 +26,8 @@ services:
     ports:
       - ${COMPOSE_BIND_HOST:-127.0.0.1}:5432:5432
     volumes:
-      - type: volume
-        source: postgres_data
-        target: /var/lib/postgresql/data
-      - ./backend/test_certs:/etc/postgresql/certs:ro
+      - postgres_data:/var/lib/postgresql/data:z
+      - ./backend/test_certs:/etc/postgresql/certs:ro,z
 
 volumes:
   postgres_data:

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: 2024 Phoenix R&D GmbH <hello@phnx.im>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+services:
+  postgres:
+    image: postgres:17.2
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: password
+      POSTGRES_DB: phnx_db
+    command: >
+      postgres
+      -c max_connections=1000
+      -c shared_buffers=2GB
+      -c ssl=on
+      -c ssl_cert_file=/etc/postgresql/certs/server.crt
+      -c ssl_key_file=/etc/postgresql/certs/server.key
+      -c ssl_ca_file=/etc/postgresql/certs/root.crt
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres", "-h", "127.0.0.1"]
+      start_period: 1s
+      interval: 1s
+      timeout: 5s
+      retries: 10
+    ports:
+      - ${COMPOSE_BIND_HOST:-127.0.0.1}:5432:5432
+    volumes:
+      - type: volume
+        source: postgres_data
+        target: /var/lib/postgresql/data
+      - ./backend/test_certs:/etc/postgresql/certs:ro
+
+volumes:
+  postgres_data:

--- a/justfile
+++ b/justfile
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: 2024 Phoenix R&D GmbH <hello@phnx.im>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+export DATABASE_URL := "postgres://postgres:password@localhost:5432/phnx_db"
+
+# run postgres via docker compose and apply migrations
+init-db: generate-db-certs
+    docker compose up --wait
+    cd backend && sqlx database create
+    cd backend && sqlx database setup
+
+# generate postgres TLS certificates
+generate-db-certs:
+    cd backend && TEST_CERT_DIR_NAME=test_certs scripts/generate_test_certs.sh
+
+# generate Rust and Dart flutter bridge files
+generate-flutter-ffi:
+    cd prototype && make frb-generate


### PR DESCRIPTION
Also add a simple docker compose file with postgres.

```
Available recipes:
    generate-db-certs    # generate postgres TLS certificates
    generate-flutter-ffi # generate Rust and Dart flutter bridge files
    init-db              # run postgres via docker compose and apply migrations
```

Note: usage of just in CI is not part of this commit.

Related #232