### PR TITLE
fix: equality of UiConversationMessage

### DIFF
--- a/app/lib/core/api/markdown.dart
+++ b/app/lib/core/api/markdown.dart
@@ -84,13 +84,12 @@ sealed class InlineElement with _$InlineElement {
   ) = InlineElement_TaskListMarker;
 }
 
-class MessageContent {
-  final List<RangedBlockElement> content;
-
-  const MessageContent({
-    required this.content,
-  });
-
+@freezed
+class MessageContent with _$MessageContent {
+  const MessageContent._();
+  const factory MessageContent({
+    required List<RangedBlockElement> content,
+  }) = _MessageContent;
   static Future<MessageContent> error({required String message}) =>
       RustLib.instance.api
           .crateApiMarkdownMessageContentError(message: message);
@@ -102,86 +101,31 @@ class MessageContent {
   static MessageContent parseMarkdownRaw({required List<int> string}) =>
       RustLib.instance.api
           .crateApiMarkdownMessageContentParseMarkdownRaw(string: string);
-
-  @override
-  int get hashCode => content.hashCode;
-
-  @override
-  bool operator ==(Object other) =>
-      identical(this, other) ||
-      other is MessageContent &&
-          runtimeType == other.runtimeType &&
-          content == other.content;
 }
 
-class RangedBlockElement {
-  final int start;
-  final int end;
-  final BlockElement element;
-
-  const RangedBlockElement({
-    required this.start,
-    required this.end,
-    required this.element,
-  });
-
-  @override
-  int get hashCode => start.hashCode ^ end.hashCode ^ element.hashCode;
-
-  @override
-  bool operator ==(Object other) =>
-      identical(this, other) ||
-      other is RangedBlockElement &&
-          runtimeType == other.runtimeType &&
-          start == other.start &&
-          end == other.end &&
-          element == other.element;
+@freezed
+class RangedBlockElement with _$RangedBlockElement {
+  const factory RangedBlockElement({
+    required int start,
+    required int end,
+    required BlockElement element,
+  }) = _RangedBlockElement;
 }
 
-class RangedCodeBlock {
-  final int start;
-  final int end;
-  final String value;
-
-  const RangedCodeBlock({
-    required this.start,
-    required this.end,
-    required this.value,
-  });
-
-  @override
-  int get hashCode => start.hashCode ^ end.hashCode ^ value.hashCode;
-
-  @override
-  bool operator ==(Object other) =>
-      identical(this, other) ||
-      other is RangedCodeBlock &&
-          runtimeType == other.runtimeType &&
-          start == other.start &&
-          end == other.end &&
-          value == other.value;
+@freezed
+class RangedCodeBlock with _$RangedCodeBlock {
+  const factory RangedCodeBlock({
+    required int start,
+    required int end,
+    required String value,
+  }) = _RangedCodeBlock;
 }
 
-class RangedInlineElement {
-  final int start;
-  final int end;
-  final InlineElement element;
-
-  const RangedInlineElement({
-    required this.start,
-    required this.end,
-    required this.element,
-  });
-
-  @override
-  int get hashCode => start.hashCode ^ end.hashCode ^ element.hashCode;
-
-  @override
-  bool operator ==(Object other) =>
-      identical(this, other) ||
-      other is RangedInlineElement &&
-          runtimeType == other.runtimeType &&
-          start == other.start &&
-          end == other.end &&
-          element == other.element;
+@freezed
+class RangedInlineElement with _$RangedInlineElement {
+  const factory RangedInlineElement({
+    required int start,
+    required int end,
+    required InlineElement element,
+  }) = _RangedInlineElement;
 }

--- a/app/lib/core/api/markdown.freezed.dart
+++ b/app/lib/core/api/markdown.freezed.dart
@@ -1652,3 +1652,667 @@ abstract class InlineElement_TaskListMarker extends InlineElement {
           _$InlineElement_TaskListMarkerImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
+
+/// @nodoc
+mixin _$MessageContent {
+  List<RangedBlockElement> get content => throw _privateConstructorUsedError;
+
+  /// Create a copy of MessageContent
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $MessageContentCopyWith<MessageContent> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $MessageContentCopyWith<$Res> {
+  factory $MessageContentCopyWith(
+          MessageContent value, $Res Function(MessageContent) then) =
+      _$MessageContentCopyWithImpl<$Res, MessageContent>;
+  @useResult
+  $Res call({List<RangedBlockElement> content});
+}
+
+/// @nodoc
+class _$MessageContentCopyWithImpl<$Res, $Val extends MessageContent>
+    implements $MessageContentCopyWith<$Res> {
+  _$MessageContentCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of MessageContent
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? content = null,
+  }) {
+    return _then(_value.copyWith(
+      content: null == content
+          ? _value.content
+          : content // ignore: cast_nullable_to_non_nullable
+              as List<RangedBlockElement>,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$MessageContentImplCopyWith<$Res>
+    implements $MessageContentCopyWith<$Res> {
+  factory _$$MessageContentImplCopyWith(_$MessageContentImpl value,
+          $Res Function(_$MessageContentImpl) then) =
+      __$$MessageContentImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({List<RangedBlockElement> content});
+}
+
+/// @nodoc
+class __$$MessageContentImplCopyWithImpl<$Res>
+    extends _$MessageContentCopyWithImpl<$Res, _$MessageContentImpl>
+    implements _$$MessageContentImplCopyWith<$Res> {
+  __$$MessageContentImplCopyWithImpl(
+      _$MessageContentImpl _value, $Res Function(_$MessageContentImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of MessageContent
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? content = null,
+  }) {
+    return _then(_$MessageContentImpl(
+      content: null == content
+          ? _value._content
+          : content // ignore: cast_nullable_to_non_nullable
+              as List<RangedBlockElement>,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$MessageContentImpl extends _MessageContent {
+  const _$MessageContentImpl({required final List<RangedBlockElement> content})
+      : _content = content,
+        super._();
+
+  final List<RangedBlockElement> _content;
+  @override
+  List<RangedBlockElement> get content {
+    if (_content is EqualUnmodifiableListView) return _content;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_content);
+  }
+
+  @override
+  String toString() {
+    return 'MessageContent(content: $content)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$MessageContentImpl &&
+            const DeepCollectionEquality().equals(other._content, _content));
+  }
+
+  @override
+  int get hashCode =>
+      Object.hash(runtimeType, const DeepCollectionEquality().hash(_content));
+
+  /// Create a copy of MessageContent
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$MessageContentImplCopyWith<_$MessageContentImpl> get copyWith =>
+      __$$MessageContentImplCopyWithImpl<_$MessageContentImpl>(
+          this, _$identity);
+}
+
+abstract class _MessageContent extends MessageContent {
+  const factory _MessageContent(
+      {required final List<RangedBlockElement> content}) = _$MessageContentImpl;
+  const _MessageContent._() : super._();
+
+  @override
+  List<RangedBlockElement> get content;
+
+  /// Create a copy of MessageContent
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$MessageContentImplCopyWith<_$MessageContentImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+mixin _$RangedBlockElement {
+  int get start => throw _privateConstructorUsedError;
+  int get end => throw _privateConstructorUsedError;
+  BlockElement get element => throw _privateConstructorUsedError;
+
+  /// Create a copy of RangedBlockElement
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $RangedBlockElementCopyWith<RangedBlockElement> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $RangedBlockElementCopyWith<$Res> {
+  factory $RangedBlockElementCopyWith(
+          RangedBlockElement value, $Res Function(RangedBlockElement) then) =
+      _$RangedBlockElementCopyWithImpl<$Res, RangedBlockElement>;
+  @useResult
+  $Res call({int start, int end, BlockElement element});
+
+  $BlockElementCopyWith<$Res> get element;
+}
+
+/// @nodoc
+class _$RangedBlockElementCopyWithImpl<$Res, $Val extends RangedBlockElement>
+    implements $RangedBlockElementCopyWith<$Res> {
+  _$RangedBlockElementCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of RangedBlockElement
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? start = null,
+    Object? end = null,
+    Object? element = null,
+  }) {
+    return _then(_value.copyWith(
+      start: null == start
+          ? _value.start
+          : start // ignore: cast_nullable_to_non_nullable
+              as int,
+      end: null == end
+          ? _value.end
+          : end // ignore: cast_nullable_to_non_nullable
+              as int,
+      element: null == element
+          ? _value.element
+          : element // ignore: cast_nullable_to_non_nullable
+              as BlockElement,
+    ) as $Val);
+  }
+
+  /// Create a copy of RangedBlockElement
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $BlockElementCopyWith<$Res> get element {
+    return $BlockElementCopyWith<$Res>(_value.element, (value) {
+      return _then(_value.copyWith(element: value) as $Val);
+    });
+  }
+}
+
+/// @nodoc
+abstract class _$$RangedBlockElementImplCopyWith<$Res>
+    implements $RangedBlockElementCopyWith<$Res> {
+  factory _$$RangedBlockElementImplCopyWith(_$RangedBlockElementImpl value,
+          $Res Function(_$RangedBlockElementImpl) then) =
+      __$$RangedBlockElementImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({int start, int end, BlockElement element});
+
+  @override
+  $BlockElementCopyWith<$Res> get element;
+}
+
+/// @nodoc
+class __$$RangedBlockElementImplCopyWithImpl<$Res>
+    extends _$RangedBlockElementCopyWithImpl<$Res, _$RangedBlockElementImpl>
+    implements _$$RangedBlockElementImplCopyWith<$Res> {
+  __$$RangedBlockElementImplCopyWithImpl(_$RangedBlockElementImpl _value,
+      $Res Function(_$RangedBlockElementImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of RangedBlockElement
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? start = null,
+    Object? end = null,
+    Object? element = null,
+  }) {
+    return _then(_$RangedBlockElementImpl(
+      start: null == start
+          ? _value.start
+          : start // ignore: cast_nullable_to_non_nullable
+              as int,
+      end: null == end
+          ? _value.end
+          : end // ignore: cast_nullable_to_non_nullable
+              as int,
+      element: null == element
+          ? _value.element
+          : element // ignore: cast_nullable_to_non_nullable
+              as BlockElement,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$RangedBlockElementImpl implements _RangedBlockElement {
+  const _$RangedBlockElementImpl(
+      {required this.start, required this.end, required this.element});
+
+  @override
+  final int start;
+  @override
+  final int end;
+  @override
+  final BlockElement element;
+
+  @override
+  String toString() {
+    return 'RangedBlockElement(start: $start, end: $end, element: $element)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$RangedBlockElementImpl &&
+            (identical(other.start, start) || other.start == start) &&
+            (identical(other.end, end) || other.end == end) &&
+            (identical(other.element, element) || other.element == element));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, start, end, element);
+
+  /// Create a copy of RangedBlockElement
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$RangedBlockElementImplCopyWith<_$RangedBlockElementImpl> get copyWith =>
+      __$$RangedBlockElementImplCopyWithImpl<_$RangedBlockElementImpl>(
+          this, _$identity);
+}
+
+abstract class _RangedBlockElement implements RangedBlockElement {
+  const factory _RangedBlockElement(
+      {required final int start,
+      required final int end,
+      required final BlockElement element}) = _$RangedBlockElementImpl;
+
+  @override
+  int get start;
+  @override
+  int get end;
+  @override
+  BlockElement get element;
+
+  /// Create a copy of RangedBlockElement
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$RangedBlockElementImplCopyWith<_$RangedBlockElementImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+mixin _$RangedCodeBlock {
+  int get start => throw _privateConstructorUsedError;
+  int get end => throw _privateConstructorUsedError;
+  String get value => throw _privateConstructorUsedError;
+
+  /// Create a copy of RangedCodeBlock
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $RangedCodeBlockCopyWith<RangedCodeBlock> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $RangedCodeBlockCopyWith<$Res> {
+  factory $RangedCodeBlockCopyWith(
+          RangedCodeBlock value, $Res Function(RangedCodeBlock) then) =
+      _$RangedCodeBlockCopyWithImpl<$Res, RangedCodeBlock>;
+  @useResult
+  $Res call({int start, int end, String value});
+}
+
+/// @nodoc
+class _$RangedCodeBlockCopyWithImpl<$Res, $Val extends RangedCodeBlock>
+    implements $RangedCodeBlockCopyWith<$Res> {
+  _$RangedCodeBlockCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of RangedCodeBlock
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? start = null,
+    Object? end = null,
+    Object? value = null,
+  }) {
+    return _then(_value.copyWith(
+      start: null == start
+          ? _value.start
+          : start // ignore: cast_nullable_to_non_nullable
+              as int,
+      end: null == end
+          ? _value.end
+          : end // ignore: cast_nullable_to_non_nullable
+              as int,
+      value: null == value
+          ? _value.value
+          : value // ignore: cast_nullable_to_non_nullable
+              as String,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$RangedCodeBlockImplCopyWith<$Res>
+    implements $RangedCodeBlockCopyWith<$Res> {
+  factory _$$RangedCodeBlockImplCopyWith(_$RangedCodeBlockImpl value,
+          $Res Function(_$RangedCodeBlockImpl) then) =
+      __$$RangedCodeBlockImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({int start, int end, String value});
+}
+
+/// @nodoc
+class __$$RangedCodeBlockImplCopyWithImpl<$Res>
+    extends _$RangedCodeBlockCopyWithImpl<$Res, _$RangedCodeBlockImpl>
+    implements _$$RangedCodeBlockImplCopyWith<$Res> {
+  __$$RangedCodeBlockImplCopyWithImpl(
+      _$RangedCodeBlockImpl _value, $Res Function(_$RangedCodeBlockImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of RangedCodeBlock
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? start = null,
+    Object? end = null,
+    Object? value = null,
+  }) {
+    return _then(_$RangedCodeBlockImpl(
+      start: null == start
+          ? _value.start
+          : start // ignore: cast_nullable_to_non_nullable
+              as int,
+      end: null == end
+          ? _value.end
+          : end // ignore: cast_nullable_to_non_nullable
+              as int,
+      value: null == value
+          ? _value.value
+          : value // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$RangedCodeBlockImpl implements _RangedCodeBlock {
+  const _$RangedCodeBlockImpl(
+      {required this.start, required this.end, required this.value});
+
+  @override
+  final int start;
+  @override
+  final int end;
+  @override
+  final String value;
+
+  @override
+  String toString() {
+    return 'RangedCodeBlock(start: $start, end: $end, value: $value)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$RangedCodeBlockImpl &&
+            (identical(other.start, start) || other.start == start) &&
+            (identical(other.end, end) || other.end == end) &&
+            (identical(other.value, value) || other.value == value));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, start, end, value);
+
+  /// Create a copy of RangedCodeBlock
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$RangedCodeBlockImplCopyWith<_$RangedCodeBlockImpl> get copyWith =>
+      __$$RangedCodeBlockImplCopyWithImpl<_$RangedCodeBlockImpl>(
+          this, _$identity);
+}
+
+abstract class _RangedCodeBlock implements RangedCodeBlock {
+  const factory _RangedCodeBlock(
+      {required final int start,
+      required final int end,
+      required final String value}) = _$RangedCodeBlockImpl;
+
+  @override
+  int get start;
+  @override
+  int get end;
+  @override
+  String get value;
+
+  /// Create a copy of RangedCodeBlock
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$RangedCodeBlockImplCopyWith<_$RangedCodeBlockImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+mixin _$RangedInlineElement {
+  int get start => throw _privateConstructorUsedError;
+  int get end => throw _privateConstructorUsedError;
+  InlineElement get element => throw _privateConstructorUsedError;
+
+  /// Create a copy of RangedInlineElement
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $RangedInlineElementCopyWith<RangedInlineElement> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $RangedInlineElementCopyWith<$Res> {
+  factory $RangedInlineElementCopyWith(
+          RangedInlineElement value, $Res Function(RangedInlineElement) then) =
+      _$RangedInlineElementCopyWithImpl<$Res, RangedInlineElement>;
+  @useResult
+  $Res call({int start, int end, InlineElement element});
+
+  $InlineElementCopyWith<$Res> get element;
+}
+
+/// @nodoc
+class _$RangedInlineElementCopyWithImpl<$Res, $Val extends RangedInlineElement>
+    implements $RangedInlineElementCopyWith<$Res> {
+  _$RangedInlineElementCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of RangedInlineElement
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? start = null,
+    Object? end = null,
+    Object? element = null,
+  }) {
+    return _then(_value.copyWith(
+      start: null == start
+          ? _value.start
+          : start // ignore: cast_nullable_to_non_nullable
+              as int,
+      end: null == end
+          ? _value.end
+          : end // ignore: cast_nullable_to_non_nullable
+              as int,
+      element: null == element
+          ? _value.element
+          : element // ignore: cast_nullable_to_non_nullable
+              as InlineElement,
+    ) as $Val);
+  }
+
+  /// Create a copy of RangedInlineElement
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $InlineElementCopyWith<$Res> get element {
+    return $InlineElementCopyWith<$Res>(_value.element, (value) {
+      return _then(_value.copyWith(element: value) as $Val);
+    });
+  }
+}
+
+/// @nodoc
+abstract class _$$RangedInlineElementImplCopyWith<$Res>
+    implements $RangedInlineElementCopyWith<$Res> {
+  factory _$$RangedInlineElementImplCopyWith(_$RangedInlineElementImpl value,
+          $Res Function(_$RangedInlineElementImpl) then) =
+      __$$RangedInlineElementImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({int start, int end, InlineElement element});
+
+  @override
+  $InlineElementCopyWith<$Res> get element;
+}
+
+/// @nodoc
+class __$$RangedInlineElementImplCopyWithImpl<$Res>
+    extends _$RangedInlineElementCopyWithImpl<$Res, _$RangedInlineElementImpl>
+    implements _$$RangedInlineElementImplCopyWith<$Res> {
+  __$$RangedInlineElementImplCopyWithImpl(_$RangedInlineElementImpl _value,
+      $Res Function(_$RangedInlineElementImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of RangedInlineElement
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? start = null,
+    Object? end = null,
+    Object? element = null,
+  }) {
+    return _then(_$RangedInlineElementImpl(
+      start: null == start
+          ? _value.start
+          : start // ignore: cast_nullable_to_non_nullable
+              as int,
+      end: null == end
+          ? _value.end
+          : end // ignore: cast_nullable_to_non_nullable
+              as int,
+      element: null == element
+          ? _value.element
+          : element // ignore: cast_nullable_to_non_nullable
+              as InlineElement,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$RangedInlineElementImpl implements _RangedInlineElement {
+  const _$RangedInlineElementImpl(
+      {required this.start, required this.end, required this.element});
+
+  @override
+  final int start;
+  @override
+  final int end;
+  @override
+  final InlineElement element;
+
+  @override
+  String toString() {
+    return 'RangedInlineElement(start: $start, end: $end, element: $element)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$RangedInlineElementImpl &&
+            (identical(other.start, start) || other.start == start) &&
+            (identical(other.end, end) || other.end == end) &&
+            (identical(other.element, element) || other.element == element));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, start, end, element);
+
+  /// Create a copy of RangedInlineElement
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$RangedInlineElementImplCopyWith<_$RangedInlineElementImpl> get copyWith =>
+      __$$RangedInlineElementImplCopyWithImpl<_$RangedInlineElementImpl>(
+          this, _$identity);
+}
+
+abstract class _RangedInlineElement implements RangedInlineElement {
+  const factory _RangedInlineElement(
+      {required final int start,
+      required final int end,
+      required final InlineElement element}) = _$RangedInlineElementImpl;
+
+  @override
+  int get start;
+  @override
+  int get end;
+  @override
+  InlineElement get element;
+
+  /// Create a copy of RangedInlineElement
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$RangedInlineElementImplCopyWith<_$RangedInlineElementImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/app/lib/core/api/types.dart
+++ b/app/lib/core/api/types.dart
@@ -395,39 +395,15 @@ sealed class UiMessage with _$UiMessage {
 }
 
 /// The actual content of a message
-class UiMimiContent {
-  final Uint8List? replaces;
-  final Uint8List topicId;
-  final Uint8List? inReplyTo;
-  final String plainBody;
-  final MessageContent content;
-
-  const UiMimiContent({
-    this.replaces,
-    required this.topicId,
-    this.inReplyTo,
-    required this.plainBody,
-    required this.content,
-  });
-
-  @override
-  int get hashCode =>
-      replaces.hashCode ^
-      topicId.hashCode ^
-      inReplyTo.hashCode ^
-      plainBody.hashCode ^
-      content.hashCode;
-
-  @override
-  bool operator ==(Object other) =>
-      identical(this, other) ||
-      other is UiMimiContent &&
-          runtimeType == other.runtimeType &&
-          replaces == other.replaces &&
-          topicId == other.topicId &&
-          inReplyTo == other.inReplyTo &&
-          plainBody == other.plainBody &&
-          content == other.content;
+@freezed
+class UiMimiContent with _$UiMimiContent {
+  const factory UiMimiContent({
+    Uint8List? replaces,
+    required Uint8List topicId,
+    Uint8List? inReplyTo,
+    required String plainBody,
+    required MessageContent content,
+  }) = _UiMimiContent;
 }
 
 /// System message

--- a/app/lib/core/api/types.freezed.dart
+++ b/app/lib/core/api/types.freezed.dart
@@ -816,3 +816,237 @@ abstract class UiMessage_Display extends UiMessage {
   _$$UiMessage_DisplayImplCopyWith<_$UiMessage_DisplayImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
+
+/// @nodoc
+mixin _$UiMimiContent {
+  Uint8List? get replaces => throw _privateConstructorUsedError;
+  Uint8List get topicId => throw _privateConstructorUsedError;
+  Uint8List? get inReplyTo => throw _privateConstructorUsedError;
+  String get plainBody => throw _privateConstructorUsedError;
+  MessageContent get content => throw _privateConstructorUsedError;
+
+  /// Create a copy of UiMimiContent
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $UiMimiContentCopyWith<UiMimiContent> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $UiMimiContentCopyWith<$Res> {
+  factory $UiMimiContentCopyWith(
+          UiMimiContent value, $Res Function(UiMimiContent) then) =
+      _$UiMimiContentCopyWithImpl<$Res, UiMimiContent>;
+  @useResult
+  $Res call(
+      {Uint8List? replaces,
+      Uint8List topicId,
+      Uint8List? inReplyTo,
+      String plainBody,
+      MessageContent content});
+
+  $MessageContentCopyWith<$Res> get content;
+}
+
+/// @nodoc
+class _$UiMimiContentCopyWithImpl<$Res, $Val extends UiMimiContent>
+    implements $UiMimiContentCopyWith<$Res> {
+  _$UiMimiContentCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of UiMimiContent
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? replaces = freezed,
+    Object? topicId = null,
+    Object? inReplyTo = freezed,
+    Object? plainBody = null,
+    Object? content = null,
+  }) {
+    return _then(_value.copyWith(
+      replaces: freezed == replaces
+          ? _value.replaces
+          : replaces // ignore: cast_nullable_to_non_nullable
+              as Uint8List?,
+      topicId: null == topicId
+          ? _value.topicId
+          : topicId // ignore: cast_nullable_to_non_nullable
+              as Uint8List,
+      inReplyTo: freezed == inReplyTo
+          ? _value.inReplyTo
+          : inReplyTo // ignore: cast_nullable_to_non_nullable
+              as Uint8List?,
+      plainBody: null == plainBody
+          ? _value.plainBody
+          : plainBody // ignore: cast_nullable_to_non_nullable
+              as String,
+      content: null == content
+          ? _value.content
+          : content // ignore: cast_nullable_to_non_nullable
+              as MessageContent,
+    ) as $Val);
+  }
+
+  /// Create a copy of UiMimiContent
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $MessageContentCopyWith<$Res> get content {
+    return $MessageContentCopyWith<$Res>(_value.content, (value) {
+      return _then(_value.copyWith(content: value) as $Val);
+    });
+  }
+}
+
+/// @nodoc
+abstract class _$$UiMimiContentImplCopyWith<$Res>
+    implements $UiMimiContentCopyWith<$Res> {
+  factory _$$UiMimiContentImplCopyWith(
+          _$UiMimiContentImpl value, $Res Function(_$UiMimiContentImpl) then) =
+      __$$UiMimiContentImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {Uint8List? replaces,
+      Uint8List topicId,
+      Uint8List? inReplyTo,
+      String plainBody,
+      MessageContent content});
+
+  @override
+  $MessageContentCopyWith<$Res> get content;
+}
+
+/// @nodoc
+class __$$UiMimiContentImplCopyWithImpl<$Res>
+    extends _$UiMimiContentCopyWithImpl<$Res, _$UiMimiContentImpl>
+    implements _$$UiMimiContentImplCopyWith<$Res> {
+  __$$UiMimiContentImplCopyWithImpl(
+      _$UiMimiContentImpl _value, $Res Function(_$UiMimiContentImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of UiMimiContent
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? replaces = freezed,
+    Object? topicId = null,
+    Object? inReplyTo = freezed,
+    Object? plainBody = null,
+    Object? content = null,
+  }) {
+    return _then(_$UiMimiContentImpl(
+      replaces: freezed == replaces
+          ? _value.replaces
+          : replaces // ignore: cast_nullable_to_non_nullable
+              as Uint8List?,
+      topicId: null == topicId
+          ? _value.topicId
+          : topicId // ignore: cast_nullable_to_non_nullable
+              as Uint8List,
+      inReplyTo: freezed == inReplyTo
+          ? _value.inReplyTo
+          : inReplyTo // ignore: cast_nullable_to_non_nullable
+              as Uint8List?,
+      plainBody: null == plainBody
+          ? _value.plainBody
+          : plainBody // ignore: cast_nullable_to_non_nullable
+              as String,
+      content: null == content
+          ? _value.content
+          : content // ignore: cast_nullable_to_non_nullable
+              as MessageContent,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$UiMimiContentImpl implements _UiMimiContent {
+  const _$UiMimiContentImpl(
+      {this.replaces,
+      required this.topicId,
+      this.inReplyTo,
+      required this.plainBody,
+      required this.content});
+
+  @override
+  final Uint8List? replaces;
+  @override
+  final Uint8List topicId;
+  @override
+  final Uint8List? inReplyTo;
+  @override
+  final String plainBody;
+  @override
+  final MessageContent content;
+
+  @override
+  String toString() {
+    return 'UiMimiContent(replaces: $replaces, topicId: $topicId, inReplyTo: $inReplyTo, plainBody: $plainBody, content: $content)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$UiMimiContentImpl &&
+            const DeepCollectionEquality().equals(other.replaces, replaces) &&
+            const DeepCollectionEquality().equals(other.topicId, topicId) &&
+            const DeepCollectionEquality().equals(other.inReplyTo, inReplyTo) &&
+            (identical(other.plainBody, plainBody) ||
+                other.plainBody == plainBody) &&
+            (identical(other.content, content) || other.content == content));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      const DeepCollectionEquality().hash(replaces),
+      const DeepCollectionEquality().hash(topicId),
+      const DeepCollectionEquality().hash(inReplyTo),
+      plainBody,
+      content);
+
+  /// Create a copy of UiMimiContent
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$UiMimiContentImplCopyWith<_$UiMimiContentImpl> get copyWith =>
+      __$$UiMimiContentImplCopyWithImpl<_$UiMimiContentImpl>(this, _$identity);
+}
+
+abstract class _UiMimiContent implements UiMimiContent {
+  const factory _UiMimiContent(
+      {final Uint8List? replaces,
+      required final Uint8List topicId,
+      final Uint8List? inReplyTo,
+      required final String plainBody,
+      required final MessageContent content}) = _$UiMimiContentImpl;
+
+  @override
+  Uint8List? get replaces;
+  @override
+  Uint8List get topicId;
+  @override
+  Uint8List? get inReplyTo;
+  @override
+  String get plainBody;
+  @override
+  MessageContent get content;
+
+  /// Create a copy of UiMimiContent
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$UiMimiContentImplCopyWith<_$UiMimiContentImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/app/test/message_list/message_cubit_test.dart
+++ b/app/test/message_list/message_cubit_test.dart
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025 Phoenix R&D GmbH <hello@phnx.im>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 import 'dart:typed_data';
 
 import 'package:prototype/core/core.dart';

--- a/app/test/message_list/message_cubit_test.dart
+++ b/app/test/message_list/message_cubit_test.dart
@@ -1,0 +1,49 @@
+import 'dart:typed_data';
+
+import 'package:prototype/core/core.dart';
+import 'package:test/test.dart';
+
+import '../conversation_list/conversation_list_content_test.dart';
+import '../helpers.dart';
+
+void main() {
+  group('MessageCubit', () {
+    test('UiConversationMessage equality', () {
+      final a = UiConversationMessage(
+        id: 1.conversationMessageId(),
+        conversationId: 1.conversationId(),
+        timestamp: '2023-01-01T00:00:00.000Z',
+        message: UiMessage_Content(
+          UiContentMessage(
+            sender: 'bob@localhost',
+            sent: true,
+            content: UiMimiContent(
+              plainBody: 'Hello Alice',
+              topicId: Uint8List(0),
+              content: simpleMessage('Hello Alice'),
+            ),
+          ),
+        ),
+        position: UiFlightPosition.single,
+      );
+      final b = UiConversationMessage(
+        id: 1.conversationMessageId(),
+        conversationId: 1.conversationId(),
+        timestamp: '2023-01-01T00:00:00.000Z',
+        message: UiMessage_Content(
+          UiContentMessage(
+            sender: 'bob@localhost',
+            sent: true,
+            content: UiMimiContent(
+              plainBody: 'Hello Alice',
+              topicId: Uint8List(0),
+              content: simpleMessage('Hello Alice'),
+            ),
+          ),
+        ),
+        position: UiFlightPosition.single,
+      );
+      expect(a, equals(b));
+    });
+  });
+}

--- a/applogic/src/api/markdown.rs
+++ b/applogic/src/api/markdown.rs
@@ -40,13 +40,13 @@ pub enum Error {
 type Result<T> = std::result::Result<T, Error>;
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
-#[frb]
+#[frb(dart_metadata = ("freezed"))]
 pub struct MessageContent {
     pub content: Vec<RangedBlockElement>,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
-#[frb]
+#[frb(dart_metadata = ("freezed"))]
 pub struct RangedInlineElement {
     pub start: u32,
     pub end: u32,
@@ -54,7 +54,7 @@ pub struct RangedInlineElement {
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
-#[frb]
+#[frb(dart_metadata = ("freezed"))]
 pub struct RangedBlockElement {
     pub start: u32,
     pub end: u32,
@@ -62,7 +62,7 @@ pub struct RangedBlockElement {
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
-#[frb]
+#[frb(dart_metadata = ("freezed"))]
 pub struct RangedCodeBlock {
     pub start: u32,
     pub end: u32,
@@ -70,7 +70,7 @@ pub struct RangedCodeBlock {
 }
 
 #[derive(Debug, Clone, PartialEq)]
-#[frb]
+#[frb(dart_metadata = ("freezed"))]
 pub struct RangedEvent<'a> {
     pub start: u32,
     pub end: u32,
@@ -78,7 +78,7 @@ pub struct RangedEvent<'a> {
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
-#[frb]
+#[frb(dart_metadata = ("freezed"))]
 pub enum BlockElement {
     Paragraph(Vec<RangedInlineElement>),
     Heading(Vec<RangedInlineElement>),
@@ -98,7 +98,7 @@ pub enum BlockElement {
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
-#[frb]
+#[frb(dart_metadata = ("freezed"))]
 pub enum InlineElement {
     Text(String),
     Code(String),

--- a/applogic/src/api/types.rs
+++ b/applogic/src/api/types.rs
@@ -215,6 +215,7 @@ impl From<Message> for UiMessage {
 
 /// The actual content of a message
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
+#[frb(dart_metadata = ("freezed"))]
 pub struct UiMimiContent {
     pub replaces: Option<Vec<u8>>,
     pub topic_id: Vec<u8>,


### PR DESCRIPTION
Before comparison of Lists inside UiConversationMessage was done via object identity. Now it is done via deep collection equality by switching the type to freezed.