### PR TITLE
perf: jank when showing/hiding keyboard in a conversation

### DIFF
--- a/app/lib/message_list/message_list_view.dart
+++ b/app/lib/message_list/message_list_view.dart
@@ -85,7 +85,7 @@ class _VisibilityConversationTile extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return VisibilityDetector(
-      key: ValueKey(_VisibilityKeyValue(messageId)),
+      key: ValueKey(VisibilityKeyValue(messageId)),
       child: const ConversationTile(),
       onVisibilityChanged: (visibilityInfo) {
         if (visibilityInfo.visibleFraction > 0) {
@@ -99,9 +99,20 @@ class _VisibilityConversationTile extends StatelessWidget {
   }
 }
 
-class _VisibilityKeyValue {
-  const _VisibilityKeyValue(this.id);
+class VisibilityKeyValue {
+  const VisibilityKeyValue(this.id);
   final ConversationMessageId id;
+
+  @override
+  int get hashCode => id.hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is VisibilityKeyValue &&
+            other.id == id);
+  }
 }
 
 final ScrollPhysics _scrollPhysics =

--- a/app/test/message_list/message_list_view_test.dart
+++ b/app/test/message_list/message_list_view_test.dart
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: 2025 Phoenix R&D GmbH <hello@phnx.im>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import 'package:prototype/message_list/message_list.dart';
+import 'package:test/test.dart';
+
+import '../helpers.dart';
+
+void main() {
+  group('MessageListView', () {
+    test('VisibilityKeyValue equality', () {
+      final a = VisibilityKeyValue(1.conversationMessageId());
+      final b = VisibilityKeyValue(1.conversationMessageId());
+      expect(a, equals(b));
+
+      final c = VisibilityKeyValue(1.conversationMessageId());
+      final d = VisibilityKeyValue(2.conversationMessageId());
+      expect(c, isNot(equals(d)));
+    });
+  });
+}


### PR DESCRIPTION
The comparison of the visibility key was based on the idenity comparison and not the equality of the ids.

Closes #375 