### PR TITLE
chore: don't invalidate cargo cache on frb codegen

### DIFF
--- a/justfile
+++ b/justfile
@@ -27,14 +27,12 @@ generate-dart-files:
     cd {{app_dir}} && dart run build_runner build --delete-conflicting-outputs
 
 # generate Rust and Dart flutter bridge files
-frb-generate:
+frb-generate $CARGO_TARGET_DIR=(justfile_directory() + "/target/frb_codegen"):
     rm -f {{app_rust_base_dir}}/src/frb_*.rs
     touch {{app_rust_base_dir}}/src/frb_generated.rs
-    mkdir -p {{app_dir}}/lib/core
     rm -Rf {{app_dir}}/lib/core/*
-    cd {{app_dir}} && flutter pub get
+    mkdir -p {{app_dir}}/lib/core
     cd {{app_dir}} && flutter_rust_bridge_codegen generate
-    cd {{app_dir}} && flutter clean
 
 # integrate the Flutter Rust bridge
 frb-integrate:

--- a/justfile
+++ b/justfile
@@ -31,7 +31,7 @@ frb-generate $CARGO_TARGET_DIR=(justfile_directory() + "/target/frb_codegen"):
     rm -f {{app_rust_base_dir}}/src/frb_*.rs
     touch {{app_rust_base_dir}}/src/frb_generated.rs
     rm -Rf {{app_dir}}/lib/core/*
-    mkdir -p {{app_dir}}/lib/core
+    mkdir {{app_dir}}/lib/core
     cd {{app_dir}} && flutter_rust_bridge_codegen generate
 
 # integrate the Flutter Rust bridge


### PR DESCRIPTION
`flutter_rust_bridge_codegen` uses the `RUSTLFAGS = ["--cfg", "frb_expand"]` which are different from the default `RUSTFLAGS` of `cargo build|test|clippy`. That's why running the codegen invalidates the cargo cache, and running `cargo build` etc. invalidates the codegen cache.

In this commit, we specify a dedicated cargo target directory for the codegen. Also, we don't delete the flutter cache anymore.