### PR TITLE
fix: race between transactions and notifier

### DIFF
--- a/coreclient/src/clients/process/process_qs.rs
+++ b/coreclient/src/clients/process/process_qs.rs
@@ -204,10 +204,10 @@ impl CoreUser {
         };
 
         // MLSMessage Phase 3: Store the updated group and the messages.
-        self.with_transaction(async |connection| {
+        self.with_transaction_and_notifier(async |connection, notifier| {
             group.store_update(&mut *connection).await?;
             let conversation_messages = self
-                .store_messages(connection, conversation_id, group_messages)
+                .store_messages(connection, notifier, conversation_id, group_messages)
                 .await?;
             Ok(match (conversation_messages, conversation_changed) {
                 (messages, true) => {

--- a/coreclient/src/store/notification.rs
+++ b/coreclient/src/store/notification.rs
@@ -73,7 +73,7 @@ impl StoreNotifier {
     /// Send collected notifications to the subscribers, if there are any.
     pub(crate) fn notify(mut self) {
         if !self.notification.ops.is_empty() {
-            let notification = mem::replace(&mut self.notification, StoreNotification::empty());
+            let notification = mem::take(&mut self.notification);
             self.tx.notify(Arc::new(notification));
         }
     }

--- a/server/tests/mod.rs
+++ b/server/tests/mod.rs
@@ -618,9 +618,7 @@ async fn client_persistence() {
     let client_id = setup.users.get(&ALICE).unwrap().user.as_client_id();
 
     // Try to load the user from the database.
-    let user_result = CoreUser::load(client_id.clone(), "./").await.unwrap();
-
-    assert!(user_result.is_some());
+    CoreUser::load(client_id.clone(), "./").await.unwrap();
 
     fs::remove_file("./phnx.db").unwrap();
     let client_db_path = format!("./{}.db", client_id);


### PR DESCRIPTION
This bug was introduced during the CoreClient to SQLx port (#291).

Previously, the store notifier triggered *before* the transaction was
committed, meaning notifications were received during the transaction.
However, the database connection was wrapped in a mutex, allowing only a
single connection to be used at a time.

Now, with concurrent database access, this leads to a race condition.
The fix is to ensure we use `with_transaction_and_notifier`, which
triggers notifications *after* the transaction is committed.

Additionally, this commit fixes user loading. Instead of giving up after
the first client record, we now continue trying until no more client
records remain.