### PR TITLE
fix: Rename field of OAuth response

### DIFF
--- a/server/src/endpoints/qs/push_notification_provider.rs
+++ b/server/src/endpoints/qs/push_notification_provider.rs
@@ -34,8 +34,9 @@ struct FcmClaims {
 #[derive(Debug, Deserialize)]
 struct OauthSuccessResponse {
     access_token: String,
-    _token_type: String,
     expires_in: u64,
+    #[allow(dead_code)]
+    token_type: String,
 }
 
 #[derive(Debug, Deserialize)]


### PR DESCRIPTION
Turns out serde cannot handle field names prefixes with an underscore.