### PR TITLE
feat: add message cubit and make message list view stateless

### DIFF
--- a/app/lib/conversation_pane/conversation_content/conversation_content.dart
+++ b/app/lib/conversation_pane/conversation_content/conversation_content.dart
@@ -184,8 +184,7 @@ class _ConversationContentState extends State<ConversationContent> {
             index = _messages.length - 1 - index;
             final key = GlobalKey();
             _tileKeys[index] = key;
-            final message = _messages[index];
-            return ConversationTile(key: key, message: message);
+            return ConversationTile(key: key);
           },
         ),
       ),

--- a/app/lib/conversation_pane/conversation_content/conversation_tile.dart
+++ b/app/lib/conversation_pane/conversation_content/conversation_tile.dart
@@ -3,28 +3,37 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import 'package:flutter/material.dart';
-import 'package:prototype/conversation_pane/conversation_content/display_message_tile.dart';
-import 'package:prototype/conversation_pane/conversation_content/text_message_tile.dart';
 import 'package:prototype/core/api/types.dart';
+import 'package:provider/provider.dart';
+
+import 'display_message_tile.dart';
+import 'message_cubit.dart';
+import 'text_message_tile.dart';
 
 class ConversationTile extends StatelessWidget {
-  const ConversationTile({
-    required Key key,
-    required this.message,
-  }) : super(key: key);
-
-  final UiConversationMessage message;
+  const ConversationTile({super.key});
 
   @override
   Widget build(BuildContext context) {
+    final (message, timestamp) = context.select(
+      (MessageCubit cubit) => (
+        cubit.state.message?.message,
+        cubit.state.message?.timestamp,
+      ),
+    );
+
+    if (message == null || timestamp == null) {
+      return const SizedBox.shrink();
+    }
+
     return ListTile(
       title: Container(
         alignment: AlignmentDirectional.centerStart,
-        child: switch (message.message) {
+        child: switch (message) {
           UiMessage_ContentFlight(field0: final contentFlight) =>
-            TextMessageTile(contentFlight, message.timestamp),
+            TextMessageTile(contentFlight, timestamp),
           UiMessage_Display(field0: final display) =>
-            DisplayMessageTile(display, message.timestamp),
+            DisplayMessageTile(display, timestamp),
           UiMessage_Unsent(field0: final unsent) => Text(
               "⚠️ UNSENT MESSAGE ⚠️ $unsent",
               style: const TextStyle(color: Colors.red)),

--- a/app/lib/conversation_pane/conversation_content/message_cubit.dart
+++ b/app/lib/conversation_pane/conversation_content/message_cubit.dart
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: 2024 Phoenix R&D GmbH <hello@phnx.im>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import 'dart:async';
+
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:prototype/core/api/message_cubit.dart';
+import 'package:prototype/core/api/types.dart';
+import 'package:prototype/user_cubit.dart';
+
+class MessageCubit extends StateStreamableSource<MessageState> {
+  MessageCubit({
+    required UserCubit userCubit,
+    required UiConversationMessageId messageId,
+  }) : _impl = MessageCubitBase(
+          userCubit: userCubit.impl,
+          messageId: messageId,
+        );
+
+  final MessageCubitBase _impl;
+
+  @override
+  FutureOr<void> close() {
+    _impl.close();
+  }
+
+  @override
+  bool get isClosed => _impl.isClosed;
+
+  @override
+  MessageState get state => _impl.state;
+
+  @override
+  Stream<MessageState> get stream => _impl.stream();
+}

--- a/app/lib/conversation_pane/conversation_content/message_list_view.dart
+++ b/app/lib/conversation_pane/conversation_content/message_list_view.dart
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText: 2024 Phoenix R&D GmbH <hello@phnx.im>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:prototype/conversation_pane/conversation_details/conversation_details_cubit.dart';
+import 'package:prototype/core/api/types.dart';
+
+import 'conversation_tile.dart';
+import 'message_cubit.dart';
+
+final ScrollPhysics _scrollPhysics =
+    (Platform.isAndroid || Platform.isWindows || Platform.isLinux)
+        ? const ClampingScrollPhysics()
+        : const BouncingScrollPhysics()
+            .applyTo(const AlwaysScrollableScrollPhysics());
+
+class MessageListView extends StatelessWidget {
+  const MessageListView({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final messagesCount = context.select(
+      (ConversationDetailsCubit cubit) =>
+          cubit.state.conversation?.messagesCount,
+    );
+
+    if (messagesCount == null) {
+      return const SizedBox.shrink();
+    }
+
+    return Expanded(
+      child: SelectionArea(
+        child: ListView.custom(
+          physics: _scrollPhysics,
+          reverse: true,
+          childrenDelegate: SliverChildBuilderDelegate(
+            (context, index) {
+              final messageId = context
+                  .read<ConversationDetailsCubit>()
+                  .messageIdFromRevOffset(index);
+              return messageId != null
+                  ? BlocProvider(
+                      key: ValueKey(messageId),
+                      create: (context) => MessageCubit(
+                        userCubit: context.read(),
+                        messageId: messageId,
+                      ),
+                      child: const ConversationTile(),
+                    )
+                  : const SizedBox.shrink();
+            },
+            findChildIndexCallback: (key) {
+              final messageKey = key as ValueKey<UiConversationMessageId>;
+              final messageId = messageKey.value;
+              return context
+                  .read<ConversationDetailsCubit>()
+                  .revOffsetFromMessageId(messageId);
+            },
+            childCount: messagesCount,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/app/lib/conversation_pane/conversation_details/conversation_details.dart
+++ b/app/lib/conversation_pane/conversation_details/conversation_details.dart
@@ -27,6 +27,7 @@ class ConversationDetailsContainer extends StatelessWidget {
     }
 
     return BlocProvider(
+      key: ValueKey(conversationId),
       create: (context) => ConversationDetailsCubit(
         userCubit: context.read(),
         conversationId: conversationId,

--- a/app/lib/conversation_pane/conversation_details/conversation_details_cubit.dart
+++ b/app/lib/conversation_pane/conversation_details/conversation_details_cubit.dart
@@ -43,4 +43,10 @@ class ConversationDetailsCubit
 
   Future<UiUserProfile?> loadConversationUserProfile() =>
       _impl.loadConversationUserProfile();
+
+  UiConversationMessageId? messageIdFromRevOffset(int offset) =>
+      _impl.messageIdFromRevOffset(offset: offset);
+
+  int? revOffsetFromMessageId(UiConversationMessageId messageId) =>
+      _impl.revOffsetFromMessageId(messageId: messageId);
 }

--- a/app/lib/conversation_pane/conversation_pane.dart
+++ b/app/lib/conversation_pane/conversation_pane.dart
@@ -2,77 +2,70 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import 'dart:async';
-
 import 'package:flutter/material.dart';
-import 'package:prototype/core/api/types.dart';
-import 'package:prototype/core_client.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:prototype/core_extension.dart';
 import 'package:prototype/elements.dart';
 import 'package:prototype/navigation/navigation.dart';
+import 'package:prototype/styles.dart';
 import 'package:prototype/theme/theme.dart';
-import 'package:provider/provider.dart';
-import 'conversation_content/conversation_content.dart';
+import 'conversation_content/message_list_view.dart';
+import 'conversation_details/conversation_details_cubit.dart';
 import 'message_composer.dart';
 
-class ConversationPane extends StatefulWidget {
-  const ConversationPane({super.key});
-
-  @override
-  State<ConversationPane> createState() => _ConversationPaneState();
-}
-
-class _ConversationPaneState extends State<ConversationPane> {
-  UiConversationDetails? _currentConversation;
-  late final StreamSubscription<UiConversationDetails> _listener;
-
-  @override
-  void initState() {
-    super.initState();
-    final coreClient = context.coreClient;
-    _currentConversation = coreClient.currentConversation;
-    _listener = coreClient.onConversationSwitch.listen((conversation) {
-      setState(() {
-        _currentConversation = conversation;
-      });
-    });
-  }
-
-  @override
-  void dispose() {
-    _listener.cancel();
-    super.dispose();
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return ConversationMessages(currentConversation: _currentConversation);
-  }
-}
-
-class ConversationMessages extends StatelessWidget {
-  const ConversationMessages({
-    super.key,
-    required UiConversationDetails? currentConversation,
-  }) : _currentConversation = currentConversation;
-
-  final UiConversationDetails? _currentConversation;
+class ConversationPaneContainer extends StatelessWidget {
+  const ConversationPaneContainer({super.key});
 
   @override
   Widget build(BuildContext context) {
     final conversationId =
         context.select((NavigationCubit cubit) => cubit.state.conversationId);
-    // only use current conversation if the navigation actually points to it
-    final currentConversation =
-        conversationId != null ? _currentConversation : null;
+
+    if (conversationId == null) {
+      return const _EmptyConversationPane();
+    }
+
+    return BlocProvider(
+      // rebuilds the cubit when the conversation changes
+      key: ValueKey(conversationId),
+      create: (context) => ConversationDetailsCubit(
+        userCubit: context.read(),
+        conversationId: conversationId,
+      ),
+      child: const ConversationPane(),
+    );
+  }
+}
+
+class _EmptyConversationPane extends StatelessWidget {
+  const _EmptyConversationPane();
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(
+        child: Text(
+          style: labelStyle.copyWith(color: colorDMB),
+          "Select a chat to start messaging",
+        ),
+      ),
+    );
+  }
+}
+
+class ConversationPane extends StatelessWidget {
+  const ConversationPane({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final conversationTitle = context.select(
+        (ConversationDetailsCubit cubit) => cubit.state.conversation?.title);
 
     return Scaffold(
       body: Stack(children: <Widget>[
         Column(
           children: [
-            ConversationContent(
-              conversation: _currentConversation,
-            ),
+            const MessageListView(),
             const MessageComposer(),
           ],
         ),
@@ -81,13 +74,13 @@ class ConversationMessages extends StatelessWidget {
           left: 0,
           right: 0,
           child: AppBar(
-            title: Text(_currentConversation?.title ?? ""),
+            title: Text(conversationTitle ?? ""),
             backgroundColor: Colors.white,
             forceMaterialTransparency: true,
             actions: [
               // Conversation details
-              currentConversation != null
-                  ? _detailsButton(context)
+              conversationTitle != null
+                  ? const _DetailsButton()
                   : const SizedBox.shrink(),
             ],
             leading: context.responsiveScreenType == ResponsiveScreenType.mobile
@@ -103,8 +96,13 @@ class ConversationMessages extends StatelessWidget {
       ]),
     );
   }
+}
 
-  IconButton _detailsButton(BuildContext context) {
+class _DetailsButton extends StatelessWidget {
+  const _DetailsButton();
+
+  @override
+  Widget build(BuildContext context) {
     return IconButton(
       icon: const Icon(
         Icons.more_horiz,

--- a/app/lib/homescreen.dart
+++ b/app/lib/homescreen.dart
@@ -20,7 +20,7 @@ class HomeScreen extends StatelessWidget {
           child: ConversationViewContainer(),
         ),
         Expanded(
-          child: ConversationPane(),
+          child: ConversationPaneContainer(),
         ),
       ],
     );

--- a/applogic/src/api/conversation_list_cubit.rs
+++ b/applogic/src/api/conversation_list_cubit.rs
@@ -111,24 +111,24 @@ where
     ) {
         spawn_from_sync(async move {
             self.load_and_emit_state().await;
-            self.fetched_messages_listen_loop(store_notifications, stop)
+            self.store_notifications_loop(store_notifications, stop)
                 .await;
         });
     }
 
     async fn load_and_emit_state(&self) {
         let conversations = self.store.conversation_details().await;
-        debug!("load_and_emit_state {conversations:?}");
+        debug!(?conversations, "load_and_emit_state");
         self.state_tx
             .send_modify(|state| state.conversations = conversations);
     }
 
-    async fn fetched_messages_listen_loop(
+    async fn store_notifications_loop(
         self,
         store_notifications: impl Stream<Item = Arc<StoreNotification>>,
         stop: CancellationToken,
     ) {
-        let mut store_notifications = pin!(store_notifications.fuse());
+        let mut store_notifications = pin!(store_notifications);
         loop {
             let res = tokio::select! {
                 _ = stop.cancelled() => return,

--- a/applogic/src/api/conversations.rs
+++ b/applogic/src/api/conversations.rs
@@ -123,6 +123,10 @@ pub(crate) async fn converation_into_ui_details(
     store: &impl Store,
     conversation: Conversation,
 ) -> UiConversationDetails {
+    let messages_count = store
+        .messages_count(conversation.id())
+        .await
+        .unwrap_or_default();
     let unread_messages = store
         .unread_messages_count(conversation.id())
         .await
@@ -147,6 +151,7 @@ pub(crate) async fn converation_into_ui_details(
         conversation_type: conversation.conversation_type,
         last_used,
         attributes: conversation.attributes,
+        messages_count: TryInto::try_into(messages_count).expect("usize overflow"),
         unread_messages: TryInto::try_into(unread_messages).expect("usize overflow"),
         last_message,
     }

--- a/applogic/src/api/message_cubit.rs
+++ b/applogic/src/api/message_cubit.rs
@@ -1,0 +1,152 @@
+// SPDX-FileCopyrightText: 2024 Phoenix R&D GmbH <hello@phnx.im>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+use std::{pin::pin, sync::Arc};
+
+use flutter_rust_bridge::frb;
+use phnxcoreclient::{
+    store::{Store, StoreNotification, StoreOperation},
+    ConversationMessageId,
+};
+use tokio::sync::watch;
+use tokio_stream::{Stream, StreamExt};
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, error};
+
+use crate::{
+    util::{spawn_from_sync, Cubit, CubitCore},
+    StreamSink,
+};
+
+use super::{
+    types::{UiConversationMessage, UiConversationMessageId},
+    user::user_cubit::UserCubitBase,
+};
+
+#[frb(dart_metadata = ("freezed"))]
+#[derive(Debug, Clone, Default, Eq, PartialEq, Hash)]
+pub struct MessageState {
+    pub message: Option<UiConversationMessage>,
+}
+
+#[frb(opaque)]
+pub struct MessageCubitBase {
+    core: CubitCore<MessageState>,
+}
+
+impl MessageCubitBase {
+    #[frb(sync)]
+    pub fn new(user_cubit: &UserCubitBase, message_id: UiConversationMessageId) -> Self {
+        let message_id = message_id.into();
+
+        let store = user_cubit.core_user.clone();
+        let store_notifications = store.subscribe();
+
+        let core = CubitCore::new();
+
+        MessageContext::new(store.clone(), core.state_tx().clone(), message_id)
+            .spawn(store_notifications, core.cancellation_token().clone());
+
+        Self { core }
+    }
+
+    // Cubit interface
+
+    #[frb(getter, sync)]
+    pub fn is_closed(&self) -> bool {
+        self.core.is_closed()
+    }
+
+    pub fn close(&mut self) {
+        self.core.close();
+    }
+
+    #[frb(getter, sync)]
+    pub fn state(&self) -> MessageState {
+        self.core.state()
+    }
+
+    pub async fn stream(&mut self, sink: StreamSink<MessageState>) {
+        self.core.stream(sink).await;
+    }
+}
+
+/// Loads the intial state and listen to the changes
+#[frb(ignore)]
+#[derive(Clone)]
+struct MessageContext<S> {
+    store: S,
+    state_tx: watch::Sender<MessageState>,
+    message_id: ConversationMessageId,
+}
+
+impl<S: Store + Send + Sync + 'static> MessageContext<S> {
+    fn new(
+        store: S,
+        state_tx: watch::Sender<MessageState>,
+        message_id: ConversationMessageId,
+    ) -> Self {
+        Self {
+            store,
+            state_tx,
+            message_id,
+        }
+    }
+
+    fn spawn(
+        self,
+        store_notifications: impl Stream<Item = Arc<StoreNotification>> + Send + 'static,
+        stop: CancellationToken,
+    ) {
+        spawn_from_sync(async move {
+            self.load_and_emit_state().await;
+            self.store_notifications_loop(store_notifications, stop)
+                .await;
+        });
+    }
+
+    async fn load_and_emit_state(&self) {
+        let conversation_message = self.store.message(self.message_id).await;
+        debug!(?conversation_message, "load_and_emit_state");
+        match conversation_message {
+            Ok(cm) => {
+                self.state_tx
+                    .send_modify(|state| state.message = cm.map(From::from));
+            }
+            Err(error) => {
+                error!(?error, "loading message failed");
+            }
+        }
+    }
+
+    async fn store_notifications_loop(
+        &self,
+        store_notifications: impl Stream<Item = Arc<StoreNotification>>,
+        stop: CancellationToken,
+    ) {
+        let mut store_notifications = pin!(store_notifications);
+        loop {
+            let res = tokio::select! {
+                _ = stop.cancelled() => return,
+                notification = store_notifications.next() => notification,
+            };
+            match res {
+                Some(notification) => {
+                    self.process_store_notification(&notification).await;
+                }
+                None => return,
+            }
+        }
+    }
+
+    async fn process_store_notification(&self, notification: &StoreNotification) {
+        match notification.ops.get(&self.message_id.into()) {
+            Some(StoreOperation::Add | StoreOperation::Update) => self.load_and_emit_state().await,
+            Some(StoreOperation::Remove) => {
+                self.state_tx.send_modify(|state| state.message = None);
+            }
+            None => (),
+        }
+    }
+}

--- a/applogic/src/api/mod.rs
+++ b/applogic/src/api/mod.rs
@@ -11,6 +11,7 @@ pub mod conversation_details_cubit;
 pub mod conversation_list_cubit;
 pub mod conversations;
 pub mod logging;
+pub mod message_cubit;
 pub mod messages;
 pub mod notifications;
 pub mod types;

--- a/applogic/src/api/types.rs
+++ b/applogic/src/api/types.rs
@@ -65,6 +65,7 @@ pub struct UiConversationDetails {
     pub conversation_type: UiConversationType,
     pub last_used: String,
     pub attributes: UiConversationAttributes,
+    pub messages_count: u32,
     pub unread_messages: u32,
     pub last_message: Option<UiConversationMessage>,
 }

--- a/coreclient/src/conversations/persistence.rs
+++ b/coreclient/src/conversations/persistence.rs
@@ -181,6 +181,23 @@ impl Conversation {
         )
     }
 
+    pub(crate) fn messages_count(
+        connection: &Connection,
+        conversation_id: ConversationId,
+    ) -> Result<u32, rusqlite::Error> {
+        connection.query_row(
+            "SELECT
+                COUNT(*)
+            FROM
+                conversation_messages cm
+            WHERE
+                cm.conversation_id = :conversation_id
+                AND cm.sender != 'system';",
+            named_params! {":conversation_id": conversation_id},
+            |row| row.get(0),
+        )
+    }
+
     pub(crate) fn unread_messages_count(
         connection: &Connection,
         conversation_id: ConversationId,

--- a/coreclient/src/store/impl.rs
+++ b/coreclient/src/store/impl.rs
@@ -106,11 +106,33 @@ impl Store for CoreUser {
         Ok(self.message(message_id).await?)
     }
 
+    async fn message_id_from_rev_offset(
+        &self,
+        conversation_id: ConversationId,
+        offset: usize,
+    ) -> Option<ConversationMessageId> {
+        let connection = self.lock_connection().await;
+        ConversationMessage::id_from_rev_offset(&connection, conversation_id, offset).ok()?
+    }
+
+    async fn rev_offset_from_message_id(
+        &self,
+        conversation_id: ConversationId,
+        message_id: ConversationMessageId,
+    ) -> Option<usize> {
+        let connection = self.lock_connection().await;
+        ConversationMessage::rev_offset_from_id(&connection, conversation_id, message_id).ok()?
+    }
+
     async fn last_message(
         &self,
         conversation_id: ConversationId,
     ) -> StoreResult<Option<ConversationMessage>> {
         Ok(self.try_last_message(conversation_id).await?)
+    }
+
+    async fn messages_count(&self, conversation_id: ConversationId) -> StoreResult<usize> {
+        Ok(self.try_messages_count(conversation_id).await?)
     }
 
     async fn unread_messages_count(&self, conversation_id: ConversationId) -> StoreResult<usize> {

--- a/coreclient/src/store/mod.rs
+++ b/coreclient/src/store/mod.rs
@@ -99,10 +99,24 @@ pub trait LocalStore {
         message_id: ConversationMessageId,
     ) -> StoreResult<Option<ConversationMessage>>;
 
+    async fn message_id_from_rev_offset(
+        &self,
+        conversation_id: ConversationId,
+        offset: usize,
+    ) -> Option<ConversationMessageId>;
+
+    async fn rev_offset_from_message_id(
+        &self,
+        conversation_id: ConversationId,
+        message_id: ConversationMessageId,
+    ) -> Option<usize>;
+
     async fn last_message(
         &self,
         conversation_id: ConversationId,
     ) -> StoreResult<Option<ConversationMessage>>;
+
+    async fn messages_count(&self, conversation_id: ConversationId) -> StoreResult<usize>;
 
     async fn unread_messages_count(&self, conversation_id: ConversationId) -> StoreResult<usize>;
 


### PR DESCRIPTION
Also use `ListView.custom` to create the list of messages. This allows us to reuse already constructed message tile widgets after a new message is added to the list. In particular, no tiles are recreated.

Still TODO:

* Port input field to use conversation details cubit
* Port mark as read when scrolling
* Port scrolling to the end when new message arrives