### PR TITLE
feat: version and negotiate DS API between client and server 

### DIFF
--- a/apiclient/src/ds_api/mod.rs
+++ b/apiclient/src/ds_api/mod.rs
@@ -20,6 +20,7 @@ use phnxtypes::{
         signatures::{signable::Signable, traits::SigningKeyBehaviour},
     },
     endpoint_paths::ENDPOINT_DS_GROUPS,
+    errors::version::VersionError,
     identifiers::QsReference,
     messages::{
         client_ds::{
@@ -34,7 +35,6 @@ use phnxtypes::{
             JoinConnectionGroupParamsOut, ResyncParamsOut, SelfRemoveParamsOut,
             SendMessageParamsOut, UpdateParamsOut,
         },
-        client_qs::VersionError,
     },
     time::TimeStamp,
     LibraryError,

--- a/apiclient/src/qs_api/mod.rs
+++ b/apiclient/src/qs_api/mod.rs
@@ -34,6 +34,7 @@ use phnxtypes::{
         push_token::EncryptedPushToken,
         FriendshipToken,
     },
+    LibraryError,
 };
 use thiserror::Error;
 use tls_codec::{DeserializeBytes, Serialize};
@@ -60,10 +61,14 @@ pub enum QsRequestError {
     UnexpectedResponse,
     #[error("Unsuccessful response: status = {status}, error = {error}")]
     RequestFailed { status: StatusCode, error: String },
-    #[error("Network error: {0}")]
-    NetworkError(String),
     #[error(transparent)]
     Version(#[from] VersionError),
+}
+
+impl From<LibraryError> for QsRequestError {
+    fn from(_: LibraryError) -> Self {
+        Self::LibraryError
+    }
 }
 
 // TODO: This is a workaround that allows us to use the Signable trait.
@@ -85,8 +90,7 @@ impl ApiClient {
             QsVersionedRequestParamsOut::with_version(request_params, api_version)?;
         let message = sign_params(request_params, &token_or_signing_key)?;
 
-        let endpoint = self.build_url(Protocol::Http, ENDPOINT_QS);
-        let response = send_qs_message(&self.client, &endpoint, &message).await?;
+        let response = self.send_qs_http_request(&message).await?;
 
         // check if we need to negotiate a new API version
         let Some(accepted_versions) = extract_api_version_negotiation(&response) else {
@@ -105,7 +109,7 @@ impl ApiClient {
             .change_version(accepted_version)?;
         let message = sign_params(request_params, &token_or_signing_key)?;
 
-        let response = send_qs_message(&self.client, &endpoint, &message).await?;
+        let response = self.send_qs_http_request(&message).await?;
         handle_qs_response(response).await
     }
 
@@ -383,6 +387,21 @@ impl ApiClient {
             }
         })
     }
