### PR TITLE
chore: test persistence layer in client

### DIFF
--- a/applogic/src/api/message_list_cubit.rs
+++ b/applogic/src/api/message_list_cubit.rs
@@ -300,8 +300,8 @@ mod tests {
 
     fn new_test_message(sender: &str, timestamp_secs: i64) -> ConversationMessage {
         ConversationMessage::new_for_test(
-            ConversationId::from(Uuid::from_u128(1)),
-            ConversationMessageId::from_uuid(Uuid::from_u128(1)),
+            ConversationId::new(Uuid::from_u128(1)),
+            ConversationMessageId::new(Uuid::from_u128(1)),
             TimeStamp::from(timestamp_secs * 1_000_000_000),
             Message::with_content(ContentMessage::new(
                 sender.into(),

--- a/coreclient/Cargo.toml
+++ b/coreclient/Cargo.toml
@@ -51,6 +51,7 @@ trait-variant = "0.1.2"
 [dev-dependencies]
 phnxserver_test_harness = { path = "../test_harness" }
 actix-rt = "^2.7"
+phnxtypes = { path = "../types", features = ["sqlite", "test_utils"] }
 
 [build-dependencies]
 

--- a/coreclient/src/clients/conversations.rs
+++ b/coreclient/src/clients/conversations.rs
@@ -71,7 +71,7 @@ impl CoreUser {
         let mut notifier = self.store_notifier();
         let mut conversation =
             Conversation::load(connection, &conversation_id)?.ok_or_else(|| {
-                let id = conversation_id.as_uuid();
+                let id = conversation_id.uuid();
                 anyhow!("Can't find conversation with id {id}")
             })?;
         let resized_picture_option = picture.and_then(|picture| self.resize_image(&picture).ok());
@@ -85,7 +85,7 @@ impl CoreUser {
         message_id: ConversationMessageId,
     ) -> Result<Option<ConversationMessage>, rusqlite::Error> {
         let connection = &self.inner.connection.lock().await;
-        ConversationMessage::load(connection, &message_id.to_uuid())
+        ConversationMessage::load(connection, message_id)
     }
 
     pub(crate) async fn prev_message(

--- a/coreclient/src/clients/message.rs
+++ b/coreclient/src/clients/message.rs
@@ -10,7 +10,9 @@ use phnxtypes::{
 use rusqlite::{Connection, Transaction};
 use uuid::Uuid;
 
-use crate::{Conversation, ConversationId, ConversationMessage, Message, MimiContent};
+use crate::{
+    Conversation, ConversationId, ConversationMessage, ConversationMessageId, Message, MimiContent,
+};
 
 use super::{ApiClients, CoreUser, Group, PhnxOpenMlsProvider, StoreNotifier};
 
@@ -125,8 +127,9 @@ impl LocalMessage {
     ) -> anyhow::Result<UnsentMessage<WithContent, GroupUpdated>> {
         let Self { local_message_id } = self;
 
-        let conversation_message = ConversationMessage::load(connection, &local_message_id)?
-            .with_context(|| format!("Can't find unsent message with id {local_message_id}"))?;
+        let conversation_message =
+            ConversationMessage::load(connection, ConversationMessageId::new(local_message_id))?
+                .with_context(|| format!("Can't find unsent message with id {local_message_id}"))?;
         let content = match conversation_message.message() {
             Message::Content(content_message) if !content_message.was_sent() => {
                 content_message.content().clone()

--- a/coreclient/src/clients/mod.rs
+++ b/coreclient/src/clients/mod.rs
@@ -376,7 +376,7 @@ impl CoreUser {
         let connection = self.inner.connection.lock().await;
         let conversation = Conversation::load(&connection, &conversation_id)?.ok_or(anyhow!(
             "Can't find conversation with id {}",
-            conversation_id.as_uuid()
+            conversation_id.uuid()
         ))?;
         let group_id = conversation.group_id().clone();
         let owner_domain = conversation.owner_domain();
@@ -475,7 +475,7 @@ impl CoreUser {
         let connection = self.inner.connection.lock().await;
         let conversation = Conversation::load(&connection, &conversation_id)?.ok_or(anyhow!(
             "Can't find conversation with id {}",
-            conversation_id.as_uuid()
+            conversation_id.uuid()
         ))?;
         let group_id = conversation.group_id();
         let mut group = Group::load(&connection, group_id)?
@@ -684,11 +684,9 @@ impl CoreUser {
     ) -> Result<Vec<ConversationMessage>> {
         // Phase 1: Load the conversation and the group
         let connection = self.inner.connection.lock().await;
-        let mut conversation =
-            Conversation::load(&connection, &conversation_id)?.ok_or(anyhow!(
-                "Can't find conversation with id {}",
-                conversation_id.as_uuid()
-            ))?;
+        let mut conversation = Conversation::load(&connection, &conversation_id)?.ok_or(
+            anyhow!("Can't find conversation with id {}", conversation_id.uuid()),
+        )?;
         let group_id = conversation.group_id();
         // Generate ciphertext
         let mut group = Group::load(&connection, group_id)?
@@ -799,7 +797,7 @@ impl CoreUser {
         let connection = self.inner.connection.lock().await;
         let conversation = Conversation::load(&connection, &conversation_id)?.ok_or(anyhow!(
             "Can't find conversation with id {}",
-            conversation_id.as_uuid()
+            conversation_id.uuid()
         ))?;
         let group_id = conversation.group_id();
         let mut group = Group::load(&connection, group_id)?
@@ -840,7 +838,7 @@ impl CoreUser {
         let connection = self.inner.connection.lock().await;
         let conversation = Conversation::load(&connection, &conversation_id)?.ok_or(anyhow!(
             "Can't find conversation with id {}",
-            conversation_id.as_uuid()
+            conversation_id.uuid()
         ))?;
         let group_id = conversation.group_id();
         let mut group = Group::load(&connection, group_id)?

--- a/coreclient/src/clients/own_client_info/mod.rs
+++ b/coreclient/src/clients/own_client_info/mod.rs
@@ -8,6 +8,7 @@ mod persistence;
 
 /// The purpose of this struct is to be stored in the local DB for use as
 /// reference for other tables.
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct OwnClientInfo {
     pub(crate) server_url: String,
     pub(crate) qs_user_id: QsUserId,

--- a/coreclient/src/clients/own_client_info/persistence.rs
+++ b/coreclient/src/clients/own_client_info/persistence.rs
@@ -38,7 +38,13 @@ impl Storable for OwnClientInfo {
 impl OwnClientInfo {
     pub(crate) fn store(&self, connection: &Connection) -> rusqlite::Result<()> {
         connection.execute(
-            "INSERT INTO own_client_info (server_url, qs_user_id, qs_client_id, as_user_name, as_client_uuid) VALUES (?, ?, ?, ?, ?)",
+            "INSERT INTO own_client_info (
+                server_url,
+                qs_user_id,
+                qs_client_id,
+                as_user_name,
+                as_client_uuid
+            ) VALUES (?, ?, ?, ?, ?)",
             params![
                 self.server_url,
                 self.qs_user_id,
@@ -47,6 +53,43 @@ impl OwnClientInfo {
                 self.as_client_id.client_id(),
             ],
         )?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use phnxtypes::identifiers::{QsClientId, QsUserId};
+    use uuid::Uuid;
+
+    use super::*;
+
+    fn test_connection() -> rusqlite::Connection {
+        let connection = rusqlite::Connection::open_in_memory().unwrap();
+        connection
+            .execute_batch(OwnClientInfo::CREATE_TABLE_STATEMENT)
+            .unwrap();
+        connection
+    }
+
+    #[test]
+    fn store() -> anyhow::Result<()> {
+        let connection = test_connection();
+
+        let own_client_info = OwnClientInfo {
+            server_url: "https://localhost".to_string(),
+            qs_user_id: QsUserId::random(),
+            qs_client_id: QsClientId::random(&mut rand::thread_rng()),
+            as_client_id: AsClientId::new("alice@localhost".parse()?, Uuid::new_v4()),
+        };
+
+        own_client_info.store(&connection)?;
+
+        let loaded = connection
+            .prepare("SELECT * FROM own_client_info")?
+            .query_row([], OwnClientInfo::from_row)?;
+        assert_eq!(loaded, own_client_info);
+
         Ok(())
     }
 }

--- a/coreclient/src/clients/process/process_qs.rs
+++ b/coreclient/src/clients/process/process_qs.rs
@@ -331,15 +331,13 @@ impl CoreUser {
                 &mut notifier,
                 conversation_picture_option,
             )?;
-            let mut transaction = connection.transaction()?;
             // Now we can turn the partial contact into a full one.
             partial_contact.mark_as_complete(
-                &mut transaction,
+                &mut connection,
                 &mut notifier,
                 friendship_package,
                 sender_client_id.clone(),
             )?;
-            transaction.commit()?;
 
             conversation.confirm(&connection, &mut notifier)?;
             conversation_changed = true;

--- a/coreclient/src/clients/process/process_qs.rs
+++ b/coreclient/src/clients/process/process_qs.rs
@@ -267,11 +267,9 @@ impl CoreUser {
 
         // StagedCommitMessage Phase 1: Load the conversation.
         let connection = self.inner.connection.lock().await;
-        let mut conversation =
-            Conversation::load(&connection, &conversation_id)?.ok_or(anyhow!(
-                "Can't find conversation with id {}",
-                conversation_id.as_uuid()
-            ))?;
+        let mut conversation = Conversation::load(&connection, &conversation_id)?.ok_or(
+            anyhow!("Can't find conversation with id {}", conversation_id.uuid()),
+        )?;
         drop(connection);
         let mut conversation_changed = false;
 

--- a/coreclient/src/clients/store.rs
+++ b/coreclient/src/clients/store.rs
@@ -70,13 +70,8 @@ impl UserCreationState {
         };
 
         // Create user profile entry for own user.
-        UserProfile::store_own_user_profile(
-            client_db_connection,
-            &mut StoreNotifier::noop(),
-            as_client_id.user_name(),
-            None,
-            None,
-        )?;
+        UserProfile::new(as_client_id.user_name(), None, None)
+            .upsert(client_db_connection, &mut StoreNotifier::noop())?;
 
         let user_creation_state = UserCreationState::BasicUserData(basic_user_data);
 

--- a/coreclient/src/contacts/mod.rs
+++ b/coreclient/src/contacts/mod.rs
@@ -24,11 +24,10 @@ use crate::{
     ConversationId,
 };
 use anyhow::Result;
-use serde::{Deserialize, Serialize};
 
 pub(crate) mod persistence;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Contact {
     pub user_name: QualifiedUserName,
     pub(crate) clients: Vec<AsClientId>,
@@ -41,7 +40,7 @@ pub struct Contact {
     pub(crate) conversation_id: ConversationId,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone)]
 pub(crate) struct ContactAddInfos {
     pub key_package: KeyPackage,
     pub identity_link_key: IdentityLinkKey,
@@ -130,7 +129,7 @@ impl Contact {
 }
 
 /// Contact which has not yet accepted our connection request.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PartialContact {
     pub user_name: QualifiedUserName,
     // ID of the connection conversation with this contact.

--- a/coreclient/src/conversations/messages/mod.rs
+++ b/coreclient/src/conversations/messages/mod.rs
@@ -70,17 +70,17 @@ pub struct ConversationMessageId {
 }
 
 impl ConversationMessageId {
-    pub(crate) fn new() -> Self {
+    pub(crate) fn random() -> Self {
         Self {
             uuid: Uuid::new_v4(),
         }
     }
 
-    pub fn from_uuid(uuid: Uuid) -> Self {
+    pub fn new(uuid: Uuid) -> Self {
         Self { uuid }
     }
 
-    pub fn to_uuid(&self) -> Uuid {
+    pub fn uuid(&self) -> Uuid {
         self.uuid
     }
 }
@@ -114,7 +114,7 @@ impl ConversationMessage {
     ) -> Self {
         Self {
             conversation_id,
-            conversation_message_id: ConversationMessageId::new(),
+            conversation_message_id: ConversationMessageId::random(),
             timestamped_message,
         }
     }
@@ -144,7 +144,7 @@ impl ConversationMessage {
         };
         ConversationMessage {
             conversation_id,
-            conversation_message_id: ConversationMessageId::new(),
+            conversation_message_id: ConversationMessageId::random(),
             timestamped_message,
         }
     }
@@ -156,8 +156,9 @@ impl ConversationMessage {
         notifier: &mut StoreNotifier,
         ds_timestamp: TimeStamp,
     ) -> Result<(), rusqlite::Error> {
+        Self::update_sent_status(connection, notifier, self.id(), ds_timestamp, true)?;
         self.timestamped_message.mark_as_sent(ds_timestamp);
-        self.update_sent_status(connection, notifier, ds_timestamp, true)
+        Ok(())
     }
 
     pub fn id_ref(&self) -> &ConversationMessageId {
@@ -172,7 +173,7 @@ impl ConversationMessage {
         *self.timestamped_message.timestamp()
     }
 
-    pub fn was_sent(&self) -> bool {
+    pub fn is_sent(&self) -> bool {
         if let Message::Content(content) = &self.timestamped_message.message {
             content.was_sent()
         } else {

--- a/coreclient/src/conversations/messages/persistence.rs
+++ b/coreclient/src/conversations/messages/persistence.rs
@@ -10,7 +10,6 @@ use rusqlite::{
 };
 use serde::{Deserialize, Serialize};
 use tracing::error;
-use uuid::Uuid;
 
 use crate::{
     store::StoreNotifier, utils::persistence::Storable, ContentMessage, ConversationId,
@@ -147,7 +146,7 @@ impl Storable for ConversationMessage {
 impl ConversationMessage {
     pub(crate) fn load(
         connection: &Connection,
-        local_message_id: &Uuid,
+        local_message_id: ConversationMessageId,
     ) -> Result<Option<Self>, rusqlite::Error> {
         let mut statement = connection.prepare(
             "SELECT
@@ -224,17 +223,17 @@ impl ConversationMessage {
 
     /// Set the message's sent status in the database and update the message's timestamp.
     pub(super) fn update_sent_status(
-        &self,
         connection: &Connection,
         notifier: &mut StoreNotifier,
+        message_id: ConversationMessageId,
         timestamp: TimeStamp,
         sent: bool,
     ) -> Result<(), rusqlite::Error> {
         connection.execute(
             "UPDATE conversation_messages SET timestamp = ?, sent = ? WHERE message_id = ?",
-            params![timestamp, sent, self.conversation_message_id],
+            params![timestamp, sent, message_id],
         )?;
-        notifier.update(self.conversation_message_id);
+        notifier.update(message_id);
         Ok(())
     }
 
@@ -280,7 +279,7 @@ impl ConversationMessage {
                 ORDER BY timestamp DESC
                 LIMIT 1",
                 named_params! {
-                    ":message_id": message_id.to_uuid(),
+                    ":message_id": message_id.uuid(),
                 },
                 Self::from_row,
             )
@@ -306,10 +305,200 @@ impl ConversationMessage {
                 ORDER BY timestamp ASC
                 LIMIT 1",
                 named_params! {
-                    ":message_id": message_id.to_uuid(),
+                    ":message_id": message_id.uuid(),
                 },
                 Self::from_row,
             )
             .optional()
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use chrono::Utc;
+
+    use crate::{
+        conversations::persistence::tests::test_conversation, Conversation, EventMessage,
+        MimiContent, SystemMessage,
+    };
+
+    use super::*;
+
+    pub(crate) fn test_connection() -> rusqlite::Connection {
+        let connection = rusqlite::Connection::open_in_memory().unwrap();
+        connection
+            .execute_batch(
+                &[
+                    Conversation::CREATE_TABLE_STATEMENT,
+                    ConversationMessage::CREATE_TABLE_STATEMENT,
+                ]
+                .join("\n"),
+            )
+            .unwrap();
+        connection
+    }
+
+    pub(crate) fn test_conversation_message(
+        conversation_id: ConversationId,
+    ) -> ConversationMessage {
+        let conversation_message_id = ConversationMessageId::random();
+        let timestamp = Utc::now().into();
+        let message = Message::Content(Box::new(ContentMessage {
+            sender: "alice@localhost".to_string(),
+            sent: false,
+            content: MimiContent::simple_markdown_message(
+                "localhost".parse().unwrap(),
+                "Hello world!".to_string(),
+            ),
+        }));
+        let timestamped_message = TimestampedMessage { timestamp, message };
+        ConversationMessage {
+            conversation_message_id,
+            conversation_id,
+            timestamped_message,
+        }
+    }
+
+    #[test]
+    fn store_load() -> anyhow::Result<()> {
+        let connection = test_connection();
+        let mut store_notifier = StoreNotifier::noop();
+
+        let conversation = test_conversation();
+        conversation.store(&connection, &mut store_notifier)?;
+
+        let message = test_conversation_message(conversation.id());
+
+        message.store(&connection, &mut store_notifier)?;
+        let loaded = ConversationMessage::load(&connection, message.id())?.unwrap();
+        assert_eq!(loaded, message);
+
+        Ok(())
+    }
+
+    #[test]
+    fn store_load_multiple() -> anyhow::Result<()> {
+        let connection = test_connection();
+        let mut store_notifier = StoreNotifier::noop();
+
+        let conversation = test_conversation();
+        conversation.store(&connection, &mut store_notifier)?;
+
+        let message_a = test_conversation_message(conversation.id());
+        let message_b = test_conversation_message(conversation.id());
+
+        message_a.store(&connection, &mut store_notifier)?;
+        message_b.store(&connection, &mut store_notifier)?;
+
+        let loaded = ConversationMessage::load_multiple(&connection, conversation.id(), 2)?;
+        assert_eq!(loaded, [message_a, message_b.clone()]);
+
+        let loaded = ConversationMessage::load_multiple(&connection, conversation.id(), 1)?;
+        assert_eq!(loaded, [message_b]);
+
+        Ok(())
+    }
+
+    #[test]
+    fn update_sent_status() -> anyhow::Result<()> {
+        let connection = test_connection();
+        let mut store_notifier = StoreNotifier::noop();
+
+        let conversation = test_conversation();
+        conversation.store(&connection, &mut store_notifier)?;
+
+        let message = test_conversation_message(conversation.id());
+        message.store(&connection, &mut store_notifier)?;
+
+        let loaded = ConversationMessage::load(&connection, message.id())?.unwrap();
+        assert!(!loaded.is_sent());
+
+        let sent_at: TimeStamp = Utc::now().into();
+        ConversationMessage::update_sent_status(
+            &connection,
+            &mut store_notifier,
+            loaded.id(),
+            sent_at,
+            true,
+        )?;
+
+        let loaded = ConversationMessage::load(&connection, message.id())?.unwrap();
+        assert_eq!(&loaded.timestamp(), sent_at.as_ref());
+        assert!(loaded.is_sent());
+
+        Ok(())
+    }
+
+    #[test]
+    fn last_content_message() -> anyhow::Result<()> {
+        let connection = test_connection();
+        let mut store_notifier = StoreNotifier::noop();
+
+        let conversation = test_conversation();
+        conversation.store(&connection, &mut store_notifier)?;
+
+        let message_a = test_conversation_message(conversation.id());
+        let message_b = test_conversation_message(conversation.id());
+
+        message_a.store(&connection, &mut store_notifier)?;
+        message_b.store(&connection, &mut store_notifier)?;
+
+        ConversationMessage {
+            conversation_id: conversation.id(),
+            conversation_message_id: ConversationMessageId::random(),
+            timestamped_message: TimestampedMessage {
+                timestamp: Utc::now().into(),
+                message: Message::Event(EventMessage::System(SystemMessage::Add(
+                    "alice@localhost".parse()?,
+                    "bob@localhost".parse()?,
+                ))),
+            },
+        }
+        .store(&connection, &mut store_notifier)?;
+
+        let loaded = ConversationMessage::last_content_message(&connection, conversation.id())?;
+        assert_eq!(loaded, Some(message_b));
+
+        Ok(())
+    }
+
+    #[test]
+    fn prev_message() -> anyhow::Result<()> {
+        let connection = test_connection();
+        let mut store_notifier = StoreNotifier::noop();
+
+        let conversation = test_conversation();
+        conversation.store(&connection, &mut store_notifier)?;
+
+        let message_a = test_conversation_message(conversation.id());
+        let message_b = test_conversation_message(conversation.id());
+
+        message_a.store(&connection, &mut store_notifier)?;
+        message_b.store(&connection, &mut store_notifier)?;
+
+        let loaded = ConversationMessage::prev_message(&connection, message_b.id())?;
+        assert_eq!(loaded, Some(message_a));
+
+        Ok(())
+    }
+
+    #[test]
+    fn next_message() -> anyhow::Result<()> {
+        let connection = test_connection();
+        let mut store_notifier = StoreNotifier::noop();
+
+        let conversation = test_conversation();
+        conversation.store(&connection, &mut store_notifier)?;
+
+        let message_a = test_conversation_message(conversation.id());
+        let message_b = test_conversation_message(conversation.id());
+
+        message_a.store(&connection, &mut store_notifier)?;
+        message_b.store(&connection, &mut store_notifier)?;
+
+        let loaded = ConversationMessage::next_message(&connection, message_a.id())?;
+        assert_eq!(loaded, Some(message_b));
+
+        Ok(())
     }
 }

--- a/coreclient/src/conversations/mod.rs
+++ b/coreclient/src/conversations/mod.rs
@@ -161,7 +161,12 @@ impl Conversation {
         notifier: &mut StoreNotifier,
         conversation_picture: Option<Vec<u8>>,
     ) -> Result<(), rusqlite::Error> {
-        self.update_conversation_picture(connection, notifier, conversation_picture.as_deref())?;
+        Self::update_picture(
+            connection,
+            notifier,
+            self.id,
+            conversation_picture.as_deref(),
+        )?;
         self.attributes.set_picture(conversation_picture);
         Ok(())
     }
@@ -173,7 +178,7 @@ impl Conversation {
         past_members: Vec<QualifiedUserName>,
     ) -> Result<(), rusqlite::Error> {
         let new_status = ConversationStatus::Inactive(InactiveConversation { past_members });
-        self.update_status(connection, notifier, &new_status)?;
+        Self::update_status(connection, notifier, self.id, &new_status)?;
         self.status = new_status;
         Ok(())
     }

--- a/coreclient/src/conversations/mod.rs
+++ b/coreclient/src/conversations/mod.rs
@@ -50,7 +50,17 @@ impl FromSql for ConversationId {
 }
 
 impl ConversationId {
-    pub fn as_uuid(&self) -> Uuid {
+    pub fn random() -> Self {
+        Self {
+            uuid: Uuid::new_v4(),
+        }
+    }
+
+    pub fn new(uuid: Uuid) -> Self {
+        Self { uuid }
+    }
+
+    pub fn uuid(&self) -> Uuid {
         self.uuid
     }
 }

--- a/coreclient/src/groups/client_auth_info/mod.rs
+++ b/coreclient/src/groups/client_auth_info/mod.rs
@@ -71,7 +71,7 @@ impl StorableClientCredential {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub(crate) struct GroupMembership {
     client_id: AsClientId,
     client_credential_fingerprint: CredentialFingerprint,

--- a/coreclient/src/groups/client_auth_info/persistence.rs
+++ b/coreclient/src/groups/client_auth_info/persistence.rs
@@ -72,7 +72,7 @@ impl StorableClientCredential {
 }
 
 impl Storable for GroupMembership {
-    // TODO: Reinstate the foreign key constraint as soon as we have migrated
+    // TODO(#349): Reinstate the foreign key constraint as soon as we have migrated
     // the mls group table to the new style of storage.
     // FOREIGN KEY (group_id) REFERENCES mlsgroup(primary_key),
     const CREATE_TABLE_STATEMENT: &str = "CREATE TABLE IF NOT EXISTS group_membership (

--- a/coreclient/src/groups/client_auth_info/persistence.rs
+++ b/coreclient/src/groups/client_auth_info/persistence.rs
@@ -71,6 +71,62 @@ impl StorableClientCredential {
     }
 }
 
+impl Storable for GroupMembership {
+    // TODO: Reinstate the foreign key constraint as soon as we have migrated
+    // the mls group table to the new style of storage.
+    // FOREIGN KEY (group_id) REFERENCES mlsgroup(primary_key),
+    const CREATE_TABLE_STATEMENT: &str = "CREATE TABLE IF NOT EXISTS group_membership (
+                client_credential_fingerprint BLOB NOT NULL,
+                group_id BLOB NOT NULL,
+                client_uuid BLOB NOT NULL,
+                user_name TEXT NOT NULL,
+                leaf_index INTEGER NOT NULL,
+                identity_link_key BLOB NOT NULL,
+                status TEXT DEFAULT 'staged_update' NOT NULL CHECK (status IN ('staged_update', 'staged_removal', 'staged_add', 'merged')),
+                FOREIGN KEY (client_credential_fingerprint) REFERENCES client_credentials(fingerprint),
+                PRIMARY KEY (group_id, leaf_index, status)
+            );";
+
+    fn from_row(row: &rusqlite::Row) -> Result<Self, rusqlite::Error> {
+        let client_credential_fingerprint = row.get(0)?;
+        let group_id: GroupIdWrapper = row.get(1)?;
+        let client_uuid = row.get(2)?;
+        let user_name = row.get(3)?;
+        let leaf_index: i64 = row.get(4)?;
+        let identity_link_key: IdentityLinkKeySecret = row.get(5)?;
+        let client_id = AsClientId::new(user_name, client_uuid);
+        Ok(Self {
+            client_id,
+            group_id: group_id.into(),
+            leaf_index: LeafNodeIndex::new(leaf_index as u32),
+            identity_link_key: IdentityLinkKey::from(identity_link_key),
+            client_credential_fingerprint,
+        })
+    }
+}
+
+pub(crate) const GROUP_MEMBERSHIP_TRIGGER: &str =
+    "CREATE TRIGGER IF NOT EXISTS delete_orphaned_data
+        AFTER DELETE ON group_membership
+        FOR EACH ROW
+        BEGIN
+            -- Delete client credentials if they are not our own and not used in any group.
+            DELETE FROM client_credentials
+            WHERE fingerprint = OLD.client_credential_fingerprint AND NOT EXISTS (
+                SELECT 1 FROM group_membership WHERE client_credential_fingerprint = OLD.client_credential_fingerprint
+            ) AND NOT EXISTS (
+                SELECT 1 FROM own_client_info WHERE as_client_uuid = OLD.client_uuid
+            );
+
+            -- Delete user profiles of users that are not in any group and that are not our own.
+            DELETE FROM users
+            WHERE user_name = OLD.user_name AND NOT EXISTS (
+                SELECT 1 FROM group_membership WHERE user_name = OLD.user_name
+            ) AND NOT EXISTS (
+                SELECT 1 FROM own_client_info WHERE as_user_name = OLD.user_name
+            );
+        END;";
+
 impl GroupMembership {
     /// Merge all staged group memberships for the given group id.
     pub(in crate::groups) fn merge_for_group(
@@ -119,7 +175,14 @@ impl GroupMembership {
 
     pub(crate) fn store(&self, connection: &Connection) -> Result<(), rusqlite::Error> {
         connection.execute(
-            "INSERT OR IGNORE INTO group_membership (client_uuid, user_name, group_id, leaf_index, identity_link_key, client_credential_fingerprint, status) VALUES (?, ?, ?, ?, ?, ?, 'merged')",
+            "INSERT OR IGNORE INTO group_membership (client_uuid,
+                user_name,
+                group_id,
+                leaf_index,
+                identity_link_key,
+                client_credential_fingerprint,
+                status
+            ) VALUES (?, ?, ?, ?, ?, ?, 'merged')",
             params![
                 self.client_id.client_id(),
                 self.client_id.user_name(),
@@ -134,7 +197,14 @@ impl GroupMembership {
 
     pub(super) fn stage_update(&self, connection: &Connection) -> Result<(), rusqlite::Error> {
         connection.execute(
-            "INSERT INTO group_membership (client_uuid, user_name, group_id, leaf_index, identity_link_key, client_credential_fingerprint, status) VALUES (?, ?, ?, ?, ?, ?, 'staged_update')",
+            "INSERT INTO group_membership (client_uuid,
+                user_name,
+                group_id,
+                leaf_index,
+                identity_link_key,
+                client_credential_fingerprint,
+                status)
+            VALUES (?, ?, ?, ?, ?, ?, 'staged_update')",
             params![
                 self.client_id.client_id(),
                 self.client_id.user_name(),
@@ -149,7 +219,14 @@ impl GroupMembership {
 
     pub(super) fn stage_add(&self, connection: &Connection) -> Result<(), rusqlite::Error> {
         connection.execute(
-            "INSERT INTO group_membership (client_uuid, user_name, group_id, leaf_index, identity_link_key, client_credential_fingerprint, status) VALUES (?, ?, ?, ?, ?, ?, 'staged_add')",
+            "INSERT INTO group_membership (client_uuid,
+                user_name,
+                group_id,
+                leaf_index,
+                identity_link_key,
+                client_credential_fingerprint,
+                status)
+            VALUES (?, ?, ?, ?, ?, ?, 'staged_add')",
             params![
                 self.client_id.client_id(),
                 self.client_id.user_name(),
@@ -202,7 +279,14 @@ impl GroupMembership {
         leaf_index: LeafNodeIndex,
         merged: bool,
     ) -> Result<Option<Self>, rusqlite::Error> {
-        let mut query_string = "SELECT client_credential_fingerprint, group_id, client_uuid, user_name, leaf_index, identity_link_key FROM group_membership WHERE group_id = ? AND leaf_index = ?".to_owned();
+        let mut query_string = "SELECT
+            client_credential_fingerprint,
+            group_id,
+            client_uuid,
+            user_name,
+            leaf_index,
+            identity_link_key FROM group_membership WHERE group_id = ? AND leaf_index = ?"
+            .to_owned();
         if merged {
             query_string += " AND status = 'merged'";
         } else {
@@ -225,7 +309,10 @@ impl GroupMembership {
         group_id: &GroupId,
     ) -> Result<Vec<LeafNodeIndex>, rusqlite::Error> {
         let mut stmt = connection.prepare(
-            "SELECT leaf_index FROM group_membership WHERE group_id = ? AND NOT (status = 'staged_removal' OR status = 'staged_add' OR status = 'staged_update')",
+            "SELECT leaf_index FROM group_membership WHERE group_id = ?
+            AND NOT (status = 'staged_removal'
+                OR status = 'staged_add'
+                OR status = 'staged_update')",
         )?;
         let indices = stmt
             .query_map(params![group_id.as_slice()], |row| {
@@ -251,7 +338,8 @@ impl GroupMembership {
             .collect::<Vec<_>>()
             .join(",");
         let query_string = format!(
-            "SELECT leaf_index FROM group_membership WHERE group_id = ? AND (client_uuid, user_name) IN ({})",
+            "SELECT leaf_index FROM group_membership
+            WHERE group_id = ? AND (client_uuid, user_name) IN ({})",
             placeholders
         );
         let group_id = GroupIdRefWrapper::from(group_id);
@@ -314,69 +402,17 @@ impl GroupMembership {
     }
 }
 
-impl Storable for GroupMembership {
-    // TODO: Reinstate the foreign key constraint as soon as we have migrated
-    // the mls group table to the new style of storage.
-    // FOREIGN KEY (group_id) REFERENCES mlsgroup(primary_key),
-    const CREATE_TABLE_STATEMENT: &'static str = "CREATE TABLE IF NOT EXISTS group_membership (
-                client_credential_fingerprint BLOB NOT NULL,
-                group_id BLOB NOT NULL,
-                client_uuid BLOB NOT NULL,
-                user_name TEXT NOT NULL,
-                leaf_index INTEGER NOT NULL,
-                identity_link_key BLOB NOT NULL,
-                status TEXT DEFAULT 'staged_update' NOT NULL CHECK (status IN ('staged_update', 'staged_removal', 'staged_add', 'merged')),
-                FOREIGN KEY (client_credential_fingerprint) REFERENCES client_credentials(fingerprint),
-                PRIMARY KEY (group_id, leaf_index, status)
-            );";
-
-    fn from_row(row: &rusqlite::Row) -> Result<Self, rusqlite::Error> {
-        let client_credential_fingerprint = row.get(0)?;
-        let group_id: GroupIdWrapper = row.get(1)?;
-        let client_uuid = row.get(2)?;
-        let user_name = row.get(3)?;
-        let leaf_index: i64 = row.get(4)?;
-        let identity_link_key: IdentityLinkKeySecret = row.get(5)?;
-        let client_id = AsClientId::new(user_name, client_uuid);
-        Ok(Self {
-            client_id,
-            group_id: group_id.into(),
-            leaf_index: LeafNodeIndex::new(leaf_index as u32),
-            identity_link_key: IdentityLinkKey::from(identity_link_key),
-            client_credential_fingerprint,
-        })
-    }
-}
-
-pub(crate) const GROUP_MEMBERSHIP_TRIGGER: &str =
-    "CREATE TRIGGER IF NOT EXISTS delete_orphaned_data
-        AFTER DELETE ON group_membership
-        FOR EACH ROW
-        BEGIN
-            -- Delete client credentials if they are not our own and not used in any group.
-            DELETE FROM client_credentials
-            WHERE fingerprint = OLD.client_credential_fingerprint AND NOT EXISTS (
-                SELECT 1 FROM group_membership WHERE client_credential_fingerprint = OLD.client_credential_fingerprint
-            ) AND NOT EXISTS (
-                SELECT 1 FROM own_client_info WHERE as_client_uuid = OLD.client_uuid
-            );
-
-            -- Delete user profiles of users that are not in any group and that are not our own.
-            DELETE FROM users
-            WHERE user_name = OLD.user_name AND NOT EXISTS (
-                SELECT 1 FROM group_membership WHERE user_name = OLD.user_name
-            ) AND NOT EXISTS (
-                SELECT 1 FROM own_client_info WHERE as_user_name = OLD.user_name
-            );
-        END;";
-
 #[cfg(test)]
 mod tests {
     use openmls::prelude::SignatureScheme;
     use phnxtypes::{
         credentials::{ClientCredential, ClientCredentialCsr, ClientCredentialPayload},
-        crypto::signatures::signable::{Signature, SignedStruct},
+        crypto::{
+            secrets::Secret,
+            signatures::signable::{Signature, SignedStruct},
+        },
     };
+    use rand::Rng;
     use tls_codec::Serialize;
     use uuid::Uuid;
 
@@ -385,14 +421,21 @@ mod tests {
     fn test_connection() -> rusqlite::Connection {
         let connection = rusqlite::Connection::open_in_memory().unwrap();
         connection
-            .execute_batch(StorableClientCredential::CREATE_TABLE_STATEMENT)
+            .execute_batch(
+                &[
+                    StorableClientCredential::CREATE_TABLE_STATEMENT,
+                    GroupMembership::CREATE_TABLE_STATEMENT,
+                ]
+                .join("\n"),
+            )
             .unwrap();
         connection
     }
 
     /// Returns test credential with a fixed identity but random payload.
-    fn test_client_credential() -> StorableClientCredential {
-        let client_id = AsClientId::new("alice@localhost".parse().unwrap(), Uuid::nil());
+    fn test_client_credential(client_id: Uuid) -> StorableClientCredential {
+        let client_id =
+            AsClientId::new(format!("{client_id}@localhost").parse().unwrap(), client_id);
         let (client_credential_csr, _) =
             ClientCredentialCsr::new(client_id, SignatureScheme::ED25519).unwrap();
         let fingerprint = CredentialFingerprint::new_for_test(b"fingerprint".to_vec());
@@ -403,12 +446,29 @@ mod tests {
         StorableClientCredential { client_credential }
     }
 
-    #[test]
-    fn store_load() -> anyhow::Result<()> {
-        let connection = test_connection();
-        let credential = test_client_credential();
+    /// Returns test group membership with a given parameters, fixed group id and random data.
+    fn test_group_membership(
+        credential: &ClientCredential,
+        index: LeafNodeIndex,
+    ) -> GroupMembership {
+        let group_id = GroupId::from_slice(&[0; 32]);
+        let secret: [u8; 32] = rand::thread_rng().gen();
 
-        credential.store(&connection).unwrap();
+        GroupMembership::new(
+            credential.identity(),
+            group_id,
+            index,
+            IdentityLinkKey::from(Secret::from(secret)),
+            credential.fingerprint(),
+        )
+    }
+
+    #[test]
+    fn client_credential_store_load() -> anyhow::Result<()> {
+        let connection = test_connection();
+        let credential = test_client_credential(Uuid::new_v4());
+
+        credential.store(&connection)?;
         let loaded =
             StorableClientCredential::load_by_client_id(&connection, &credential.identity())?
                 .expect("missing credential");
@@ -421,11 +481,11 @@ mod tests {
     }
 
     #[test]
-    fn store_load_by_id() -> anyhow::Result<()> {
+    fn client_credential_store_load_by_id() -> anyhow::Result<()> {
         let connection = test_connection();
-        let credential = test_client_credential();
+        let credential = test_client_credential(Uuid::new_v4());
 
-        credential.store(&connection).unwrap();
+        credential.store(&connection)?;
         let loaded =
             StorableClientCredential::load_by_client_id(&connection, &credential.identity())?
                 .expect("missing credential");
@@ -433,6 +493,54 @@ mod tests {
             loaded.client_credential.tls_serialize_detached(),
             credential.client_credential.tls_serialize_detached()
         );
+
+        Ok(())
+    }
+
+    #[test]
+    fn group_membership_merge_for_group() -> anyhow::Result<()> {
+        let connection = test_connection();
+
+        let credential_add = test_client_credential(Uuid::new_v4());
+        credential_add.store(&connection)?;
+        let index_add = LeafNodeIndex::new(0);
+        let membership_add = test_group_membership(&credential_add, index_add);
+        membership_add.stage_add(&connection)?;
+
+        let credential_update = test_client_credential(Uuid::new_v4());
+        credential_update.store(&connection)?;
+        let index_update = LeafNodeIndex::new(1);
+        let membership_update = test_group_membership(&credential_update, index_update);
+        membership_update.stage_update(&connection)?;
+
+        let credential_remove = test_client_credential(Uuid::new_v4());
+        credential_remove.store(&connection)?;
+        let index_remove = LeafNodeIndex::new(2);
+        let membership_remove = test_group_membership(&credential_remove, index_remove);
+        membership_remove.store(&connection)?;
+        GroupMembership::stage_removal(&connection, &membership_remove.group_id, index_remove)?;
+
+        let credential = test_client_credential(Uuid::new_v4());
+        credential.store(&connection)?;
+        let index = LeafNodeIndex::new(3);
+        let membership = test_group_membership(&credential, index);
+        membership.store(&connection)?;
+
+        GroupMembership::merge_for_group(&connection, &membership.group_id)?;
+
+        let group_id = &membership.group_id;
+
+        let loaded =
+            GroupMembership::load(&connection, group_id, index_add)?.expect("missing membership");
+        assert_eq!(loaded, membership_add);
+        let loaded = GroupMembership::load(&connection, group_id, index_update)?
+            .expect("missing membership");
+        assert_eq!(loaded, membership_update);
+        let loaded = GroupMembership::load(&connection, group_id, index_remove)?;
+        assert_eq!(loaded, None);
+        let loaded =
+            GroupMembership::load(&connection, group_id, index)?.expect("missing membership");
+        assert_eq!(loaded, membership);
 
         Ok(())
     }
@@ -440,8 +548,9 @@ mod tests {
     #[test]
     fn store_idempotent() -> anyhow::Result<()> {
         let connection = test_connection();
-        let credential_1 = test_client_credential();
-        let credential_2 = test_client_credential();
+        let id = Uuid::new_v4();
+        let credential_1 = test_client_credential(id);
+        let credential_2 = test_client_credential(id);
 
         // precondition
         assert_eq!(credential_1.identity(), credential_2.identity());
@@ -450,8 +559,8 @@ mod tests {
             credential_2.tls_serialize_detached()
         );
 
-        credential_1.store(&connection).unwrap();
-        credential_2.store(&connection).unwrap();
+        credential_1.store(&connection)?;
+        credential_2.store(&connection)?;
 
         let loaded =
             StorableClientCredential::load_by_client_id(&connection, &credential_1.identity())?
@@ -460,6 +569,145 @@ mod tests {
             loaded.client_credential.tls_serialize_detached(),
             credential_1.client_credential.tls_serialize_detached()
         );
+
+        Ok(())
+    }
+
+    #[test]
+    fn group_membership_store_load() -> anyhow::Result<()> {
+        let connection = test_connection();
+
+        let credential = test_client_credential(Uuid::new_v4());
+        credential.store(&connection)?;
+
+        let index = LeafNodeIndex::new(0);
+        let membership = test_group_membership(&credential, index);
+
+        membership.store(&connection)?;
+        let loaded = GroupMembership::load(&connection, &membership.group_id, index)?
+            .expect("missing membership");
+        assert_eq!(loaded, membership);
+        let loaded = GroupMembership::load_staged(&connection, &membership.group_id, index)?;
+        assert_eq!(loaded, None);
+
+        Ok(())
+    }
+
+    #[test]
+    fn group_membership_store_load_staged() -> anyhow::Result<()> {
+        let connection = test_connection();
+
+        let credential = test_client_credential(Uuid::new_v4());
+        credential.store(&connection)?;
+
+        let index = LeafNodeIndex::new(0);
+        let membership = test_group_membership(&credential, index);
+
+        membership.stage_add(&connection)?;
+        let loaded = GroupMembership::load(&connection, &membership.group_id, index)?;
+        assert_eq!(loaded, None);
+        let loaded = GroupMembership::load_staged(&connection, &membership.group_id, index)?
+            .expect("missing membership");
+        assert_eq!(loaded, membership);
+
+        Ok(())
+    }
+
+    #[test]
+    fn group_membership_member_indices() -> anyhow::Result<()> {
+        let connection = test_connection();
+
+        let credential = test_client_credential(Uuid::new_v4());
+        credential.store(&connection)?;
+
+        let index = LeafNodeIndex::new(0);
+        let membership = test_group_membership(&credential, index);
+
+        membership.store(&connection)?;
+        let indices = GroupMembership::member_indices(&connection, &membership.group_id)?;
+        assert_eq!(indices, [index]);
+
+        Ok(())
+    }
+
+    #[test]
+    fn group_membership_client_indices() -> anyhow::Result<()> {
+        let connection = test_connection();
+
+        let credential_a = test_client_credential(Uuid::new_v4());
+        credential_a.store(&connection)?;
+
+        let credential_b = test_client_credential(Uuid::new_v4());
+        credential_b.store(&connection)?;
+
+        let index_a = LeafNodeIndex::new(0);
+        let membership_a = test_group_membership(&credential_a, index_a);
+
+        let index_b = LeafNodeIndex::new(1);
+        let membership_b = test_group_membership(&credential_b, index_b);
+
+        membership_a.store(&connection)?;
+        membership_b.store(&connection)?;
+
+        let indices = GroupMembership::client_indices(
+            &connection,
+            &membership_a.group_id,
+            &[credential_a.identity()],
+        )?;
+        assert_eq!(indices, vec![index_a]);
+
+        let indices = GroupMembership::client_indices(
+            &connection,
+            &membership_b.group_id,
+            &[credential_b.identity()],
+        )?;
+        assert_eq!(indices, [index_b]);
+
+        Ok(())
+    }
+
+    #[test]
+    fn group_membership_user_client_ids() -> anyhow::Result<()> {
+        let connection = test_connection();
+
+        let credential = test_client_credential(Uuid::new_v4());
+        credential.store(&connection)?;
+
+        let index = LeafNodeIndex::new(0);
+        let membership = test_group_membership(&credential, index);
+
+        membership.store(&connection)?;
+        let client_ids = GroupMembership::user_client_ids(
+            &connection,
+            &membership.group_id,
+            &membership.client_id.user_name(),
+        )?;
+        assert_eq!(client_ids, [credential.identity()]);
+
+        Ok(())
+    }
+
+    #[test]
+    fn group_membership_group_members() -> anyhow::Result<()> {
+        let connection = test_connection();
+
+        let credential_a = test_client_credential(Uuid::new_v4());
+        credential_a.store(&connection)?;
+
+        let credential_b = test_client_credential(Uuid::new_v4());
+        credential_b.store(&connection)?;
+
+        let index_a = LeafNodeIndex::new(0);
+        let membership_a = test_group_membership(&credential_a, index_a);
+
+        let index_b = LeafNodeIndex::new(1);
+        let membership_b = test_group_membership(&credential_b, index_b);
+
+        membership_a.store(&connection)?;
+        membership_b.store(&connection)?;
+
+        let members = GroupMembership::group_members(&connection, &membership_a.group_id)?;
+        assert_eq!(members, [credential_a.identity(), credential_b.identity()]);
 
         Ok(())
     }

--- a/coreclient/src/user_profiles/mod.rs
+++ b/coreclient/src/user_profiles/mod.rs
@@ -17,7 +17,9 @@ pub(crate) mod persistence;
 
 /// A user profile contains information about a user, such as their display name
 /// and profile picture.
-#[derive(Debug, TlsSerialize, TlsDeserializeBytes, TlsSize, Clone, Serialize, Deserialize)]
+#[derive(
+    Debug, Clone, PartialEq, Eq, TlsSerialize, TlsDeserializeBytes, TlsSize, Serialize, Deserialize,
+)]
 pub struct UserProfile {
     user_name: QualifiedUserName,
     display_name_option: Option<DisplayName>,
@@ -59,7 +61,7 @@ impl UserProfile {
 }
 
 /// A display name is a human-readable name that can be used to identify a user.
-#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
 pub struct DisplayName {
     display_name: String,
 }

--- a/test_harness/src/utils/setup.rs
+++ b/test_harness/src/utils/setup.rs
@@ -140,7 +140,7 @@ impl TestBackend {
         info!(
             "{} performs an update in group {}",
             updater_name,
-            conversation_id.as_uuid()
+            conversation_id.uuid()
         );
 
         let test_updater = self.users.get_mut(&updater_name).unwrap();
@@ -222,7 +222,7 @@ impl TestBackend {
         info!(
             "{} performs an update in group {}",
             updater_name,
-            conversation_id.as_uuid()
+            conversation_id.uuid()
         );
 
         let test_updater = self.users.get_mut(updater_name).unwrap();
@@ -619,7 +619,7 @@ impl TestBackend {
             "{} invites {} to the group with id {}",
             inviter_name,
             invitee_strings.join(", "),
-            conversation_id.as_uuid()
+            conversation_id.uuid()
         );
 
         // Perform the invite operation and check that the invitees are now in the group.
@@ -674,7 +674,7 @@ impl TestBackend {
                 .expect("Error processing qs messages.");
 
             let mut invitee_conversations_after = invitee.conversations().await.unwrap();
-            let conversation_uuid = conversation_id.as_uuid();
+            let conversation_uuid = conversation_id.uuid();
             let new_conversation_position = invitee_conversations_after
                 .iter()
                 .position(|c| c.id() == conversation_id)
@@ -796,7 +796,7 @@ impl TestBackend {
             "{} removes {} from the group with id {}",
             remover_name,
             removed_strings.join(", "),
-            conversation_id.as_uuid()
+            conversation_id.uuid()
         );
 
         // Perform the remove operation and check that the removed are not in
@@ -874,7 +874,7 @@ impl TestBackend {
                 .unwrap_or_else(|| {
                     panic!(
                         "{removed_name} should have the conversation with id {}",
-                        conversation_id.as_uuid()
+                        conversation_id.uuid()
                     )
                 });
             assert!(conversation.id() == conversation_id);
@@ -945,7 +945,7 @@ impl TestBackend {
         info!(
             "{} leaves the group with id {}",
             leaver_name,
-            conversation_id.as_uuid()
+            conversation_id.uuid()
         );
         let test_leaver = self.users.get_mut(leaver_name).unwrap();
         let leaver = &mut test_leaver.user;
@@ -994,7 +994,7 @@ impl TestBackend {
         info!(
             "{} deletes the group with id {}",
             deleter_name,
-            conversation_id.as_uuid()
+            conversation_id.uuid()
         );
         let test_deleter = self.users.get_mut(deleter_name).unwrap();
         let deleter = &mut test_deleter.user;
@@ -1131,7 +1131,7 @@ impl TestBackend {
                 info!(
                     random_operation = true,
                     "Random operation: Created group {}",
-                    conversation_id.as_uuid()
+                    conversation_id.uuid()
                 );
                 // TODO: Invite user(s)
             }
@@ -1185,7 +1185,7 @@ impl TestBackend {
                             "Random operation: {} invites {} to group {}",
                             random_user,
                             invitee_strings.join(", "),
-                            conversation.id().as_uuid()
+                            conversation.id().uuid()
                         );
                         self.invite_to_group(
                             conversation.id(),
@@ -1229,7 +1229,7 @@ impl TestBackend {
                             "Random operation: {} removes {} from group {}",
                             random_user,
                             removed_strings.join(", "),
-                            conversation.id().as_uuid()
+                            conversation.id().uuid()
                         );
                         let members_to_remove = members_to_remove.iter().collect();
                         self.remove_from_group(conversation.id(), &random_user, members_to_remove)
@@ -1255,7 +1255,7 @@ impl TestBackend {
                         random_operation = true,
                         "Random operation: {} leaves group {}",
                         random_user,
-                        conversation.id().as_uuid()
+                        conversation.id().uuid()
                     );
                     self.leave_group(conversation.id(), &random_user).await;
                 }

--- a/types/src/credentials/mod.rs
+++ b/types/src/credentials/mod.rs
@@ -68,6 +68,11 @@ impl std::fmt::Display for CredentialFingerprint {
 }
 
 impl CredentialFingerprint {
+    #[cfg(any(feature = "test_utils", test))]
+    pub fn new_for_test(value: Vec<u8>) -> Self {
+        Self(value)
+    }
+
     fn with_label(credential: &impl TlsSerialize, label: &str) -> Self {
         let hash_label = format!("Infra Credential Fingerprint {}", label);
         let rust_crypto = OpenMlsRustCrypto::default();

--- a/types/src/crypto/ear/keys.rs
+++ b/types/src/crypto/ear/keys.rs
@@ -119,7 +119,9 @@ impl From<Secret<AEAD_KEY_SIZE>> for PushTokenEarKey {
 pub type KeyPackageEarKeySecret = Secret<AEAD_KEY_SIZE>;
 
 // EAR key used to encrypt [`AddPackage`]s.
-#[derive(Clone, Debug, TlsSerialize, TlsDeserializeBytes, TlsSize, Serialize, Deserialize)]
+#[derive(
+    Clone, Debug, PartialEq, Eq, TlsSerialize, TlsDeserializeBytes, TlsSize, Serialize, Deserialize,
+)]
 pub struct KeyPackageEarKey {
     key: KeyPackageEarKeySecret,
 }
@@ -283,7 +285,9 @@ impl KdfDerivable<ConnectionKey, PseudonymousCredentialTbs, AEAD_KEY_SIZE> for I
 pub type WelcomeAttributionInfoEarKeySecret = Secret<AEAD_KEY_SIZE>;
 
 // EAR key used to encrypt [`WelcomeAttributionInfo`]s.
-#[derive(Clone, Debug, TlsSerialize, TlsDeserializeBytes, TlsSize, Serialize, Deserialize)]
+#[derive(
+    Clone, Debug, PartialEq, Eq, TlsSerialize, TlsDeserializeBytes, TlsSize, Serialize, Deserialize,
+)]
 pub struct WelcomeAttributionInfoEarKey {
     key: WelcomeAttributionInfoEarKeySecret,
 }
@@ -328,7 +332,9 @@ impl From<Secret<AEAD_KEY_SIZE>> for WelcomeAttributionInfoEarKey {
 pub type FriendshipPackageEarKeySecret = Secret<AEAD_KEY_SIZE>;
 
 // EAR key used to encrypt [`WelcomeAttributionInfo`]s.
-#[derive(Clone, Debug, TlsSerialize, TlsDeserializeBytes, TlsSize, Serialize, Deserialize)]
+#[derive(
+    Clone, Debug, PartialEq, Eq, TlsSerialize, TlsDeserializeBytes, TlsSize, Serialize, Deserialize,
+)]
 pub struct FriendshipPackageEarKey {
     key: FriendshipPackageEarKeySecret,
 }

--- a/types/src/crypto/ear/keys.rs
+++ b/types/src/crypto/ear/keys.rs
@@ -240,7 +240,9 @@ impl KdfDerivable<RatchetSecret, Vec<u8>, AEAD_KEY_SIZE> for RatchetKey {
 
 pub type IdentityLinkKeySecret = Secret<AEAD_KEY_SIZE>;
 
-#[derive(Serialize, Deserialize, Clone, Debug, TlsSerialize, TlsDeserializeBytes, TlsSize)]
+#[derive(
+    Serialize, Deserialize, Clone, Debug, PartialEq, Eq, TlsSerialize, TlsDeserializeBytes, TlsSize,
+)]
 pub struct IdentityLinkKey {
     key: IdentityLinkKeySecret,
 }

--- a/types/src/crypto/kdf/keys.rs
+++ b/types/src/crypto/kdf/keys.rs
@@ -150,7 +150,9 @@ impl KdfDerivable<RatchetSecret, Vec<u8>, KDF_KEY_SIZE> for RatchetSecret {
 
 pub type ConnectionKeyKey = Secret<KDF_KEY_SIZE>;
 
-#[derive(Serialize, Deserialize, Clone, Debug, TlsSerialize, TlsDeserializeBytes, TlsSize)]
+#[derive(
+    Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TlsSerialize, TlsDeserializeBytes, TlsSize,
+)]
 pub struct ConnectionKey {
     key: ConnectionKeyKey,
 }

--- a/types/src/crypto/secrets.rs
+++ b/types/src/crypto/secrets.rs
@@ -18,7 +18,9 @@ use tls_codec::{TlsDeserializeBytes, TlsSerialize, TlsSize};
 use super::RandomnessError;
 
 /// Struct that contains a (symmetric) secret of fixed length LENGTH.
-#[derive(TlsSerialize, TlsDeserializeBytes, TlsSize, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(
+    TlsSerialize, TlsDeserializeBytes, TlsSize, Clone, PartialEq, Eq, Serialize, Deserialize,
+)]
 pub struct Secret<const LENGTH: usize> {
     #[serde(with = "super::serde_arrays")]
     secret: [u8; LENGTH],

--- a/types/src/crypto/signatures/signable.rs
+++ b/types/src/crypto/signatures/signable.rs
@@ -71,6 +71,11 @@ impl Signature {
     pub fn into_bytes(self) -> Vec<u8> {
         self.0
     }
+
+    #[cfg(any(feature = "test_utils", test))]
+    pub fn new_for_test(value: Vec<u8>) -> Self {
+        Self::from_bytes(value)
+    }
 }
 
 #[derive(


### PR DESCRIPTION
Testing revealed two bugs

1. Staged group membership update did not work on
   `GroupMembership::merge_for_group` due to unique key constraint.
2. `Conversation::mark_as_read_until_message_id` failed when given
   message id did not exist.

Addition break up long SQL query strings. Rust formatter does not 
format lines longer than 100 chars.