### PR TITLE
refactor: expose the user via a provider in the whole app

### DIFF
--- a/app/lib/app.dart
+++ b/app/lib/app.dart
@@ -89,8 +89,8 @@ class _AppState extends State<App> with WidgetsBindingObserver {
         // 1. Listen to the loadable user and switch the navigation accordingly.
         // 2. Provide the logged in user to the app, when it is loaded.
         child: BlocConsumer<LoadableUserCubit, LoadableUser>(
-          listenWhen: _nullToSomeOrSomeToNull,
-          buildWhen: _nullToSomeOrSomeToNull,
+          listenWhen: _isUserLoadedOrUnloaded,
+          buildWhen: _isUserLoadedOrUnloaded,
           listener: (context, loadableUser) {
             // Side Effect: navigate to the home screen or away to the intro
             // screen, depending on whether the user was loaded or unloaded.
@@ -116,7 +116,8 @@ class _AppState extends State<App> with WidgetsBindingObserver {
   }
 }
 
-bool _nullToSomeOrSomeToNull(LoadableUser previous, LoadableUser current) =>
+/// Checks if [LoadableUser.user] transitioned from loaded to null or vice versa
+bool _isUserLoadedOrUnloaded(LoadableUser previous, LoadableUser current) =>
     (previous.user != null || current.user != null) &&
     previous.user != current.user;
 

--- a/app/lib/app.dart
+++ b/app/lib/app.dart
@@ -91,10 +91,10 @@ class _AppState extends State<App> with WidgetsBindingObserver {
         child: BlocConsumer<LoadableUserCubit, LoadableUser>(
           listenWhen: _nullToSomeOrSomeToNull,
           buildWhen: _nullToSomeOrSomeToNull,
-          listener: (context, lodableUser) {
+          listener: (context, loadableUser) {
             // Side Effect: navigate to the home screen or away to the intro
             // screen, depending on whether the user was loaded or unloaded.
-            switch (lodableUser) {
+            switch (loadableUser) {
               case LoadedUser(user: final _?):
                 context.read<NavigationCubit>().openHome();
               case LoadingUser() || LoadedUser(user: null):

--- a/app/lib/conversation_list_pane/conversation_list.dart
+++ b/app/lib/conversation_list_pane/conversation_list.dart
@@ -14,6 +14,7 @@ import 'package:prototype/styles.dart';
 import 'package:prototype/theme/theme.dart';
 import 'package:convert/convert.dart';
 import 'package:collection/collection.dart';
+import 'package:prototype/user_cubit.dart';
 import 'package:provider/provider.dart';
 
 class ConversationList extends StatefulWidget {
@@ -142,7 +143,7 @@ class _ConversationListState extends State<ConversationList> {
     );
   }
 
-  Widget _lastMessage(int index) {
+  Widget _lastMessage(String userName, int index) {
     var sender = '';
     var displayedLastMessage = '';
     final lastMessage = _conversations[index].lastMessage;
@@ -160,13 +161,11 @@ class _ConversationListState extends State<ConversationList> {
 
     final senderStyle = style.copyWith(fontVariations: variationSemiBold);
 
-    final coreClient = context.coreClient;
-
     if (lastMessage != null) {
       lastMessage.message.when(
           contentFlight: (c) {
             final lastContentMessage = c.last;
-            if (lastContentMessage.sender == coreClient.username) {
+            if (lastContentMessage.sender == userName) {
               sender = 'You: ';
             }
             displayedLastMessage = lastContentMessage.content.body;
@@ -246,14 +245,14 @@ class _ConversationListState extends State<ConversationList> {
     );
   }
 
-  Widget _bottomPart(int index) {
+  Widget _bottomPart(String userName, int index) {
     return Row(
       mainAxisAlignment: MainAxisAlignment.spaceBetween,
       children: [
         Expanded(
           child: Align(
             alignment: Alignment.topLeft,
-            child: _lastMessage(index),
+            child: _lastMessage(userName, index),
           ),
         ),
         const SizedBox(width: 16),
@@ -265,7 +264,7 @@ class _ConversationListState extends State<ConversationList> {
     );
   }
 
-  Widget _listTile(int index) {
+  Widget _listTile(String userName, int index) {
     return ListTile(
       horizontalTitleGap: 0,
       contentPadding: const EdgeInsets.symmetric(
@@ -295,7 +294,7 @@ class _ConversationListState extends State<ConversationList> {
                 children: [
                   _topPart(index),
                   const SizedBox(height: 2),
-                  Expanded(child: _bottomPart(index)),
+                  Expanded(child: _bottomPart(userName, index)),
                 ],
               ),
             ),
@@ -328,6 +327,8 @@ class _ConversationListState extends State<ConversationList> {
 
   @override
   Widget build(BuildContext context) {
+    final userName = context.select((UserCubit cubit) => cubit.state.userName);
+
     if (_conversations.isNotEmpty) {
       return ListView.builder(
         itemCount: _conversations.length,
@@ -336,7 +337,7 @@ class _ConversationListState extends State<ConversationList> {
         ),
         controller: _scrollController,
         itemBuilder: (BuildContext context, int index) {
-          return _listTile(index);
+          return _listTile(userName, index);
         },
       );
     } else {

--- a/app/lib/conversation_list_pane/pane.dart
+++ b/app/lib/conversation_list_pane/pane.dart
@@ -2,54 +2,15 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import 'dart:async';
-import 'dart:typed_data';
-
 import 'package:flutter/material.dart';
 import 'package:prototype/conversation_list_pane/conversation_list.dart';
 import 'package:prototype/conversation_list_pane/footer.dart';
 import 'package:prototype/conversation_list_pane/top.dart';
-import 'package:prototype/core/api/types.dart';
-import 'package:prototype/core_client.dart';
 import 'package:prototype/styles.dart';
 import 'package:prototype/theme/theme.dart';
 
-class ConversationView extends StatefulWidget {
+class ConversationView extends StatelessWidget {
   const ConversationView({super.key});
-
-  @override
-  State<ConversationView> createState() => _ConversationViewState();
-}
-
-class _ConversationViewState extends State<ConversationView> {
-  String? displayName;
-  Uint8List? profilePicture;
-  late final StreamSubscription<UiUserProfile> _profileSubscription;
-
-  @override
-  void initState() {
-    super.initState();
-
-    final coreClient = context.coreClient;
-    setState(() {
-      displayName = coreClient.ownProfile.displayName;
-      profilePicture = coreClient.ownProfile.profilePictureOption;
-    });
-
-    // Listen for changes to the user's profile picture
-    _profileSubscription = coreClient.onOwnProfileUpdate.listen((profile) {
-      setState(() {
-        profilePicture = profile.profilePictureOption;
-        displayName = profile.displayName;
-      });
-    });
-  }
-
-  @override
-  void dispose() {
-    _profileSubscription.cancel();
-    super.dispose();
-  }
 
   @override
   Widget build(BuildContext context) {
@@ -63,18 +24,15 @@ class _ConversationViewState extends State<ConversationView> {
           ),
         ),
       ),
-      child: Scaffold(
+      child: const Scaffold(
         backgroundColor: convPaneBackgroundColor,
         body: Column(
           mainAxisAlignment: MainAxisAlignment.end,
           children: [
-            ConversationListTop(
-              displayName: displayName,
-              profilePicture: profilePicture,
-            ),
-            const SizedBox(height: Spacings.s),
-            const Expanded(child: ConversationList()),
-            const ConversationListFooter(),
+            ConversationListTop(),
+            SizedBox(height: Spacings.s),
+            Expanded(child: ConversationList()),
+            ConversationListFooter(),
           ],
         ),
       ),

--- a/app/lib/conversation_list_pane/top.dart
+++ b/app/lib/conversation_list_pane/top.dart
@@ -2,24 +2,17 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import 'dart:typed_data';
-
 import 'package:flutter/material.dart';
-import 'package:prototype/core_client.dart';
 import 'package:prototype/elements.dart';
 import 'package:prototype/navigation/navigation.dart';
 import 'package:prototype/styles.dart';
+import 'package:prototype/user_cubit.dart';
 import 'package:provider/provider.dart';
 
 class ConversationListTop extends StatelessWidget {
   const ConversationListTop({
     super.key,
-    required this.displayName,
-    required this.profilePicture,
   });
-
-  final String? displayName;
-  final Uint8List? profilePicture;
 
   double _topOffset() {
     return isPointer() ? 30 : kToolbarHeight;
@@ -27,70 +20,6 @@ class ConversationListTop extends StatelessWidget {
 
   double _topHeight() {
     return 60 + _topOffset();
-  }
-
-  Widget _avatar(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.only(left: 18.0),
-      child: Row(
-        mainAxisAlignment: MainAxisAlignment.center,
-        crossAxisAlignment: CrossAxisAlignment.center,
-        children: [
-          UserAvatar(
-            size: 32,
-            username: context.coreClient.username,
-            image: profilePicture,
-            onPressed: () {
-              context.read<NavigationCubit>().openUserSettings();
-            },
-          )
-        ],
-      ),
-    );
-  }
-
-  Column _usernameSpace(String username) {
-    return Column(
-      children: [
-        Text(
-          displayName ?? "",
-          style: const TextStyle(
-            color: colorDMB,
-            fontVariations: variationBold,
-            fontSize: 13,
-            letterSpacing: -0.2,
-          ),
-        ),
-        const SizedBox(height: 5),
-        Text(
-          username,
-          style: const TextStyle(
-            color: colorDMB,
-            fontSize: 10,
-            fontVariations: variationMedium,
-            letterSpacing: -0.2,
-          ),
-          overflow: TextOverflow.ellipsis,
-        ),
-      ],
-    );
-  }
-
-  Widget _settingsButton(BuildContext context) {
-    return IconButton(
-      onPressed: () {
-        context.read<NavigationCubit>().openDeveloperSettings();
-      },
-      hoverColor: Colors.transparent,
-      focusColor: Colors.transparent,
-      splashColor: Colors.transparent,
-      highlightColor: Colors.transparent,
-      icon: const Icon(
-        Icons.settings,
-        size: 20,
-        color: colorDMB,
-      ),
-    );
   }
 
   @override
@@ -104,17 +33,110 @@ class ConversationListTop extends StatelessWidget {
         ),
         Padding(
           padding: EdgeInsets.only(left: 8, right: 8, top: _topOffset()),
-          child: Row(
+          child: const Row(
             children: [
-              _avatar(context),
+              _Avatar(),
               Expanded(
-                child: _usernameSpace(context.coreClient.username),
+                child: _UsernameSpace(),
               ),
-              _settingsButton(context),
+              _SettingsButton(),
             ],
           ),
         ),
       ],
+    );
+  }
+}
+
+class _Avatar extends StatelessWidget {
+  const _Avatar();
+
+  @override
+  Widget build(BuildContext context) {
+    final (userName, profilePicture) = context.select(
+      (UserCubit cubit) => (
+        cubit.state.userName,
+        cubit.state.profilePicture,
+      ),
+    );
+
+    return Padding(
+      padding: const EdgeInsets.only(left: 18.0),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.center,
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
+          UserAvatar(
+            size: 32,
+            username: userName,
+            image: profilePicture,
+            onPressed: () {
+              context.read<NavigationCubit>().openUserSettings();
+            },
+          )
+        ],
+      ),
+    );
+  }
+}
+
+class _UsernameSpace extends StatelessWidget {
+  const _UsernameSpace();
+
+  @override
+  Widget build(BuildContext context) {
+    final (userName, displayName) = context.select(
+      (UserCubit cubit) => (
+        cubit.state.userName,
+        cubit.state.displayName,
+      ),
+    );
+
+    return Column(
+      children: [
+        Text(
+          displayName ?? "",
+          style: const TextStyle(
+            color: colorDMB,
+            fontVariations: variationBold,
+            fontSize: 13,
+            letterSpacing: -0.2,
+          ),
+        ),
+        const SizedBox(height: 5),
+        Text(
+          userName,
+          style: const TextStyle(
+            color: colorDMB,
+            fontSize: 10,
+            fontVariations: variationMedium,
+            letterSpacing: -0.2,
+          ),
+          overflow: TextOverflow.ellipsis,
+        ),
+      ],
+    );
+  }
+}
+
+class _SettingsButton extends StatelessWidget {
+  const _SettingsButton();
+
+  @override
+  Widget build(BuildContext context) {
+    return IconButton(
+      onPressed: () {
+        context.read<NavigationCubit>().openDeveloperSettings();
+      },
+      hoverColor: Colors.transparent,
+      focusColor: Colors.transparent,
+      splashColor: Colors.transparent,
+      highlightColor: Colors.transparent,
+      icon: const Icon(
+        Icons.settings,
+        size: 20,
+        color: colorDMB,
+      ),
     );
   }
 }

--- a/app/lib/conversation_pane/conversation_details/group_details.dart
+++ b/app/lib/conversation_pane/conversation_details/group_details.dart
@@ -44,6 +44,8 @@ class _GroupDetailsState extends State<GroupDetails> {
 
   @override
   Widget build(BuildContext context) {
+    final coreClient = context.coreClient;
+
     return Center(
       child: Column(
         mainAxisAlignment: MainAxisAlignment.start,
@@ -107,7 +109,7 @@ class _GroupDetailsState extends State<GroupDetails> {
                           return ListTile(
                             leading: FutureUserAvatar(
                               size: 24,
-                              profile: context.coreClient.user
+                              profile: coreClient.user
                                   .userProfile(userName: members[index]),
                             ),
                             title: Text(

--- a/app/lib/conversation_pane/conversation_details/member_details.dart
+++ b/app/lib/conversation_pane/conversation_details/member_details.dart
@@ -7,6 +7,7 @@ import 'package:prototype/core_client.dart';
 import 'package:prototype/elements.dart';
 import 'package:prototype/navigation/navigation.dart';
 import 'package:prototype/styles.dart';
+import 'package:prototype/user_cubit.dart';
 import 'package:provider/provider.dart';
 
 // Constant for padding between the elements
@@ -28,7 +29,8 @@ class MemberDetails extends StatelessWidget {
                 (conversationId, memberId),
             });
 
-    final ownUsername = context.coreClient.username;
+    final ownUsername =
+        context.select((UserCubit cubit) => cubit.state.userName);
     final isSelf = memberUsername == ownUsername;
 
     if (conversationId == null || memberUsername == null) {

--- a/app/lib/intro_screen.dart
+++ b/app/lib/intro_screen.dart
@@ -4,7 +4,7 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:prototype/observable_user.dart';
+import 'package:prototype/loadable_user_cubit.dart';
 import 'package:prototype/styles.dart';
 
 import 'navigation/navigation.dart';
@@ -15,7 +15,7 @@ class IntroScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final isUserLoading =
-        context.select((ObservableUser user) => user is LoadingUserState);
+        context.select((LoadableUserCubit cubit) => cubit.state is LoadingUser);
 
     return Scaffold(
       body: Center(

--- a/app/lib/loadable_user_cubit.dart
+++ b/app/lib/loadable_user_cubit.dart
@@ -4,45 +4,49 @@
 
 import 'dart:async';
 
+import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:prototype/core/api/user.dart';
 
-part 'observable_user.freezed.dart';
+part 'loadable_user_cubit.freezed.dart';
 
 /// Ternary user state: loading, loaded some or loaded none
 @freezed
-sealed class UserState with _$UserState {
-  const UserState._();
+sealed class LoadableUser with _$LoadableUser {
+  const LoadableUser._();
 
   /// Initial state before or in process of loading the user
-  const factory UserState.loading() = LoadingUserState;
+  const factory LoadableUser.loading() = LoadingUser;
 
   /// The user has been loaded
   ///
   /// If loading was successful, the [user] will be non-null.
-  const factory UserState.loaded(User? user) = LoadedUserState;
+  const factory LoadableUser.loaded(User? user) = LoadedUser;
 
   User? get user => switch (this) {
-        LoadingUserState() => null,
-        LoadedUserState(:final user) => user,
+        LoadingUser() => null,
+        LoadedUser(:final user) => user,
       };
 }
 
-/// Observe the [User] state as [UserState] initialized from a [User] stream
+/// Observe the [User] state as [LoadableUser] initialized from a [User] stream
 ///
 /// Can be plugged into a [BlocProvider].
-class ObservableUser implements StateStreamableSource<UserState> {
-  ObservableUser(Stream<User?> stream) {
+class LoadableUserCubit implements StateStreamableSource<LoadableUser> {
+  LoadableUserCubit(Stream<User?> stream) {
     // forward the stream to an internal broadcast stream
+    debugPrint("LoadableUserCubit: initializing");
     _subscription = stream.listen((user) {
-      _state = UserState.loaded(user);
+      debugPrint("LodableUserCubit: user loaded: $user");
+      _state = LoadableUser.loaded(user);
       _controller.add(_state);
     });
   }
 
-  UserState _state = const UserState.loading();
-  final StreamController<UserState> _controller = StreamController.broadcast();
+  LoadableUser _state = const LoadableUser.loading();
+  final StreamController<LoadableUser> _controller =
+      StreamController.broadcast();
   late final StreamSubscription<User?> _subscription;
 
   @override
@@ -55,8 +59,8 @@ class ObservableUser implements StateStreamableSource<UserState> {
   bool get isClosed => _controller.isClosed;
 
   @override
-  UserState get state => _state;
+  LoadableUser get state => _state;
 
   @override
-  Stream<UserState> get stream => _controller.stream;
+  Stream<LoadableUser> get stream => _controller.stream;
 }

--- a/app/lib/registration/registration_cubit.dart
+++ b/app/lib/registration/registration_cubit.dart
@@ -90,7 +90,13 @@ class RegistrationCubit extends Cubit<RegistrationState> {
 
     try {
       _log.info("Registering user ${state.username} ...");
-      await _coreClient.createUser(fqun, state.password, url);
+      await _coreClient.createUser(
+        fqun,
+        state.password,
+        url,
+        state.displayName,
+        state.avatar,
+      );
     } catch (e) {
       final message = "Error when registering user: ${e.toString()}";
       _log.severe(message);
@@ -98,15 +104,7 @@ class RegistrationCubit extends Cubit<RegistrationState> {
       return SignUpError(message);
     }
 
-    // Set the user's display name and profile picture
-    try {
-      await _coreClient.setOwnProfile(state.displayName ?? "", state.avatar);
-    } catch (e) {
-      final message = "Error when setting profile: $e";
-      _log.severe(message);
-      emit(state.copyWith(isSigningUp: false));
-      return SignUpError(message);
-    }
+    emit(state.copyWith(isSigningUp: false));
 
     return null;
   }

--- a/app/lib/user_cubit.dart
+++ b/app/lib/user_cubit.dart
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: 2024 Phoenix R&D GmbH <hello@phnx.im>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:prototype/core/api/user/user_cubit.dart';
+import 'package:prototype/core_client.dart';
+
+class UserCubit implements StateStreamableSource<UiUser> {
+  UserCubit({required CoreClient coreClient})
+      : _impl = UserCubitBase(user: coreClient.user);
+
+  final UserCubitBase _impl;
+
+  @override
+  FutureOr<void> close() {
+    _impl.close();
+  }
+
+  @override
+  bool get isClosed => _impl.isClosed;
+
+  @override
+  UiUser get state => _impl.state;
+
+  @override
+  Stream<UiUser> get stream => _impl.stream();
+
+  // Cubit methods
+
+  Future<void> setProfile({String? displayName, Uint8List? profilePicture}) =>
+      _impl.setProfile(
+        displayName: displayName,
+        profilePicture: profilePicture,
+      );
+}

--- a/app/lib/user_cubit.dart
+++ b/app/lib/user_cubit.dart
@@ -9,6 +9,9 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:prototype/core/api/user/user_cubit.dart';
 import 'package:prototype/core_client.dart';
 
+/// Wrapper of the [UserCubitBase] that implements a [StateStreamableSource]
+///
+// See <https://github.com/phnx-im/infra/issues/248>
 class UserCubit implements StateStreamableSource<UiUser> {
   UserCubit({required CoreClient coreClient})
       : _impl = UserCubitBase(user: coreClient.user);

--- a/applogic/src/api/types.rs
+++ b/applogic/src/api/types.rs
@@ -5,12 +5,11 @@
 use chrono::{DateTime, Utc};
 use openmls::group::GroupId;
 use phnxcoreclient::{
-    Asset, Contact, ContentMessage, Conversation, ConversationAttributes, ConversationId,
-    ConversationMessage, ConversationMessageId, ConversationStatus, ConversationType, DisplayName,
-    ErrorMessage, EventMessage, InactiveConversation, Message, MessageId, MimiContent,
-    NotificationType, SystemMessage, UserProfile,
+    Contact, ContentMessage, Conversation, ConversationAttributes, ConversationId,
+    ConversationMessage, ConversationMessageId, ConversationStatus, ConversationType, ErrorMessage,
+    EventMessage, InactiveConversation, Message, MessageId, MimiContent, NotificationType,
+    SystemMessage, UserProfile,
 };
-use phnxtypes::identifiers::SafeTryInto;
 use uuid::Uuid;
 
 #[derive(Eq, PartialEq, Debug, Clone, Hash)]
@@ -381,30 +380,15 @@ pub struct UiUserProfile {
     pub profile_picture_option: Option<Vec<u8>>,
 }
 
-impl From<UserProfile> for UiUserProfile {
-    fn from(user_profile: UserProfile) -> Self {
+impl UiUserProfile {
+    pub(crate) fn from_profile(user_profile: &UserProfile) -> Self {
         Self {
             user_name: user_profile.user_name().to_string(),
-            display_name: user_profile.display_name().map(|a| a.to_string()),
+            display_name: user_profile.display_name().map(|name| name.to_string()),
             profile_picture_option: user_profile
                 .profile_picture()
-                .and_then(|a| a.value())
-                .map(|a| a.to_vec()),
+                .and_then(|asset| asset.value())
+                .map(|bytes| bytes.to_vec()),
         }
-    }
-}
-
-impl TryFrom<UiUserProfile> for UserProfile {
-    type Error = anyhow::Error;
-
-    fn try_from(value: UiUserProfile) -> Result<Self, Self::Error> {
-        let user_name = <String as SafeTryInto<_>>::try_into(value.user_name)?;
-        let display_name = value.display_name.map(DisplayName::try_from).transpose()?;
-        let profile_picture_option = value.profile_picture_option.map(Asset::Value);
-        Ok(UserProfile::new(
-            user_name,
-            display_name,
-            profile_picture_option,
-        ))
     }
 }

--- a/applogic/src/api/user/connections.rs
+++ b/applogic/src/api/user/connections.rs
@@ -41,7 +41,7 @@ impl User {
             .user
             .user_profile(&user_name)
             .await?
-            .map(UiUserProfile::from);
+            .map(|profile| UiUserProfile::from_profile(&profile));
         Ok(user_profile)
     }
 }

--- a/applogic/src/api/user/user_cubit.rs
+++ b/applogic/src/api/user/user_cubit.rs
@@ -1,0 +1,174 @@
+// SPDX-FileCopyrightText: 2024 Phoenix R&D GmbH <hello@phnx.im>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+use std::sync::Arc;
+
+use anyhow::bail;
+use flutter_rust_bridge::frb;
+use log::info;
+use phnxcoreclient::clients::CoreUser;
+use phnxcoreclient::{Asset, UserProfile};
+use phnxtypes::identifiers::QualifiedUserName;
+use tokio::sync::RwLock;
+
+use crate::util::spawn_from_sync;
+
+use super::{StreamSink, User};
+
+/// Logged in user
+///
+/// Opaque, cheaply clonable, copy-on-write type
+///
+/// Note: This has a prefix `Ui` to avoid conflicts with the `User`.
+//
+// TODO: Currently, frb does not support exposing eq and hash to Dart. When it is possible, we
+// should do it, to minimize the amount of UI rebuilds in Flutter.
+//
+// See:
+// * <https://github.com/phnx-im/infra/issues/247>
+// * <https://github.com/fzyzcjy/flutter_rust_bridge/issues/2238>
+#[frb(opaque)]
+#[derive(Debug, Clone)]
+pub struct UiUser {
+    inner: Arc<UiUserInner>,
+}
+
+#[derive(Debug)]
+struct UiUserInner {
+    user_name: QualifiedUserName,
+    profile: Option<UserProfile>,
+}
+
+impl UiUser {
+    fn new(user_name: QualifiedUserName, profile: Option<UserProfile>) -> Self {
+        let inner = Arc::new(UiUserInner { user_name, profile });
+        Self { inner }
+    }
+
+    /// Loads the user profile in the background
+    fn spawn_load(this: Arc<RwLock<Self>>, core_user: CoreUser) {
+        spawn_from_sync(async move {
+            match core_user.own_user_profile().await {
+                Ok(profile) => {
+                    let mut state = this.write().await;
+                    *state = UiUser::new(state.inner.user_name.clone(), Some(profile));
+                }
+                Err(error) => {
+                    log::error!("Could not load own user profile: {:?}", error);
+                }
+            }
+        });
+    }
+
+    #[frb(getter, sync)]
+    pub fn user_name(&self) -> String {
+        self.inner.user_name.to_string()
+    }
+
+    #[frb(getter, sync)]
+    pub fn display_name(&self) -> Option<String> {
+        let profile = self.inner.profile.as_ref()?;
+        Some(profile.display_name()?.to_string())
+    }
+
+    #[frb(getter, sync)]
+    pub fn profile_picture(&self) -> Option<Vec<u8>> {
+        let profile = self.inner.profile.as_ref()?;
+        Some(profile.profile_picture()?.value()?.to_vec())
+    }
+}
+
+/// Provides access to the logged in user and their profile.
+///
+/// Note: this has a suffix `Base` because the corresponding Dart class does not implement
+/// `StateStreamableSource`, and therefore to impemlement it we need to wrap it Dart.
+#[frb(opaque)]
+pub struct UserCubitBase {
+    state: Arc<RwLock<UiUser>>,
+    sinks: Option<Vec<StreamSink<UiUser>>>,
+    core_user: CoreUser,
+}
+
+impl UserCubitBase {
+    #[frb(sync)]
+    pub fn new(user: &User) -> Self {
+        info!("UserCubitBase::new");
+
+        let core_user = user.user.clone();
+        let state = Arc::new(RwLock::new(UiUser::new(core_user.user_name(), None)));
+
+        UiUser::spawn_load(state.clone(), core_user.clone());
+
+        // TODO: We are missing subscription to changes of the user from the core user. Since,
+        // there is no way to change the user profile from other place than this cubit, it is not a
+        // problem currently. However, in a multi-client scenario, this will become one.
+
+        Self {
+            state,
+            sinks: Some(Default::default()),
+            core_user,
+        }
+    }
+
+    fn emit(&mut self, state: UiUser) {
+        if let Some(sinks) = &mut self.sinks {
+            sinks.retain(|sink| sink.add(state.clone()).is_ok());
+        }
+    }
+
+    // Cubit inteface
+
+    pub fn close(&mut self) {
+        self.sinks = None;
+    }
+
+    #[frb(getter, sync)]
+    pub fn is_closed(&self) -> bool {
+        self.sinks.is_none()
+    }
+
+    #[frb(getter, sync)]
+    pub fn state(&self) -> UiUser {
+        self.state.blocking_read().clone()
+    }
+
+    pub fn stream(&mut self, sink: StreamSink<UiUser>) {
+        if let Some(sinks) = &mut self.sinks {
+            sinks.push(sink);
+        }
+    }
+
+    // Cubit methods
+
+    /// Set the display name and/or profile picture of the user.
+    pub async fn set_profile(
+        &mut self,
+        display_name: Option<String>,
+        profile_picture: Option<Vec<u8>>,
+    ) -> anyhow::Result<()> {
+        let display_name = display_name.map(TryFrom::try_from).transpose()?;
+        let profile_picture = profile_picture.map(Asset::Value);
+        let user = {
+            let mut state = self.state.write().await;
+            let Some(user_profile) = &state.inner.profile else {
+                bail!("Can't set display name for user without a profile");
+            };
+            let mut user_profile = user_profile.clone();
+            if let Some(value) = display_name {
+                user_profile.set_display_name(Some(value));
+            }
+            if let Some(value) = profile_picture {
+                user_profile.set_profile_picture(Some(value));
+            }
+            self.core_user
+                .set_own_user_profile(user_profile.clone())
+                .await?;
+            let user = UiUser::new(state.inner.user_name.clone(), Some(user_profile.clone()));
+            *state = user.clone();
+            user
+        };
+        self.emit(user);
+        Ok(())
+    }
+}

--- a/applogic/src/api/user/user_cubit.rs
+++ b/applogic/src/api/user/user_cubit.rs
@@ -100,9 +100,8 @@ impl UserCubitBase {
 
         UiUser::spawn_load(state.clone(), core_user.clone());
 
-        // TODO: We are missing subscription to changes of the user from the core user. Since,
-        // there is no way to change the user profile from other place than this cubit, it is not a
-        // problem currently. However, in a multi-client scenario, this will become one.
+        // TODO: Subscribe to the change notifications from the core user.
+        // See <https://github.com/phnx-im/infra/issues/254>
 
         Self {
             state,

--- a/applogic/src/lib.rs
+++ b/applogic/src/lib.rs
@@ -12,3 +12,4 @@ pub mod background_execution;
 pub(crate) mod app_state;
 pub(crate) mod frb_generated;
 pub(crate) mod notifier;
+pub(crate) mod util;

--- a/applogic/src/util.rs
+++ b/applogic/src/util.rs
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: 2024 Phoenix R&D GmbH <hello@phnx.im>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+use flutter_rust_bridge::{BaseAsyncRuntime, JoinHandle};
+use std::future::Future;
+
+use crate::FLUTTER_RUST_BRIDGE_HANDLER;
+
+/// Spawn a future from a synchronous function.
+///
+/// Note: Spawning a task via [`flutter_rust_bridge::spawn`] is only possible from async functions.
+#[track_caller]
+pub(crate) fn spawn_from_sync<F>(future: F) -> JoinHandle<F::Output>
+where
+    F: Future + Send + 'static,
+    F::Output: Send + 'static,
+{
+    FLUTTER_RUST_BRIDGE_HANDLER.async_runtime().spawn(future)
+}

--- a/justfile
+++ b/justfile
@@ -30,11 +30,9 @@ generate-dart-files:
 frb-generate:
     rm -f {{app_rust_base_dir}}/src/frb_*.rs
     touch {{app_rust_base_dir}}/src/frb_generated.rs
+    rm -Rf {{app_dir}}/lib/core
     mkdir -p {{app_dir}}/lib/core
-    rm -Rf {{app_dir}}/lib/core/*
-    cd {{app_dir}} && flutter pub get
     cd {{app_dir}} && flutter_rust_bridge_codegen generate
-    cd {{app_dir}} && flutter clean
 
 # integrate the Flutter Rust bridge
 frb-integrate:


### PR DESCRIPTION
The `UserCubit` is accessible in the whole app, after a user is loaded. All widgets that access the user information e.g. their user name or profile, are doing it via the `UserCubit`. In particular, it makes them stateless and they automatically re-rendered when the user information is changed.

Implementation details:

The cubit is implemented on the Rust side, and
is exposed to Flutter via frb. On the Flutter side, the `UserCubit` is a wrapper around the `UserCubit` in Rust. Currently, it is not possible to require that a from-Rust generated class in Dart impements a specific interface. When this will be possible, the wrapper can be removed. ([1])

Also:
* rename `ObservableUser` to `LoadableUserCubit`
* CI: don't flutter clean and pub get in `just frb-generate`

[1]: https://github.com/phnx-im/infra/issues/248