### PR TITLE
refactor: only mount the conversation details cubit once

### DIFF
--- a/app/lib/app.dart
+++ b/app/lib/app.dart
@@ -212,6 +212,8 @@ class ConversationDetailsCubitProvider extends StatelessWidget {
           return child;
         }
         return BlocProvider(
+          // rebuilds the cubit when a different conversation is selected
+          key: ValueKey("conversation-details-cubit-$conversationId"),
           create:
               (context) => ConversationDetailsCubit(
                 userCubit: context.read<UserCubit>(),

--- a/app/lib/conversation_details/conversation_details_screen.dart
+++ b/app/lib/conversation_details/conversation_details_screen.dart
@@ -5,7 +5,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:prototype/core/core.dart';
-import 'package:prototype/navigation/navigation.dart';
 import 'package:prototype/widgets/widgets.dart';
 
 import 'connection_details.dart';
@@ -20,22 +19,7 @@ class ConversationDetailsScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final conversationId = context.select(
-      (NavigationCubit cubit) => cubit.state.conversationId,
-    );
-    if (conversationId == null) {
-      throw StateError("an active conversation is obligatory");
-    }
-
-    return BlocProvider(
-      key: ValueKey(conversationId),
-      create:
-          (context) => ConversationDetailsCubit(
-            userCubit: context.read(),
-            conversationId: conversationId,
-          ),
-      child: const ConversationDetailsScreenView(),
-    );
+    return const ConversationDetailsScreenView();
   }
 }
 

--- a/app/lib/conversation_details/conversation_screen.dart
+++ b/app/lib/conversation_details/conversation_screen.dart
@@ -30,15 +30,6 @@ class ConversationScreen extends StatelessWidget {
       providers: [
         BlocProvider(
           // rebuilds the cubit when a different conversation is selected
-          key: ValueKey("conversation-detail-cubit-$conversationId"),
-          create:
-              (context) => ConversationDetailsCubit(
-                userCubit: context.read<UserCubit>(),
-                conversationId: conversationId,
-              ),
-        ),
-        BlocProvider(
-          // rebuilds the cubit when a different conversation is selected
           key: ValueKey("message-list-cubit-$conversationId"),
           create:
               (context) => MessageListCubit(


### PR DESCRIPTION
In particular, this also allows to use the conversation details state from any screen, as long as a conversation is open.