### PR TITLE
fix: local compilation without running postgres DB

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -170,4 +170,4 @@ jobs:
         uses: extractions/setup-just@v2
 
       - name: Run tests
-        run: just test --verbose
+        run: just test-rust --verbose

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -166,5 +166,8 @@ jobs:
       - name: Set up Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Set up Just
+        uses: extractions/setup-just@v2
+
       - name: Run tests
         run: just test --verbose

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: Set up Flutter FVM
         uses: kuhnroyal/flutter-fvm-config-action/setup@v3
         with:
@@ -167,4 +167,4 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Run tests
-        run: cargo test --verbose
+        run: just test --verbose

--- a/.github/workflows/docker_tests.yml
+++ b/.github/workflows/docker_tests.yml
@@ -67,4 +67,4 @@ jobs:
       - name: Integrate bridge
         run: just frb-integrate
       - name: Run docker-based tests
-        run: cargo test --verbose -- --ignored
+        run: just test-rust --verbose -- --ignored

--- a/backend/.env
+++ b/backend/.env
@@ -1,5 +1,0 @@
-# SPDX-FileCopyrightText: 2023 Phoenix R&D GmbH <hello@phnx.im>
-#
-# SPDX-License-Identifier: AGPL-3.0-or-later
-
-DATABASE_URL="postgres://postgres:password@localhost:5432/phnx_db"

--- a/justfile
+++ b/justfile
@@ -72,6 +72,9 @@ setup-ios-ci: setup-ci
 setup-macos-ci: setup-ci
 	bundle install
 
+test-rust *args='':
+    cargo test {{args}}
+
 # build Android
 # we limit it to android-arm64 to speed up the build process
 [working-directory: 'app']
@@ -100,7 +103,7 @@ analyze-dart:
 # run Flutter tests
 [working-directory: 'app']
 test-flutter *args='':
-    flutter test
+    flutter test {{args}}
 
 # run backend server (at localhost)
 run-backend: init-db


### PR DESCRIPTION
The variable DATABASE_URL is predefined in the backend/.env file. This conflicts with the prepared compile-time sqlx metadata, since the environment variable takes precedence over the metadata. In particular, the rust compilation fails when the database server is not running.