### PR TITLE
chore: store notifications for already stored user profiles

### DIFF
--- a/coreclient/src/user_profiles/persistence.rs
+++ b/coreclient/src/user_profiles/persistence.rs
@@ -56,7 +56,7 @@ impl UserProfile {
         executor: impl SqliteExecutor<'_>,
         notifier: &mut StoreNotifier,
     ) -> sqlx::Result<()> {
-        query!(
+        let res = query!(
             "INSERT OR IGNORE INTO users (user_name, display_name, profile_picture)
             VALUES (?, ?, ?)",
             self.user_name,
@@ -65,8 +65,9 @@ impl UserProfile {
         )
         .execute(executor)
         .await?;
-        // TODO(#369): We can skip this notification if the user profile was already stored.
-        notifier.add(self.user_name.clone());
+        if res.rows_affected() > 0 {
+            notifier.add(self.user_name.clone());
+        }
         Ok(())
     }
 


### PR DESCRIPTION
Avoid sending store notifications when the user profile is already stored (on ignore conflict).

Closes #369