### PR TITLE
fix: back navigation from conversation

### DIFF
--- a/app/lib/conversation_list/conversation_list_content.dart
+++ b/app/lib/conversation_list/conversation_list_content.dart
@@ -62,8 +62,8 @@ class _ListTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final currentConversationId =
-        context.select((NavigationCubit cubit) => cubit.state.conversationId);
+    final currentConversationId = context
+        .select((NavigationCubit cubit) => cubit.state.openConversationId);
     final isSelected = currentConversationId == conversation.id;
     return ListTile(
       horizontalTitleGap: 0,

--- a/app/lib/core/api/navigation_cubit.dart
+++ b/app/lib/core/api/navigation_cubit.dart
@@ -73,6 +73,7 @@ enum DeveloperSettingsScreenType {
 class HomeNavigationState with _$HomeNavigationState {
   const HomeNavigationState._();
   const factory HomeNavigationState({
+    @Default(false) bool conversationOpen,
     ConversationId? conversationId,
     DeveloperSettingsScreenType? developerSettingsScreen,
     String? memberDetails,

--- a/app/lib/core/api/navigation_cubit.freezed.dart
+++ b/app/lib/core/api/navigation_cubit.freezed.dart
@@ -16,6 +16,7 @@ final _privateConstructorUsedError = UnsupportedError(
 
 /// @nodoc
 mixin _$HomeNavigationState {
+  bool get conversationOpen => throw _privateConstructorUsedError;
   ConversationId? get conversationId => throw _privateConstructorUsedError;
   DeveloperSettingsScreenType? get developerSettingsScreen =>
       throw _privateConstructorUsedError;
@@ -38,7 +39,8 @@ abstract class $HomeNavigationStateCopyWith<$Res> {
       _$HomeNavigationStateCopyWithImpl<$Res, HomeNavigationState>;
   @useResult
   $Res call(
-      {ConversationId? conversationId,
+      {bool conversationOpen,
+      ConversationId? conversationId,
       DeveloperSettingsScreenType? developerSettingsScreen,
       String? memberDetails,
       bool userSettingsOpen,
@@ -61,6 +63,7 @@ class _$HomeNavigationStateCopyWithImpl<$Res, $Val extends HomeNavigationState>
   @pragma('vm:prefer-inline')
   @override
   $Res call({
+    Object? conversationOpen = null,
     Object? conversationId = freezed,
     Object? developerSettingsScreen = freezed,
     Object? memberDetails = freezed,
@@ -69,6 +72,10 @@ class _$HomeNavigationStateCopyWithImpl<$Res, $Val extends HomeNavigationState>
     Object? addMembersOpen = null,
   }) {
     return _then(_value.copyWith(
+      conversationOpen: null == conversationOpen
+          ? _value.conversationOpen
+          : conversationOpen // ignore: cast_nullable_to_non_nullable
+              as bool,
       conversationId: freezed == conversationId
           ? _value.conversationId
           : conversationId // ignore: cast_nullable_to_non_nullable
@@ -106,7 +113,8 @@ abstract class _$$HomeNavigationStateImplCopyWith<$Res>
   @override
   @useResult
   $Res call(
-      {ConversationId? conversationId,
+      {bool conversationOpen,
+      ConversationId? conversationId,
       DeveloperSettingsScreenType? developerSettingsScreen,
       String? memberDetails,
       bool userSettingsOpen,
@@ -127,6 +135,7 @@ class __$$HomeNavigationStateImplCopyWithImpl<$Res>
   @pragma('vm:prefer-inline')
   @override
   $Res call({
+    Object? conversationOpen = null,
     Object? conversationId = freezed,
     Object? developerSettingsScreen = freezed,
     Object? memberDetails = freezed,
@@ -135,6 +144,10 @@ class __$$HomeNavigationStateImplCopyWithImpl<$Res>
     Object? addMembersOpen = null,
   }) {
     return _then(_$HomeNavigationStateImpl(
+      conversationOpen: null == conversationOpen
+          ? _value.conversationOpen
+          : conversationOpen // ignore: cast_nullable_to_non_nullable
+              as bool,
       conversationId: freezed == conversationId
           ? _value.conversationId
           : conversationId // ignore: cast_nullable_to_non_nullable
@@ -167,7 +180,8 @@ class __$$HomeNavigationStateImplCopyWithImpl<$Res>
 
 class _$HomeNavigationStateImpl extends _HomeNavigationState {
   const _$HomeNavigationStateImpl(
-      {this.conversationId,
+      {this.conversationOpen = false,
+      this.conversationId,
       this.developerSettingsScreen,
       this.memberDetails,
       this.userSettingsOpen = false,
@@ -175,6 +189,9 @@ class _$HomeNavigationStateImpl extends _HomeNavigationState {
       this.addMembersOpen = false})
       : super._();
 
+  @override
+  @JsonKey()
+  final bool conversationOpen;
   @override
   final ConversationId? conversationId;
   @override
@@ -193,7 +210,7 @@ class _$HomeNavigationStateImpl extends _HomeNavigationState {
 
   @override
   String toString() {
-    return 'HomeNavigationState(conversationId: $conversationId, developerSettingsScreen: $developerSettingsScreen, memberDetails: $memberDetails, userSettingsOpen: $userSettingsOpen, conversationDetailsOpen: $conversationDetailsOpen, addMembersOpen: $addMembersOpen)';
+    return 'HomeNavigationState(conversationOpen: $conversationOpen, conversationId: $conversationId, developerSettingsScreen: $developerSettingsScreen, memberDetails: $memberDetails, userSettingsOpen: $userSettingsOpen, conversationDetailsOpen: $conversationDetailsOpen, addMembersOpen: $addMembersOpen)';
   }
 
   @override
@@ -201,6 +218,8 @@ class _$HomeNavigationStateImpl extends _HomeNavigationState {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$HomeNavigationStateImpl &&
+            (identical(other.conversationOpen, conversationOpen) ||
+                other.conversationOpen == conversationOpen) &&
             (identical(other.conversationId, conversationId) ||
                 other.conversationId == conversationId) &&
             (identical(
@@ -220,6 +239,7 @@ class _$HomeNavigationStateImpl extends _HomeNavigationState {
   @override
   int get hashCode => Object.hash(
       runtimeType,
+      conversationOpen,
       conversationId,
       developerSettingsScreen,
       memberDetails,
@@ -239,7 +259,8 @@ class _$HomeNavigationStateImpl extends _HomeNavigationState {
 
 abstract class _HomeNavigationState extends HomeNavigationState {
   const factory _HomeNavigationState(
-      {final ConversationId? conversationId,
+      {final bool conversationOpen,
+      final ConversationId? conversationId,
       final DeveloperSettingsScreenType? developerSettingsScreen,
       final String? memberDetails,
       final bool userSettingsOpen,
@@ -247,6 +268,8 @@ abstract class _HomeNavigationState extends HomeNavigationState {
       final bool addMembersOpen}) = _$HomeNavigationStateImpl;
   const _HomeNavigationState._() : super._();
 
+  @override
+  bool get conversationOpen;
   @override
   ConversationId? get conversationId;
   @override

--- a/app/lib/core/core_extension.dart
+++ b/app/lib/core/core_extension.dart
@@ -65,8 +65,14 @@ extension ImageDataExtension on Uint8List {
 
 extension NavigationStateExtension on NavigationState {
   ConversationId? get conversationId => switch (this) {
-        NavigationState_Intro() => null,
         NavigationState_Home(:final home) => home.conversationId,
+        NavigationState_Intro() => null,
+      };
+
+  ConversationId? get openConversationId => switch (this) {
+        NavigationState_Home(:final home) when home.conversationOpen =>
+          home.conversationId,
+        NavigationState_Intro() || NavigationState_Home() => null,
       };
 }
 

--- a/app/lib/core/frb_generated.dart
+++ b/app/lib/core/frb_generated.dart
@@ -3724,16 +3724,17 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   HomeNavigationState dco_decode_home_navigation_state(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
-    if (arr.length != 6)
-      throw Exception('unexpected arr length: expect 6 but see ${arr.length}');
+    if (arr.length != 7)
+      throw Exception('unexpected arr length: expect 7 but see ${arr.length}');
     return HomeNavigationState(
-      conversationId: dco_decode_opt_box_autoadd_conversation_id(arr[0]),
+      conversationOpen: dco_decode_bool(arr[0]),
+      conversationId: dco_decode_opt_box_autoadd_conversation_id(arr[1]),
       developerSettingsScreen:
-          dco_decode_opt_box_autoadd_developer_settings_screen_type(arr[1]),
-      memberDetails: dco_decode_opt_String(arr[2]),
-      userSettingsOpen: dco_decode_bool(arr[3]),
-      conversationDetailsOpen: dco_decode_bool(arr[4]),
-      addMembersOpen: dco_decode_bool(arr[5]),
+          dco_decode_opt_box_autoadd_developer_settings_screen_type(arr[2]),
+      memberDetails: dco_decode_opt_String(arr[3]),
+      userSettingsOpen: dco_decode_bool(arr[4]),
+      conversationDetailsOpen: dco_decode_bool(arr[5]),
+      addMembersOpen: dco_decode_bool(arr[6]),
     );
   }
 
@@ -5069,6 +5070,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   HomeNavigationState sse_decode_home_navigation_state(
       SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_conversationOpen = sse_decode_bool(deserializer);
     var var_conversationId =
         sse_decode_opt_box_autoadd_conversation_id(deserializer);
     var var_developerSettingsScreen =
@@ -5078,6 +5080,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     var var_conversationDetailsOpen = sse_decode_bool(deserializer);
     var var_addMembersOpen = sse_decode_bool(deserializer);
     return HomeNavigationState(
+        conversationOpen: var_conversationOpen,
         conversationId: var_conversationId,
         developerSettingsScreen: var_developerSettingsScreen,
         memberDetails: var_memberDetails,
@@ -6608,6 +6611,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   void sse_encode_home_navigation_state(
       HomeNavigationState self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_bool(self.conversationOpen, serializer);
     sse_encode_opt_box_autoadd_conversation_id(self.conversationId, serializer);
     sse_encode_opt_box_autoadd_developer_settings_screen_type(
         self.developerSettingsScreen, serializer);

--- a/app/lib/navigation/app_router.dart
+++ b/app/lib/navigation/app_router.dart
@@ -173,24 +173,30 @@ extension on HomeNavigationState {
           key: ValueKey("user-settings-screen"),
           child: UserSettingsScreen(),
         ),
-      if (conversationId != null && screenType == ResponsiveScreenType.mobile)
+      if (conversationId != null &&
+          conversationOpen &&
+          screenType == ResponsiveScreenType.mobile)
         const MaterialPage(
           key: ValueKey("conversation-screen"),
           child: ConversationScreen(),
         ),
-      if (conversationId != null && conversationDetailsOpen)
+      if (conversationId != null && conversationOpen && conversationDetailsOpen)
         const MaterialPage(
           key: ValueKey("conversation-details-screen"),
           child: ConversationDetailsScreen(),
         ),
       if (conversationId != null &&
+          conversationOpen &&
           conversationDetailsOpen &&
           memberDetails != null)
         const MaterialPage(
           key: ValueKey("conversation-member-details-screen"),
           child: MemberDetailsScreen(),
         ),
-      if (conversationId != null && conversationDetailsOpen && addMembersOpen)
+      if (conversationId != null &&
+          conversationOpen &&
+          conversationDetailsOpen &&
+          addMembersOpen)
         const MaterialPage(
           key: ValueKey("add-members-screen"),
           child: AddMembersScreen(),

--- a/applogic/src/frb_generated.rs
+++ b/applogic/src/frb_generated.rs
@@ -4661,6 +4661,7 @@ impl SseDecode for crate::api::navigation_cubit::DeveloperSettingsScreenType {
 impl SseDecode for crate::api::navigation_cubit::HomeNavigationState {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_conversationOpen = <bool>::sse_decode(deserializer);
         let mut var_conversationId =
             <Option<crate::api::types::ConversationId>>::sse_decode(deserializer);
         let mut var_developerSettingsScreen = <Option<
@@ -4671,6 +4672,7 @@ impl SseDecode for crate::api::navigation_cubit::HomeNavigationState {
         let mut var_conversationDetailsOpen = <bool>::sse_decode(deserializer);
         let mut var_addMembersOpen = <bool>::sse_decode(deserializer);
         return crate::api::navigation_cubit::HomeNavigationState {
+            conversation_open: var_conversationOpen,
             conversation_id: var_conversationId,
             developer_settings_screen: var_developerSettingsScreen,
             member_details: var_memberDetails,
@@ -6029,6 +6031,7 @@ impl flutter_rust_bridge::IntoIntoDart<crate::api::navigation_cubit::DeveloperSe
 impl flutter_rust_bridge::IntoDart for crate::api::navigation_cubit::HomeNavigationState {
     fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
         [
+            self.conversation_open.into_into_dart().into_dart(),
             self.conversation_id.into_into_dart().into_dart(),
             self.developer_settings_screen.into_into_dart().into_dart(),
             self.member_details.into_into_dart().into_dart(),
@@ -7226,6 +7229,7 @@ impl SseEncode for crate::api::navigation_cubit::DeveloperSettingsScreenType {
 impl SseEncode for crate::api::navigation_cubit::HomeNavigationState {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <bool>::sse_encode(self.conversation_open, serializer);
         <Option<crate::api::types::ConversationId>>::sse_encode(self.conversation_id, serializer);
         <Option<crate::api::navigation_cubit::DeveloperSettingsScreenType>>::sse_encode(
             self.developer_settings_screen,


### PR DESCRIPTION
When navigating back from a conversation (in mobile view) to the conversation list, the conversation view was briefly cleared before the actual navigation occurred. This happened because the pop route set the conversation ID to `null`, causing the entire conversation view to be rebuilt.

This commit introduces a flag in the navigation state that indicates whether a conversation is open, independent of the conversation ID. This allows navigation back while keeping the conversation ID unchanged, preventing unnecessary rebuilding of the conversation view.