+
+    async fn send_qs_http_request(
+        &self,
+        message: &ClientToQsMessageOut,
+    ) -> Result<reqwest::Response, QsRequestError> {
+        let message_bytes = message.tls_serialize_detached()?;
+        let endpoint = self.build_url(Protocol::Http, ENDPOINT_QS);
+        let response = self
+            .client
+            .post(&endpoint)
+            .body(message_bytes)
+            .send()
+            .await?;
+        Ok(response)
+    }
 }
 
 fn sign_params<T: SigningKeyBehaviour>(
@@ -392,29 +411,10 @@ fn sign_params<T: SigningKeyBehaviour>(
     let tbs = ClientToQsMessageTbsOut::new(request_params);
     let message = match token_or_signing_key {
         AuthenticationMethod::Token(token) => ClientToQsMessageOut::from_token(tbs, token.clone()),
-        AuthenticationMethod::SigningKey(signing_key) => tbs
-            .sign(*signing_key)
-            .map_err(|_| QsRequestError::LibraryError)?,
+        AuthenticationMethod::SigningKey(signing_key) => tbs.sign(*signing_key)?,
         AuthenticationMethod::None => ClientToQsMessageOut::without_signature(tbs),
     };
     Ok(message)
-}
-
-async fn send_qs_message(
-    client: &reqwest::Client,
-    endpoint: &str,
-    message: &ClientToQsMessageOut,
-) -> Result<reqwest::Response, QsRequestError> {
-    client
-        .post(endpoint)
-        .body(
-            message
-                .tls_serialize_detached()
-                .map_err(|_| QsRequestError::LibraryError)?,
-        )
-        .send()
-        .await
-        .map_err(From::from)
 }
 
 async fn handle_qs_response(
@@ -422,9 +422,8 @@ async fn handle_qs_response(
 ) -> Result<QsProcessResponseIn, QsRequestError> {
     let status = response.status();
     if status.is_success() {
-        let bytes = response.bytes().await.map_err(QsRequestError::Reqwest)?;
-        let qs_response = QsVersionedProcessResponseIn::tls_deserialize_exact_bytes(&bytes)
-            .map_err(QsRequestError::Tls)?
+        let bytes = response.bytes().await?;
+        let qs_response = QsVersionedProcessResponseIn::tls_deserialize_exact_bytes(&bytes)?
             .into_unversioned()?;
         Ok(qs_response)
     } else {

--- a/apiclient/src/qs_api/mod.rs
+++ b/apiclient/src/qs_api/mod.rs
@@ -16,6 +16,7 @@ use phnxtypes::{
         RatchetEncryptionKey,
     },
     endpoint_paths::ENDPOINT_QS,
+    errors::version::VersionError,
     identifiers::{QsClientId, QsUserId},
     messages::{
         client_qs::{
@@ -24,7 +25,7 @@ use phnxtypes::{
             DequeueMessagesParams, DequeueMessagesResponse, EncryptionKeyResponse,
             KeyPackageParams, KeyPackageResponseIn, QsProcessResponseIn,
             QsVersionedProcessResponseIn, UpdateClientRecordParams, UpdateUserRecordParams,
-            VersionError, SUPPORTED_QS_API_VERSIONS,
+            SUPPORTED_QS_API_VERSIONS,
         },
         client_qs_out::{
             ClientToQsMessageOut, ClientToQsMessageTbsOut, CreateClientRecordParamsOut,

--- a/apiclient/src/version.rs
+++ b/apiclient/src/version.rs
@@ -9,11 +9,8 @@ use std::{
 
 use http::{HeaderMap, StatusCode};
 use phnxtypes::{
-    messages::{
-        client_ds::CURRENT_DS_API_VERSION,
-        client_qs::{VersionError, CURRENT_QS_API_VERSION},
-        ApiVersion,
-    },
+    errors::version::VersionError,
+    messages::{client_ds::CURRENT_DS_API_VERSION, client_qs::CURRENT_QS_API_VERSION, ApiVersion},
     ACCEPTED_API_VERSIONS_HEADER,
 };
 use tracing::error;

--- a/backend/src/ds/process.rs
+++ b/backend/src/ds/process.rs
@@ -166,7 +166,7 @@ use phnxtypes::{
         ear::keys::{EncryptedIdentityLinkKey, GroupStateEarKey},
         signatures::{keys::LeafVerifyingKey, signable::Verifiable},
     },
-    errors::DsProcessingError,
+    errors::{version::VersionError, DsProcessingError},
     identifiers::QualifiedGroupId,
     messages::{
         client_ds::{
@@ -174,7 +174,6 @@ use phnxtypes::{
             DsSender, DsVersionedRequestParams, QsQueueMessagePayload, VerifiableClientToDsMessage,
             SUPPORTED_DS_API_VERSIONS,
         },
-        client_qs::VersionError,
         ApiVersion,
     },
     time::TimeStamp,

--- a/server/src/endpoints/ds.rs
+++ b/server/src/endpoints/ds.rs
@@ -7,9 +7,7 @@ use actix_web::{
     HttpResponse, Responder,
 };
 use phnxbackend::{ds::Ds, qs::QsConnector};
-use phnxtypes::{
-    errors::DsProcessingError, messages::client_ds::DsMessageTypeIn, ACCEPTED_API_VERSIONS_HEADER,
-};
+use phnxtypes::{errors::DsProcessingError, ACCEPTED_API_VERSIONS_HEADER};
 use tls_codec::{DeserializeBytes, Serialize};
 use tracing::{info, trace, warn};
 
@@ -24,7 +22,7 @@ pub(crate) async fn ds_process_message<Qep: QsConnector>(
     let storage_provider = ds_storage_provider.get_ref();
     let qs_connector = qs_connector.get_ref();
     // Create a new group on the DS.
-    let message = match DsMessageTypeIn::tls_deserialize_exact_bytes(&message) {
+    let message = match DeserializeBytes::tls_deserialize_exact_bytes(&message) {
         Ok(message) => message,
         Err(e) => {
             warn!("Received invalid message: {:?}", e);

--- a/server/src/endpoints/qs/mod.rs
+++ b/server/src/endpoints/qs/mod.rs
@@ -41,16 +41,11 @@ pub(crate) async fn qs_process_message(qs: Data<Qs>, message: web::Bytes) -> imp
             HttpResponse::Ok().body(response.tls_serialize_detached().unwrap())
         }
         Err(QsProcessError::Api(version_error)) => {
-            info!(%version_error, "Unsupported API version");
+            info!(%version_error, "Unsupported QS API version");
             HttpResponse::NotAcceptable()
                 .insert_header((
                     ACCEPTED_API_VERSIONS_HEADER,
-                    version_error
-                        .supported_versions()
-                        .iter()
-                        .map(|v| v.to_string())
-                        .collect::<Vec<_>>()
-                        .join(","),
+                    version_error.supported_versions_header_value(),
                 ))
                 .body(version_error.to_string())
         }

--- a/types/src/errors/mod.rs
+++ b/types/src/errors/mod.rs
@@ -7,11 +7,13 @@ use mls_assist::{
     openmls::group::MergeCommitError,
 };
 use thiserror::Error;
+use version::VersionError;
 
-use crate::{codec::PhnxCodec, messages::client_qs::VersionError};
+use crate::codec::PhnxCodec;
 
 pub mod auth_service;
 pub mod qs;
+pub mod version;
 
 pub type CborMlsAssistStorage = MlsAssistMemoryStorage<PhnxCodec>;
 

--- a/types/src/errors/mod.rs
+++ b/types/src/errors/mod.rs
@@ -8,7 +8,7 @@ use mls_assist::{
 };
 use thiserror::Error;
 
-use crate::codec::PhnxCodec;
+use crate::{codec::PhnxCodec, messages::client_qs::VersionError};
 
 pub mod auth_service;
 pub mod qs;
@@ -77,6 +77,9 @@ pub enum ClientUpdateError {
 #[derive(Debug, Error)]
 #[repr(u8)]
 pub enum DsProcessingError {
+    /// API Version error
+    #[error(transparent)]
+    Api(#[from] VersionError),
     /// Failed to distribute message to other members
     #[error("Failed to distribute message to other members")]
     DistributionError,

--- a/types/src/errors/qs.rs
+++ b/types/src/errors/qs.rs
@@ -5,7 +5,7 @@
 use thiserror::Error;
 use tls_codec::{TlsDeserializeBytes, TlsSerialize, TlsSize};
 
-use crate::messages::client_qs::VersionError;
+use super::version::VersionError;
 
 /// Error fetching a message from the QS.
 #[derive(Error, Debug, Clone, TlsSerialize, TlsDeserializeBytes, TlsSize)]

--- a/types/src/errors/version.rs
+++ b/types/src/errors/version.rs
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: 2025 Phoenix R&D GmbH <hello@phnx.im>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+use crate::messages::ApiVersion;
+
+#[derive(Debug, thiserror::Error)]
+#[error("Unsupported version: {version}, supported versions: {supported_versions:?}")]
+pub struct VersionError {
+    version: ApiVersion,
+    supported_versions: &'static [ApiVersion],
+}
+
+impl VersionError {
+    pub fn new(version: ApiVersion, supported_versions: &'static [ApiVersion]) -> Self {
+        Self {
+            version,
+            supported_versions,
+        }
+    }
+
+    pub fn supported_versions(&self) -> &[ApiVersion] {
+        self.supported_versions
+    }
+
+    pub fn supported_versions_header_value(&self) -> String {
+        self.supported_versions
+            .iter()
+            .map(|v| v.to_string())
+            .collect::<Vec<_>>()
+            .join(",")
+    }
+
+    pub fn parse_supported_versions_header_value(
+        value: &str,
+    ) -> impl Iterator<Item = ApiVersion> + '_ {
+        value
+            .split(',')
+            .filter_map(|s| s.parse().ok())
+            .filter_map(ApiVersion::new)
+    }
+}

--- a/types/src/identifiers/mod.rs
+++ b/types/src/identifiers/mod.rs
@@ -143,6 +143,14 @@ impl TryFrom<GroupId> for QualifiedGroupId {
     type Error = tls_codec::Error;
 
     fn try_from(value: GroupId) -> Result<Self, Self::Error> {
+        Self::try_from(&value)
+    }
+}
+
+impl TryFrom<&GroupId> for QualifiedGroupId {
+    type Error = tls_codec::Error;
+
+    fn try_from(value: &GroupId) -> Result<Self, Self::Error> {
         Self::tls_deserialize_exact_bytes(value.as_slice())
     }
 }

--- a/types/src/messages/client_ds.rs
+++ b/types/src/messages/client_ds.rs
@@ -36,12 +36,13 @@ use crate::{
         ratchet::QueueRatchet,
         signatures::signable::{Signature, Verifiable, VerifiedStruct},
     },
+    errors::version::VersionError,
     identifiers::QsReference,
     time::TimeStamp,
 };
 
 use super::{
-    client_as::EncryptedFriendshipPackage, client_qs::VersionError,
+    client_as::EncryptedFriendshipPackage,
     welcome_attribution_info::EncryptedWelcomeAttributionInfo, ApiVersion, EncryptedQsQueueMessage,
     MlsInfraVersion,
 };

--- a/types/src/messages/client_ds_out.rs
+++ b/types/src/messages/client_ds_out.rs
@@ -23,6 +23,7 @@ use crate::{
         ear::keys::{EncryptedIdentityLinkKey, GroupStateEarKey},
         signatures::signable::{Signable, Signature, SignedStruct},
     },
+    errors::version::VersionError,
     identifiers::QsReference,
     time::TimeStamp,
 };
@@ -32,7 +33,6 @@ use super::{
         ConnectionGroupInfoParams, ExternalCommitInfoParams, UpdateQsClientReferenceParams,
         WelcomeInfoParams, SUPPORTED_DS_API_VERSIONS,
     },
-    client_qs::VersionError,
     welcome_attribution_info::EncryptedWelcomeAttributionInfo,
     ApiVersion,
 };

--- a/types/src/messages/client_qs.rs
+++ b/types/src/messages/client_qs.rs
@@ -24,13 +24,13 @@ use crate::{
         ear::keys::KeyPackageEarKey,
         hpke::ClientIdEncryptionKey,
         kdf::keys::RatchetSecret,
-        signatures::keys::QsClientVerifyingKey,
         signatures::{
-            keys::QsUserVerifyingKey,
+            keys::{QsClientVerifyingKey, QsUserVerifyingKey},
             signable::{Signature, Verifiable, VerifiedStruct},
         },
         RatchetEncryptionKey,
     },
+    errors::version::VersionError,
     identifiers::{QsClientId, QsUserId},
 };
 
@@ -376,44 +376,6 @@ impl DeserializeBytes for QsVersionedRequestParams {
                 bytes,
             )),
         }
-    }
-}
-
-// TODO: Move to a different module.
-#[derive(Debug, thiserror::Error)]
-#[error("Unsupported version: {version}, supported versions: {supported_versions:?}")]
-pub struct VersionError {
-    version: ApiVersion,
-    supported_versions: &'static [ApiVersion],
-}
-
-impl VersionError {
-    pub fn new(version: ApiVersion, supported_versions: &'static [ApiVersion]) -> Self {
-        Self {
-            version,
-            supported_versions,
-        }
-    }
-
-    pub fn supported_versions(&self) -> &[ApiVersion] {
-        self.supported_versions
-    }
-
-    pub fn supported_versions_header_value(&self) -> String {
-        self.supported_versions
-            .iter()
-            .map(|v| v.to_string())
-            .collect::<Vec<_>>()
-            .join(",")
-    }
-
-    pub fn parse_supported_versions_header_value(
-        value: &str,
-    ) -> impl Iterator<Item = ApiVersion> + '_ {
-        value
-            .split(',')
-            .filter_map(|s| s.parse().ok())
-            .filter_map(ApiVersion::new)
     }
 }
 

--- a/types/src/messages/client_qs.rs
+++ b/types/src/messages/client_qs.rs
@@ -313,7 +313,6 @@ pub struct ClientToQsMessageTbs {
 /// **WARNING**: Only add new variants with new API versions. Do not reuse the API version (variant
 /// tag).
 #[derive(Debug)]
-#[repr(u64)]
 pub enum QsVersionedRequestParams {
     /// Fallback for unknown versions
     Other(ApiVersion),
@@ -380,6 +379,7 @@ impl DeserializeBytes for QsVersionedRequestParams {
     }
 }
 
+// TODO: Move to a different module.
 #[derive(Debug, thiserror::Error)]
 #[error("Unsupported version: {version}, supported versions: {supported_versions:?}")]
 pub struct VersionError {
@@ -397,6 +397,23 @@ impl VersionError {
 
     pub fn supported_versions(&self) -> &[ApiVersion] {
         self.supported_versions
+    }
+
+    pub fn supported_versions_header_value(&self) -> String {
+        self.supported_versions
+            .iter()
+            .map(|v| v.to_string())
+            .collect::<Vec<_>>()
+            .join(",")
+    }
+
+    pub fn parse_supported_versions_header_value(
+        value: &str,
+    ) -> impl Iterator<Item = ApiVersion> + '_ {
+        value
+            .split(',')
+            .filter_map(|s| s.parse().ok())
+            .filter_map(ApiVersion::new)
     }
 }
 

--- a/types/src/messages/client_qs_out.rs
+++ b/types/src/messages/client_qs_out.rs
@@ -15,6 +15,7 @@ use crate::{
         },
         RatchetEncryptionKey,
     },
+    errors::version::VersionError,
     identifiers::{QsClientId, QsUserId},
 };
 
@@ -22,7 +23,7 @@ use super::{
     client_qs::{
         ClientKeyPackageParams, DeleteClientRecordParams, DeleteUserRecordParams,
         DequeueMessagesParams, KeyPackageParams, UpdateClientRecordParams, UpdateUserRecordParams,
-        VersionError, SUPPORTED_QS_API_VERSIONS,
+        SUPPORTED_QS_API_VERSIONS,
     },
     push_token::EncryptedPushToken,
     ApiVersion, FriendshipToken,

--- a/types/src/messages/mod.rs
+++ b/types/src/messages/mod.rs
@@ -179,7 +179,7 @@ impl ApiVersion {
         Self(value)
     }
 
-    pub(crate) const fn tls_value(&self) -> TlsVarInt {
+    pub const fn tls_value(&self) -> TlsVarInt {
         self.0
     }
 }


### PR DESCRIPTION
If the DS backend does not support the API version used by the client,
it responds with a `406 Not Acceptable` status and includes an
`x-accepted-api-versions` header containing a comma-separated list of
supported API versions.

The client handles the `406` status code by attempting to resend the
request using the highest supported API version, if possible.

The server always responds with the API version from the client's
request. The latest supported API version is stored in the client's
memory.

Additionally, non-group API requests are moved into
`ClientToDsMessageTbs` from the top-level `DsMessageTypeIn/Out` struct.
The top-level struct is replaced by `ClientToDsMessageOut` /
`VerifiableClientToDsMessage`, enabling versioning for non-group API
requests as well.