### PR TITLE
fix: idle connection termination

### DIFF
--- a/applogic/src/api/user_cubit.rs
+++ b/applogic/src/api/user_cubit.rs
@@ -295,7 +295,7 @@ fn spawn_listen(
             .await;
 
             // stop handler on cancellation
-            if let Ok(true) = res {
+            if cancel.is_cancelled() {
                 return;
             }
 
@@ -325,7 +325,7 @@ async fn run_listen(
     notification_service: &NotificationService,
     cancel: &CancellationToken,
     backoff: &mut FibonacciBackoff,
-) -> anyhow::Result<bool> {
+) -> anyhow::Result<()> {
     let mut queue_stream = core_user.listen_queue().await?;
     info!("listening to the queue");
 
@@ -335,8 +335,8 @@ async fn run_listen(
 
         let event = tokio::select! {
             event = queue_stream.next() => event,
-            _ = in_background => return Ok(false),
-            _ = cancel.cancelled() => return Ok(true),
+            _ = in_background => return Ok(()),
+            _ = cancel.cancelled() => return Ok(()),
         };
 
         match event {

--- a/deployment/ingress-nginx-values.yaml
+++ b/deployment/ingress-nginx-values.yaml
@@ -24,7 +24,8 @@ controller:
                         }
                       ],
                       "properties": {
-                        "http2_enabled": false
+                        "http2_enabled": false,
+                        "timeout_client": 3600
                       }
                     },
                     {
@@ -44,7 +45,8 @@ controller:
                         }
                       ],
                       "properties": {
-                        "http2_enabled": true
+                        "http2_enabled": true,
+                        "timeout_client": 3600
                       }
                     }
                   ],
@@ -54,7 +56,8 @@ controller:
                       "properties": {
                         "outbound_proxy_protocol": "v2",
                         "http2_enabled": false,
-                        "tls_enabled": true
+                        "tls_enabled": true,
+                        "timeout_server": 3600
                       }
                     },
                     {
@@ -62,7 +65,8 @@ controller:
                       "properties": {
                         "outbound_proxy_protocol": "v2",
                         "http2_enabled": true,
-                        "tls_enabled": true
+                        "tls_enabled": true,
+                        "timeout_server": 3600
                       }
                     }
                   ]

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -100,6 +100,7 @@ pub async fn run<
     let health_service = configure_health_service::<Qc, Np>().await;
 
     tonic::transport::Server::builder()
+        .http2_keepalive_interval(Some(Duration::from_secs(30)))
         .layer(InterceptorLayer::new(ConnectInfoInterceptor))
         .layer(
             TraceLayer::new_for_grpc()


### PR DESCRIPTION
Connections to the backend were terminated after 10 seconds of inactivity. Turns out the load balancer of upcloud has a configuration parameter for this. Now we set it to 1 hour.

Also 
* Fix listen cancellation in user cubit.
* Add http2 keep alive on the server-side. This prevents the reverse proxy to terminate connections to the backend when it is idle.