### PR TITLE
fix: race between the first state notification and sink

### DIFF
--- a/applogic/src/util/cubit_core.rs
+++ b/applogic/src/util/cubit_core.rs
@@ -143,15 +143,16 @@ where
                 changed = state_rx.changed() => {
                     if changed.is_err() {
                         return;
-                    };
-                    let state = state_rx.borrow().clone();
-                    trace!(num_sinks = sinks.len(), ?state, "emitting new state");
-                    sinks.retain(|sink| sink.add(state.clone()).is_ok());
+                    }
                 },
                 _ = stop.cancelled() => {
                     return;
                 }
             }
+
+            let state = state_rx.borrow_and_update().clone();
+            trace!(num_sinks = sinks.len(), ?state, "emitting new state");
+            sinks.retain(|sink| sink.add(state.clone()).is_ok());
         }
     }
 }


### PR DESCRIPTION
At times, the sink was added *after* the initial state notification. Now, we ensure the state is always observed after a sink has been added.