### PR TITLE
feat: add localization support

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,3 +8,5 @@ applogic/src/frb_generated.rs linguist-generated=true
 app/lib/core/api/** linguist-generated=true
 app/lib/core/frb_**.dart linguist-generated=true
 app/lib/core/notifications.dart linguist-generated=true
+app/lib/l10n/app_localizations.dart linguist-generated=true
+app/lib/l10n/app_localizations_*.dart linguist-generated=true

--- a/.github/workflows/flutter_test.yml
+++ b/.github/workflows/flutter_test.yml
@@ -16,6 +16,17 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  flutter-check-localizations:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: extractions/setup-just@v2
+      - name: Set up Flutter FVM
+        uses: kuhnroyal/flutter-fvm-config-action/setup@v3
+        with:
+          path: 'app/.fvmrc'
+      - run: just check-localizations
+
   flutter-test:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/flutter_test.yml
+++ b/.github/workflows/flutter_test.yml
@@ -25,7 +25,7 @@ jobs:
         uses: kuhnroyal/flutter-fvm-config-action/setup@v3
         with:
           path: 'app/.fvmrc'
-      - run: just check-localizations
+      - run: just check-l10n
 
   flutter-test:
     runs-on: ubuntu-latest

--- a/app/l10n.yaml
+++ b/app/l10n.yaml
@@ -1,0 +1,5 @@
+arb-dir: lib/l10n
+template-arb-file: app_en.arb
+output-localization-file: app_localizations.dart
+nullable-getter: false
+synthetic-package: false

--- a/app/l10n.yaml
+++ b/app/l10n.yaml
@@ -1,5 +1,13 @@
+# SPDX-FileCopyrightText: 2025 Phoenix R&D GmbH <hello@phnx.im>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 arb-dir: lib/l10n
 template-arb-file: app_en.arb
 output-localization-file: app_localizations.dart
 nullable-getter: false
 synthetic-package: false
+header: |
+  // SPDX-FileCopyrightText: 2025 Phoenix R&D GmbH <hello@phnx.im>
+  //
+  // SPDX-License-Identifier: AGPL-3.0-or-later

--- a/app/l10n.yaml
+++ b/app/l10n.yaml
@@ -7,6 +7,7 @@ template-arb-file: app_en.arb
 output-localization-file: app_localizations.dart
 nullable-getter: false
 synthetic-package: false
+format: true
 header: |
   // SPDX-FileCopyrightText: 2025 Phoenix R&D GmbH <hello@phnx.im>
   //

--- a/app/lib/app.dart
+++ b/app/lib/app.dart
@@ -11,9 +11,10 @@ import 'package:logging/logging.dart';
 import 'package:permission_handler/permission_handler.dart';
 import 'package:prototype/background_service.dart';
 import 'package:prototype/core/core.dart';
+import 'package:prototype/l10n/l10n.dart';
 import 'package:prototype/navigation/navigation.dart';
-import 'package:prototype/util/platform.dart';
 import 'package:prototype/user/user.dart';
+import 'package:prototype/util/platform.dart';
 import 'package:provider/provider.dart';
 
 import 'conversation_details/conversation_details.dart';
@@ -110,7 +111,9 @@ class _AppState extends State<App> with WidgetsBindingObserver {
         ),
       ],
       child: MaterialApp.router(
-        title: 'Prototype',
+        onGenerateTitle: (context) => AppLocalizations.of(context).appTitle,
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
         debugShowCheckedModeBanner: false,
         theme: themeData(context),
         routerConfig: _appRouter,

--- a/app/lib/conversation_details/add_members_screen.dart
+++ b/app/lib/conversation_details/add_members_screen.dart
@@ -4,6 +4,7 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:prototype/l10n/app_localizations.dart';
 import 'package:prototype/core/core.dart';
 import 'package:prototype/navigation/navigation.dart';
 import 'package:prototype/theme/theme.dart';
@@ -39,13 +40,15 @@ class AddMembersScreenView extends StatelessWidget {
       ),
     );
 
+    final loc = AppLocalizations.of(context);
+
     return Scaffold(
       appBar: AppBar(
         backgroundColor: Colors.white,
         elevation: 0,
         scrolledUnderElevation: 0,
         leading: const AppBarBackButton(),
-        title: const Text("Add members"),
+        title: Text(loc.addMembersScreen_title),
       ),
       body: Padding(
         padding: const EdgeInsets.all(32.0),
@@ -99,15 +102,11 @@ class AddMembersScreenView extends StatelessWidget {
                   onPressed:
                       selectedContacts.isNotEmpty
                           ? () async {
-                            _addSelectedContacts(
-                              context.read<NavigationCubit>(),
-                              context.read<UserCubit>(),
-                              selectedContacts,
-                            );
+                            _addSelectedContacts(context, selectedContacts);
                           }
                           : null,
                   style: buttonStyle(context, selectedContacts.isNotEmpty),
-                  child: const Text("Add member(s)"),
+                  child: Text(loc.addMembersScreen_addMembers),
                 ),
               ],
             ),
@@ -118,17 +117,19 @@ class AddMembersScreenView extends StatelessWidget {
   }
 
   void _addSelectedContacts(
-    NavigationCubit navigation,
-    UserCubit userCubit,
+    BuildContext context,
     Set<UiUserId> selectedContacts,
   ) async {
-    final conversationId = navigation.state.conversationId;
+    final navigationCubit = context.read<NavigationCubit>();
+    final userCubit = context.read<UserCubit>();
+    final conversationId = navigationCubit.state.conversationId;
+    final loc = AppLocalizations.of(context);
     if (conversationId == null) {
-      throw StateError("an active conversation is obligatory");
+      throw StateError(loc.addMembersScreen_error_noActiveConversation);
     }
     for (final userId in selectedContacts) {
       await userCubit.addUserToConversation(conversationId, userId);
     }
-    navigation.pop();
+    navigationCubit.pop();
   }
 }

--- a/app/lib/conversation_details/conversation_details_screen.dart
+++ b/app/lib/conversation_details/conversation_details_screen.dart
@@ -5,6 +5,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:prototype/core/core.dart';
+import 'package:prototype/l10n/l10n.dart';
 import 'package:prototype/widgets/widgets.dart';
 
 import 'connection_details.dart';
@@ -34,19 +35,23 @@ class ConversationDetailsScreenView extends StatelessWidget {
           cubit.state.conversation?.conversationType,
     );
 
+    final loc = AppLocalizations.of(context);
+
     return Scaffold(
       appBar: AppBar(
         backgroundColor: Colors.white,
         elevation: 0,
         scrolledUnderElevation: 0,
         leading: const AppBarBackButton(),
-        title: const Text("Details"),
+        title: Text(loc.conversationDetailsScreen_title),
       ),
       body: switch (conversationType) {
         UiConversationType_UnconfirmedConnection() ||
         UiConversationType_Connection() => const ConnectionDetails(),
         UiConversationType_Group() => const GroupDetails(),
-        null => const Center(child: Text("Unknown conversation")),
+        null => Center(
+          child: Text(loc.conversationDetailsScreen_unknownConversation),
+        ),
       },
     );
   }

--- a/app/lib/conversation_details/conversation_screen.dart
+++ b/app/lib/conversation_details/conversation_screen.dart
@@ -5,6 +5,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:prototype/core/core.dart';
+import 'package:prototype/l10n/l10n.dart';
 import 'package:prototype/message_list/message_list.dart';
 import 'package:prototype/navigation/navigation.dart';
 import 'package:prototype/theme/theme.dart';
@@ -48,13 +49,14 @@ class _EmptyConversationPane extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final loc = AppLocalizations.of(context);
     return Scaffold(
       body: Center(
         child: Text(
           style: Theme.of(
             context,
           ).textTheme.labelMedium?.copyWith(color: colorDMB),
-          "Select a chat to start messaging",
+          loc.conversationScreen_emptyConversation,
         ),
       ),
     );

--- a/app/lib/conversation_details/member_details_screen.dart
+++ b/app/lib/conversation_details/member_details_screen.dart
@@ -4,6 +4,7 @@
 
 import 'package:flutter/material.dart';
 import 'package:prototype/core/core.dart';
+import 'package:prototype/l10n/l10n.dart';
 import 'package:prototype/navigation/navigation.dart';
 import 'package:prototype/theme/theme.dart';
 import 'package:prototype/user/user.dart';
@@ -18,10 +19,12 @@ class MemberDetailsScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final loc = AppLocalizations.of(context);
+
     final (conversationId, memberClientId) = context.select(
       (NavigationCubit cubit) => switch (cubit.state) {
         NavigationState_Intro(:final screens) =>
-          throw StateError("No member details for intro screen"),
+          throw StateError(loc.memberDetailsScreen_error),
         NavigationState_Home(
           home: HomeNavigationState(
             conversationId: final conversationId,
@@ -32,9 +35,7 @@ class MemberDetailsScreen extends StatelessWidget {
       },
     );
 
-    final ownClientId = context.select(
-      (UserCubit cubit) => cubit.state.userId,
-    );
+    final ownClientId = context.select((UserCubit cubit) => cubit.state.userId);
     final isSelf = memberClientId == ownClientId;
 
     if (conversationId == null || memberClientId == null) {
@@ -47,7 +48,7 @@ class MemberDetailsScreen extends StatelessWidget {
         elevation: 0,
         scrolledUnderElevation: 0,
         leading: const AppBarBackButton(),
-        title: const Text("Member details"),
+        title: Text(loc.memberDetailsScreen_title),
       ),
       body: Center(
         child: Column(
@@ -81,17 +82,15 @@ class MemberDetailsScreen extends StatelessWidget {
                         context: context,
                         builder: (BuildContext context) {
                           return AlertDialog(
-                            title: const Text("Remove user"),
-                            content: const Text(
-                              "Are you sure you want to remove this user from the group?",
-                            ),
+                            title: Text(loc.removeUserDialog_title),
+                            content: Text(loc.removeUserDialog_content),
                             actions: [
                               TextButton(
                                 onPressed: () {
                                   Navigator.of(context).pop(false);
                                 },
                                 style: textButtonStyle(context),
-                                child: const Text("Cancel"),
+                                child: Text(loc.removeUserDialog_cancel),
                               ),
                               TextButton(
                                 onPressed: () async {
@@ -106,7 +105,7 @@ class MemberDetailsScreen extends StatelessWidget {
                                   }
                                 },
                                 style: textButtonStyle(context),
-                                child: const Text("Remove user"),
+                                child: Text(loc.removeUserDialog_removeUser),
                               ),
                             ],
                           );
@@ -116,7 +115,7 @@ class MemberDetailsScreen extends StatelessWidget {
                         Navigator.of(context).pop(true);
                       }
                     },
-                    child: const Text("Remove user"),
+                    child: Text(loc.removeUserButton_text),
                   ),
                 )
                 : const SizedBox.shrink(),

--- a/app/lib/conversation_list/conversation_list_footer.dart
+++ b/app/lib/conversation_list/conversation_list_footer.dart
@@ -53,10 +53,7 @@ class ConversationListFooter extends StatelessWidget {
                   connectionUuid,
                   ValidationMode.nonStrict,
                 );
-                final connectionId = UiUserId(
-                  uuid: clientUuid,
-                  domain: domain,
-                );
+                final connectionId = UiUserId(uuid: clientUuid, domain: domain);
                 try {
                   await conversationListCubit.createConnection(
                     userId: connectionId,

--- a/app/lib/intro_screen.dart
+++ b/app/lib/intro_screen.dart
@@ -4,10 +4,10 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:prototype/l10n/l10n.dart';
+import 'package:prototype/navigation/navigation.dart';
 import 'package:prototype/user/user.dart';
 import 'package:prototype/theme/theme.dart';
-
-import 'navigation/navigation.dart';
 
 class IntroScreen extends StatelessWidget {
   const IntroScreen({super.key});
@@ -17,6 +17,8 @@ class IntroScreen extends StatelessWidget {
     final isUserLoading = context.select((LoadableUserCubit cubit) {
       return cubit.state is LoadingUser;
     });
+
+    final loc = AppLocalizations.of(context);
 
     return Scaffold(
       body: Center(
@@ -35,7 +37,7 @@ class IntroScreen extends StatelessWidget {
                 color: Colors.grey[350],
               ),
               _GradientText(
-                "Prototype.",
+                loc.appTitle,
                 gradient: const LinearGradient(
                   colors: [
                     Color.fromARGB(255, 34, 163, 255),
@@ -54,7 +56,7 @@ class IntroScreen extends StatelessWidget {
                     () =>
                         context.read<NavigationCubit>().openDeveloperSettings(),
                 style: textButtonStyle(context),
-                child: const Text('Developer Settings'),
+                child: Text(loc.introScreen_developerSettings),
               ),
               if (!isUserLoading)
                 Column(
@@ -70,7 +72,7 @@ class IntroScreen extends StatelessWidget {
                                   .read<NavigationCubit>()
                                   .openServerChoice(),
                       style: buttonStyle(context, true),
-                      child: const Text('Sign up'),
+                      child: Text(loc.introScreen_signUp),
                     ),
                   ],
                 ),

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -1,0 +1,45 @@
+{
+  "appTitle": "Prototype",
+
+  "userSettingsScreen_title": "User Settings",
+  "userSettingsScreen_idCopied": "User ID copied to clipboard",
+  "userSettingsScreen_profileDescription": "Others will see your picture and name when you communicate with them.",
+  "userSettingsScreen_userNamesDescription": "Share usernames with others so they can connect with you. After the connection, usernames are not visible to others anymore. You can have up to 5 usernames.",
+  "removeUsernameDialog_title": "Remove Username",
+  "removeUsernameDialog_content": "If you continue, your username will be removed and may be claimed by someone else. You’ll no longer be reachable through it.",
+  "removeUsernameDialog_cancel": "Cancel",
+  "removeUsernameDialog_remove": "Remove",
+  "userSettingsScreen_noUserHandles": "no user handles yet",
+  "userSettingsScreen_userHandlePlaceholder": "Username",
+
+  "addMembersScreen_title": "Add members",
+  "addMembersScreen_addMembers": "Add member(s)",
+  "addMembersScreen_error_noActiveConversation": "an active conversation is obligatory",
+
+  "conversationDetailsScreen_title": "Details",
+  "conversationDetailsScreen_unknownConversation": "Unknown conversation",
+
+  "conversationScreen_emptyConversation": "Select a chat to start messaging",
+
+  "memberDetailsScreen_title": "Member details",
+  "memberDetailsScreen_error": "No member details for intro screen",
+  "removeUserDialog_title": "Remove user",
+  "removeUserDialog_content": "Are you sure you want to remove this user from the group?",
+  "removeUserDialog_cancel": "Cancel",
+  "removeUserDialog_removeUser": "Remove user",
+  "removeUserButton_text": "Remove user",
+
+  "introScreen_developerSettings": "Developer Settings",
+  "introScreen_signUp": "Sign up",
+
+  "userHandleScreen_title": "Username",
+  "userHandleScreen_inputHint": "Username",
+  "userHandleScreen_error_emptyHandle": "User handle cannot be empty",
+  "userHandleScreen_description": "Choose a username that others can use to connect with you.\n\nUse letters, numbers, or underscores. Minimum 5 characters.",
+  "userHandleScreen_save": "Save",
+
+  "editDisplayNameScreen_title": "Display Name",
+  "editDisplayNameScreen_hintText": "Display name",
+  "editDisplayNameScreen_description": "Choose a name that others will see when you communicate with them.",
+  "editDisplayNameScreen_save": "Save"
+}

--- a/app/lib/l10n/app_en.arb.license
+++ b/app/lib/l10n/app_en.arb.license
@@ -1,5 +1,3 @@
 // SPDX-FileCopyrightText: 2025 Phoenix R&D GmbH <hello@phnx.im>
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
-
-export 'app_localizations.dart' show AppLocalizations;

--- a/app/lib/l10n/app_localizations.dart
+++ b/app/lib/l10n/app_localizations.dart
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025 Phoenix R&D GmbH <hello@phnx.im>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 import 'dart:async';
 
 import 'package:flutter/foundation.dart';

--- a/app/lib/l10n/app_localizations.dart
+++ b/app/lib/l10n/app_localizations.dart
@@ -65,7 +65,8 @@ import 'app_localizations_en.dart';
 /// be consistent with the languages listed in the AppLocalizations.supportedLocales
 /// property.
 abstract class AppLocalizations {
-  AppLocalizations(String locale) : localeName = intl.Intl.canonicalizedLocale(locale.toString());
+  AppLocalizations(String locale)
+    : localeName = intl.Intl.canonicalizedLocale(locale.toString());
 
   final String localeName;
 
@@ -73,7 +74,8 @@ abstract class AppLocalizations {
     return Localizations.of<AppLocalizations>(context, AppLocalizations)!;
   }
 
-  static const LocalizationsDelegate<AppLocalizations> delegate = _AppLocalizationsDelegate();
+  static const LocalizationsDelegate<AppLocalizations> delegate =
+      _AppLocalizationsDelegate();
 
   /// A list of this localizations delegate along with the default localizations
   /// delegates.
@@ -85,17 +87,16 @@ abstract class AppLocalizations {
   /// Additional delegates can be added by appending to this list in
   /// MaterialApp. This list does not have to be used at all if a custom list
   /// of delegates is preferred or required.
-  static const List<LocalizationsDelegate<dynamic>> localizationsDelegates = <LocalizationsDelegate<dynamic>>[
-    delegate,
-    GlobalMaterialLocalizations.delegate,
-    GlobalCupertinoLocalizations.delegate,
-    GlobalWidgetsLocalizations.delegate,
-  ];
+  static const List<LocalizationsDelegate<dynamic>> localizationsDelegates =
+      <LocalizationsDelegate<dynamic>>[
+        delegate,
+        GlobalMaterialLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+      ];
 
   /// A list of this localizations delegate's supported locales.
-  static const List<Locale> supportedLocales = <Locale>[
-    Locale('en')
-  ];
+  static const List<Locale> supportedLocales = <Locale>[Locale('en')];
 
   /// No description provided for @appTitle.
   ///
@@ -308,7 +309,8 @@ abstract class AppLocalizations {
   String get editDisplayNameScreen_save;
 }
 
-class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {
+class _AppLocalizationsDelegate
+    extends LocalizationsDelegate<AppLocalizations> {
   const _AppLocalizationsDelegate();
 
   @override
@@ -317,24 +319,24 @@ class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> 
   }
 
   @override
-  bool isSupported(Locale locale) => <String>['en'].contains(locale.languageCode);
+  bool isSupported(Locale locale) =>
+      <String>['en'].contains(locale.languageCode);
 
   @override
   bool shouldReload(_AppLocalizationsDelegate old) => false;
 }
 
 AppLocalizations lookupAppLocalizations(Locale locale) {
-
-
   // Lookup logic when only language code is specified.
   switch (locale.languageCode) {
-    case 'en': return AppLocalizationsEn();
+    case 'en':
+      return AppLocalizationsEn();
   }
 
   throw FlutterError(
     'AppLocalizations.delegate failed to load unsupported locale "$locale". This is likely '
     'an issue with the localizations generation tool. Please file an issue '
     'on GitHub with a reproducible sample app and the gen-l10n configuration '
-    'that was used.'
+    'that was used.',
   );
 }

--- a/app/lib/l10n/app_localizations.dart
+++ b/app/lib/l10n/app_localizations.dart
@@ -1,0 +1,336 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:intl/intl.dart' as intl;
+
+import 'app_localizations_en.dart';
+
+// ignore_for_file: type=lint
+
+/// Callers can lookup localized strings with an instance of AppLocalizations
+/// returned by `AppLocalizations.of(context)`.
+///
+/// Applications need to include `AppLocalizations.delegate()` in their app's
+/// `localizationDelegates` list, and the locales they support in the app's
+/// `supportedLocales` list. For example:
+///
+/// ```dart
+/// import 'l10n/app_localizations.dart';
+///
+/// return MaterialApp(
+///   localizationsDelegates: AppLocalizations.localizationsDelegates,
+///   supportedLocales: AppLocalizations.supportedLocales,
+///   home: MyApplicationHome(),
+/// );
+/// ```
+///
+/// ## Update pubspec.yaml
+///
+/// Please make sure to update your pubspec.yaml to include the following
+/// packages:
+///
+/// ```yaml
+/// dependencies:
+///   # Internationalization support.
+///   flutter_localizations:
+///     sdk: flutter
+///   intl: any # Use the pinned version from flutter_localizations
+///
+///   # Rest of dependencies
+/// ```
+///
+/// ## iOS Applications
+///
+/// iOS applications define key application metadata, including supported
+/// locales, in an Info.plist file that is built into the application bundle.
+/// To configure the locales supported by your app, you’ll need to edit this
+/// file.
+///
+/// First, open your project’s ios/Runner.xcworkspace Xcode workspace file.
+/// Then, in the Project Navigator, open the Info.plist file under the Runner
+/// project’s Runner folder.
+///
+/// Next, select the Information Property List item, select Add Item from the
+/// Editor menu, then select Localizations from the pop-up menu.
+///
+/// Select and expand the newly-created Localizations item then, for each
+/// locale your application supports, add a new item and select the locale
+/// you wish to add from the pop-up menu in the Value field. This list should
+/// be consistent with the languages listed in the AppLocalizations.supportedLocales
+/// property.
+abstract class AppLocalizations {
+  AppLocalizations(String locale) : localeName = intl.Intl.canonicalizedLocale(locale.toString());
+
+  final String localeName;
+
+  static AppLocalizations of(BuildContext context) {
+    return Localizations.of<AppLocalizations>(context, AppLocalizations)!;
+  }
+
+  static const LocalizationsDelegate<AppLocalizations> delegate = _AppLocalizationsDelegate();
+
+  /// A list of this localizations delegate along with the default localizations
+  /// delegates.
+  ///
+  /// Returns a list of localizations delegates containing this delegate along with
+  /// GlobalMaterialLocalizations.delegate, GlobalCupertinoLocalizations.delegate,
+  /// and GlobalWidgetsLocalizations.delegate.
+  ///
+  /// Additional delegates can be added by appending to this list in
+  /// MaterialApp. This list does not have to be used at all if a custom list
+  /// of delegates is preferred or required.
+  static const List<LocalizationsDelegate<dynamic>> localizationsDelegates = <LocalizationsDelegate<dynamic>>[
+    delegate,
+    GlobalMaterialLocalizations.delegate,
+    GlobalCupertinoLocalizations.delegate,
+    GlobalWidgetsLocalizations.delegate,
+  ];
+
+  /// A list of this localizations delegate's supported locales.
+  static const List<Locale> supportedLocales = <Locale>[
+    Locale('en')
+  ];
+
+  /// No description provided for @appTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Prototype'**
+  String get appTitle;
+
+  /// No description provided for @userSettingsScreen_title.
+  ///
+  /// In en, this message translates to:
+  /// **'User Settings'**
+  String get userSettingsScreen_title;
+
+  /// No description provided for @userSettingsScreen_idCopied.
+  ///
+  /// In en, this message translates to:
+  /// **'User ID copied to clipboard'**
+  String get userSettingsScreen_idCopied;
+
+  /// No description provided for @userSettingsScreen_profileDescription.
+  ///
+  /// In en, this message translates to:
+  /// **'Others will see your picture and name when you communicate with them.'**
+  String get userSettingsScreen_profileDescription;
+
+  /// No description provided for @userSettingsScreen_userNamesDescription.
+  ///
+  /// In en, this message translates to:
+  /// **'Share usernames with others so they can connect with you. After the connection, usernames are not visible to others anymore. You can have up to 5 usernames.'**
+  String get userSettingsScreen_userNamesDescription;
+
+  /// No description provided for @removeUsernameDialog_title.
+  ///
+  /// In en, this message translates to:
+  /// **'Remove Username'**
+  String get removeUsernameDialog_title;
+
+  /// No description provided for @removeUsernameDialog_content.
+  ///
+  /// In en, this message translates to:
+  /// **'If you continue, your username will be removed and may be claimed by someone else. You’ll no longer be reachable through it.'**
+  String get removeUsernameDialog_content;
+
+  /// No description provided for @removeUsernameDialog_cancel.
+  ///
+  /// In en, this message translates to:
+  /// **'Cancel'**
+  String get removeUsernameDialog_cancel;
+
+  /// No description provided for @removeUsernameDialog_remove.
+  ///
+  /// In en, this message translates to:
+  /// **'Remove'**
+  String get removeUsernameDialog_remove;
+
+  /// No description provided for @userSettingsScreen_noUserHandles.
+  ///
+  /// In en, this message translates to:
+  /// **'no user handles yet'**
+  String get userSettingsScreen_noUserHandles;
+
+  /// No description provided for @userSettingsScreen_userHandlePlaceholder.
+  ///
+  /// In en, this message translates to:
+  /// **'Username'**
+  String get userSettingsScreen_userHandlePlaceholder;
+
+  /// No description provided for @addMembersScreen_title.
+  ///
+  /// In en, this message translates to:
+  /// **'Add members'**
+  String get addMembersScreen_title;
+
+  /// No description provided for @addMembersScreen_addMembers.
+  ///
+  /// In en, this message translates to:
+  /// **'Add member(s)'**
+  String get addMembersScreen_addMembers;
+
+  /// No description provided for @addMembersScreen_error_noActiveConversation.
+  ///
+  /// In en, this message translates to:
+  /// **'an active conversation is obligatory'**
+  String get addMembersScreen_error_noActiveConversation;
+
+  /// No description provided for @conversationDetailsScreen_title.
+  ///
+  /// In en, this message translates to:
+  /// **'Details'**
+  String get conversationDetailsScreen_title;
+
+  /// No description provided for @conversationDetailsScreen_unknownConversation.
+  ///
+  /// In en, this message translates to:
+  /// **'Unknown conversation'**
+  String get conversationDetailsScreen_unknownConversation;
+
+  /// No description provided for @conversationScreen_emptyConversation.
+  ///
+  /// In en, this message translates to:
+  /// **'Select a chat to start messaging'**
+  String get conversationScreen_emptyConversation;
+
+  /// No description provided for @memberDetailsScreen_title.
+  ///
+  /// In en, this message translates to:
+  /// **'Member details'**
+  String get memberDetailsScreen_title;
+
+  /// No description provided for @memberDetailsScreen_error.
+  ///
+  /// In en, this message translates to:
+  /// **'No member details for intro screen'**
+  String get memberDetailsScreen_error;
+
+  /// No description provided for @removeUserDialog_title.
+  ///
+  /// In en, this message translates to:
+  /// **'Remove user'**
+  String get removeUserDialog_title;
+
+  /// No description provided for @removeUserDialog_content.
+  ///
+  /// In en, this message translates to:
+  /// **'Are you sure you want to remove this user from the group?'**
+  String get removeUserDialog_content;
+
+  /// No description provided for @removeUserDialog_cancel.
+  ///
+  /// In en, this message translates to:
+  /// **'Cancel'**
+  String get removeUserDialog_cancel;
+
+  /// No description provided for @removeUserDialog_removeUser.
+  ///
+  /// In en, this message translates to:
+  /// **'Remove user'**
+  String get removeUserDialog_removeUser;
+
+  /// No description provided for @removeUserButton_text.
+  ///
+  /// In en, this message translates to:
+  /// **'Remove user'**
+  String get removeUserButton_text;
+
+  /// No description provided for @introScreen_developerSettings.
+  ///
+  /// In en, this message translates to:
+  /// **'Developer Settings'**
+  String get introScreen_developerSettings;
+
+  /// No description provided for @introScreen_signUp.
+  ///
+  /// In en, this message translates to:
+  /// **'Sign up'**
+  String get introScreen_signUp;
+
+  /// No description provided for @userHandleScreen_title.
+  ///
+  /// In en, this message translates to:
+  /// **'Username'**
+  String get userHandleScreen_title;
+
+  /// No description provided for @userHandleScreen_inputHint.
+  ///
+  /// In en, this message translates to:
+  /// **'Username'**
+  String get userHandleScreen_inputHint;
+
+  /// No description provided for @userHandleScreen_error_emptyHandle.
+  ///
+  /// In en, this message translates to:
+  /// **'User handle cannot be empty'**
+  String get userHandleScreen_error_emptyHandle;
+
+  /// No description provided for @userHandleScreen_description.
+  ///
+  /// In en, this message translates to:
+  /// **'Choose a username that others can use to connect with you.\n\nUse letters, numbers, or underscores. Minimum 5 characters.'**
+  String get userHandleScreen_description;
+
+  /// No description provided for @userHandleScreen_save.
+  ///
+  /// In en, this message translates to:
+  /// **'Save'**
+  String get userHandleScreen_save;
+
+  /// No description provided for @editDisplayNameScreen_title.
+  ///
+  /// In en, this message translates to:
+  /// **'Display Name'**
+  String get editDisplayNameScreen_title;
+
+  /// No description provided for @editDisplayNameScreen_hintText.
+  ///
+  /// In en, this message translates to:
+  /// **'Display name'**
+  String get editDisplayNameScreen_hintText;
+
+  /// No description provided for @editDisplayNameScreen_description.
+  ///
+  /// In en, this message translates to:
+  /// **'Choose a name that others will see when you communicate with them.'**
+  String get editDisplayNameScreen_description;
+
+  /// No description provided for @editDisplayNameScreen_save.
+  ///
+  /// In en, this message translates to:
+  /// **'Save'**
+  String get editDisplayNameScreen_save;
+}
+
+class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {
+  const _AppLocalizationsDelegate();
+
+  @override
+  Future<AppLocalizations> load(Locale locale) {
+    return SynchronousFuture<AppLocalizations>(lookupAppLocalizations(locale));
+  }
+
+  @override
+  bool isSupported(Locale locale) => <String>['en'].contains(locale.languageCode);
+
+  @override
+  bool shouldReload(_AppLocalizationsDelegate old) => false;
+}
+
+AppLocalizations lookupAppLocalizations(Locale locale) {
+
+
+  // Lookup logic when only language code is specified.
+  switch (locale.languageCode) {
+    case 'en': return AppLocalizationsEn();
+  }
+
+  throw FlutterError(
+    'AppLocalizations.delegate failed to load unsupported locale "$locale". This is likely '
+    'an issue with the localizations generation tool. Please file an issue '
+    'on GitHub with a reproducible sample app and the gen-l10n configuration '
+    'that was used.'
+  );
+}

--- a/app/lib/l10n/app_localizations_en.dart
+++ b/app/lib/l10n/app_localizations_en.dart
@@ -2,7 +2,6 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
 import 'app_localizations.dart';
@@ -23,16 +22,19 @@ class AppLocalizationsEn extends AppLocalizations {
   String get userSettingsScreen_idCopied => 'User ID copied to clipboard';
 
   @override
-  String get userSettingsScreen_profileDescription => 'Others will see your picture and name when you communicate with them.';
+  String get userSettingsScreen_profileDescription =>
+      'Others will see your picture and name when you communicate with them.';
 
   @override
-  String get userSettingsScreen_userNamesDescription => 'Share usernames with others so they can connect with you. After the connection, usernames are not visible to others anymore. You can have up to 5 usernames.';
+  String get userSettingsScreen_userNamesDescription =>
+      'Share usernames with others so they can connect with you. After the connection, usernames are not visible to others anymore. You can have up to 5 usernames.';
 
   @override
   String get removeUsernameDialog_title => 'Remove Username';
 
   @override
-  String get removeUsernameDialog_content => 'If you continue, your username will be removed and may be claimed by someone else. You’ll no longer be reachable through it.';
+  String get removeUsernameDialog_content =>
+      'If you continue, your username will be removed and may be claimed by someone else. You’ll no longer be reachable through it.';
 
   @override
   String get removeUsernameDialog_cancel => 'Cancel';
@@ -53,16 +55,19 @@ class AppLocalizationsEn extends AppLocalizations {
   String get addMembersScreen_addMembers => 'Add member(s)';
 
   @override
-  String get addMembersScreen_error_noActiveConversation => 'an active conversation is obligatory';
+  String get addMembersScreen_error_noActiveConversation =>
+      'an active conversation is obligatory';
 
   @override
   String get conversationDetailsScreen_title => 'Details';
 
   @override
-  String get conversationDetailsScreen_unknownConversation => 'Unknown conversation';
+  String get conversationDetailsScreen_unknownConversation =>
+      'Unknown conversation';
 
   @override
-  String get conversationScreen_emptyConversation => 'Select a chat to start messaging';
+  String get conversationScreen_emptyConversation =>
+      'Select a chat to start messaging';
 
   @override
   String get memberDetailsScreen_title => 'Member details';
@@ -74,7 +79,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get removeUserDialog_title => 'Remove user';
 
   @override
-  String get removeUserDialog_content => 'Are you sure you want to remove this user from the group?';
+  String get removeUserDialog_content =>
+      'Are you sure you want to remove this user from the group?';
 
   @override
   String get removeUserDialog_cancel => 'Cancel';
@@ -98,10 +104,12 @@ class AppLocalizationsEn extends AppLocalizations {
   String get userHandleScreen_inputHint => 'Username';
 
   @override
-  String get userHandleScreen_error_emptyHandle => 'User handle cannot be empty';
+  String get userHandleScreen_error_emptyHandle =>
+      'User handle cannot be empty';
 
   @override
-  String get userHandleScreen_description => 'Choose a username that others can use to connect with you.\n\nUse letters, numbers, or underscores. Minimum 5 characters.';
+  String get userHandleScreen_description =>
+      'Choose a username that others can use to connect with you.\n\nUse letters, numbers, or underscores. Minimum 5 characters.';
 
   @override
   String get userHandleScreen_save => 'Save';
@@ -113,7 +121,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get editDisplayNameScreen_hintText => 'Display name';
 
   @override
-  String get editDisplayNameScreen_description => 'Choose a name that others will see when you communicate with them.';
+  String get editDisplayNameScreen_description =>
+      'Choose a name that others will see when you communicate with them.';
 
   @override
   String get editDisplayNameScreen_save => 'Save';

--- a/app/lib/l10n/app_localizations_en.dart
+++ b/app/lib/l10n/app_localizations_en.dart
@@ -1,3 +1,8 @@
+// SPDX-FileCopyrightText: 2025 Phoenix R&D GmbH <hello@phnx.im>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
 import 'app_localizations.dart';

--- a/app/lib/l10n/app_localizations_en.dart
+++ b/app/lib/l10n/app_localizations_en.dart
@@ -1,0 +1,115 @@
+// ignore: unused_import
+import 'package:intl/intl.dart' as intl;
+import 'app_localizations.dart';
+
+// ignore_for_file: type=lint
+
+/// The translations for English (`en`).
+class AppLocalizationsEn extends AppLocalizations {
+  AppLocalizationsEn([String locale = 'en']) : super(locale);
+
+  @override
+  String get appTitle => 'Prototype';
+
+  @override
+  String get userSettingsScreen_title => 'User Settings';
+
+  @override
+  String get userSettingsScreen_idCopied => 'User ID copied to clipboard';
+
+  @override
+  String get userSettingsScreen_profileDescription => 'Others will see your picture and name when you communicate with them.';
+
+  @override
+  String get userSettingsScreen_userNamesDescription => 'Share usernames with others so they can connect with you. After the connection, usernames are not visible to others anymore. You can have up to 5 usernames.';
+
+  @override
+  String get removeUsernameDialog_title => 'Remove Username';
+
+  @override
+  String get removeUsernameDialog_content => 'If you continue, your username will be removed and may be claimed by someone else. You’ll no longer be reachable through it.';
+
+  @override
+  String get removeUsernameDialog_cancel => 'Cancel';
+
+  @override
+  String get removeUsernameDialog_remove => 'Remove';
+
+  @override
+  String get userSettingsScreen_noUserHandles => 'no user handles yet';
+
+  @override
+  String get userSettingsScreen_userHandlePlaceholder => 'Username';
+
+  @override
+  String get addMembersScreen_title => 'Add members';
+
+  @override
+  String get addMembersScreen_addMembers => 'Add member(s)';
+
+  @override
+  String get addMembersScreen_error_noActiveConversation => 'an active conversation is obligatory';
+
+  @override
+  String get conversationDetailsScreen_title => 'Details';
+
+  @override
+  String get conversationDetailsScreen_unknownConversation => 'Unknown conversation';
+
+  @override
+  String get conversationScreen_emptyConversation => 'Select a chat to start messaging';
+
+  @override
+  String get memberDetailsScreen_title => 'Member details';
+
+  @override
+  String get memberDetailsScreen_error => 'No member details for intro screen';
+
+  @override
+  String get removeUserDialog_title => 'Remove user';
+
+  @override
+  String get removeUserDialog_content => 'Are you sure you want to remove this user from the group?';
+
+  @override
+  String get removeUserDialog_cancel => 'Cancel';
+
+  @override
+  String get removeUserDialog_removeUser => 'Remove user';
+
+  @override
+  String get removeUserButton_text => 'Remove user';
+
+  @override
+  String get introScreen_developerSettings => 'Developer Settings';
+
+  @override
+  String get introScreen_signUp => 'Sign up';
+
+  @override
+  String get userHandleScreen_title => 'Username';
+
+  @override
+  String get userHandleScreen_inputHint => 'Username';
+
+  @override
+  String get userHandleScreen_error_emptyHandle => 'User handle cannot be empty';
+
+  @override
+  String get userHandleScreen_description => 'Choose a username that others can use to connect with you.\n\nUse letters, numbers, or underscores. Minimum 5 characters.';
+
+  @override
+  String get userHandleScreen_save => 'Save';
+
+  @override
+  String get editDisplayNameScreen_title => 'Display Name';
+
+  @override
+  String get editDisplayNameScreen_hintText => 'Display name';
+
+  @override
+  String get editDisplayNameScreen_description => 'Choose a name that others will see when you communicate with them.';
+
+  @override
+  String get editDisplayNameScreen_save => 'Save';
+}

--- a/app/lib/l10n/l10n.dart
+++ b/app/lib/l10n/l10n.dart
@@ -1,0 +1,1 @@
+export 'app_localizations.dart' show AppLocalizations;

--- a/app/lib/user/add_user_handle_screen.dart
+++ b/app/lib/user/add_user_handle_screen.dart
@@ -3,7 +3,8 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import 'package:flutter/material.dart';
-import 'package:prototype/core/core.dart' show UiUserHandle;
+import 'package:prototype/core/core.dart';
+import 'package:prototype/l10n/l10n.dart';
 import 'package:prototype/navigation/navigation.dart';
 import 'package:prototype/theme/theme.dart';
 import 'package:prototype/user/user.dart';
@@ -29,9 +30,10 @@ class _AddUserHandleScreenState extends State<AddUserHandleScreen> {
 
   @override
   Widget build(BuildContext context) {
+    final loc = AppLocalizations.of(context);
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Username'),
+        title: Text(loc.userHandleScreen_title),
         toolbarHeight: isPointer() ? 100 : null,
         leading: const AppBarBackButton(),
       ),
@@ -52,11 +54,13 @@ class _AddUserHandleScreenState extends State<AddUserHandleScreen> {
                   TextFormField(
                     autofocus: true,
                     controller: _controller,
-                    decoration: const InputDecoration(hintText: "Username"),
+                    decoration: InputDecoration(
+                      hintText: loc.userHandleScreen_inputHint,
+                    ),
                     style: inputTextStyle(context),
                     validator: (value) {
                       if (value == null || value.trim().isEmpty) {
-                        return 'User handle cannot be empty';
+                        return loc.userHandleScreen_error_emptyHandle;
                       }
                       final handle = UiUserHandle(
                         plaintext: value.trim().toLowerCase(),
@@ -73,9 +77,7 @@ class _AddUserHandleScreenState extends State<AddUserHandleScreen> {
                       ),
                       child: Text(
                         style: TextStyle(color: Theme.of(context).hintColor),
-                        "Choose a username that others can use to connect with you."
-                        "\n\n"
-                        "Use letters, numbers, or underscores. Minimum 5 characters.",
+                        loc.userHandleScreen_description,
                       ),
                     ),
                   ),
@@ -83,7 +85,7 @@ class _AddUserHandleScreenState extends State<AddUserHandleScreen> {
                   OutlinedButton(
                     onPressed: () => _submit(context),
                     style: buttonStyle(context, true),
-                    child: const Text('Save'),
+                    child: Text(loc.userHandleScreen_save),
                   ),
                 ],
               ),

--- a/app/lib/user/edit_display_name_screen.dart
+++ b/app/lib/user/edit_display_name_screen.dart
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import 'package:flutter/material.dart';
+import 'package:prototype/l10n/l10n.dart';
 import 'package:prototype/navigation/navigation.dart';
 import 'package:prototype/theme/theme.dart';
 import 'package:prototype/user/user.dart';
@@ -38,9 +39,11 @@ class _EditDisplayNameScreenState extends State<EditDisplayNameScreen> {
       (UserCubit cubit) => cubit.state.profilePicture,
     );
 
+    final loc = AppLocalizations.of(context);
+
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Display Name'),
+        title: Text(loc.editDisplayNameScreen_title),
         toolbarHeight: isPointer() ? 100 : null,
         leading: const AppBarBackButton(),
       ),
@@ -62,7 +65,9 @@ class _EditDisplayNameScreenState extends State<EditDisplayNameScreen> {
                 TextFormField(
                   autofocus: true,
                   controller: _controller,
-                  decoration: const InputDecoration(hintText: "Display name"),
+                  decoration: InputDecoration(
+                    hintText: loc.userHandleScreen_inputHint,
+                  ),
                   style: inputTextStyle(context),
                 ),
                 const SizedBox(height: Spacings.s),
@@ -74,7 +79,7 @@ class _EditDisplayNameScreenState extends State<EditDisplayNameScreen> {
                     ),
                     child: Text(
                       style: TextStyle(color: Theme.of(context).hintColor),
-                      "Choose a name that others will see when you communicate with them.",
+                      loc.editDisplayNameScreen_description,
                     ),
                   ),
                 ),
@@ -82,7 +87,7 @@ class _EditDisplayNameScreenState extends State<EditDisplayNameScreen> {
                 OutlinedButton(
                   onPressed: () => _submit(context),
                   style: buttonStyle(context, true),
-                  child: const Text('Save'),
+                  child: Text(loc.editDisplayNameScreen_save),
                 ),
               ],
             ),

--- a/app/lib/user/user_settings_screen.dart
+++ b/app/lib/user/user_settings_screen.dart
@@ -6,6 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:prototype/core/core.dart';
+import 'package:prototype/l10n/l10n.dart';
 import 'package:prototype/navigation/navigation.dart';
 import 'package:prototype/theme/theme.dart';
 import 'package:prototype/user/user.dart';
@@ -26,9 +27,11 @@ class UserSettingsScreen extends StatelessWidget {
       ),
     );
 
+    final loc = AppLocalizations.of(context);
+
     return Scaffold(
       appBar: AppBar(
-        title: const Text('User Settings'),
+        title: Text(loc.userSettingsScreen_title),
         toolbarHeight: isPointer() ? 100 : null,
         leading: const AppBarBackButton(),
       ),
@@ -88,6 +91,8 @@ class _UserProfileData extends StatelessWidget {
       (UserCubit cubit) => (cubit.state.displayName, cubit.state.userId),
     );
 
+    final loc = AppLocalizations.of(context);
+
     return ListView(
       shrinkWrap: true,
       children: [
@@ -107,7 +112,7 @@ class _UserProfileData extends StatelessWidget {
             _copyTextToClipboard(
               context,
               userId.uuid.toString(),
-              snackBarMessage: "User ID copied to clipboard",
+              snackBarMessage: loc.userSettingsScreen_idCopied,
             );
           },
         ),
@@ -115,7 +120,7 @@ class _UserProfileData extends StatelessWidget {
         ListTile(
           subtitle: Text(
             style: TextStyle(color: Theme.of(context).hintColor),
-            "Others will see your picture and name when you communicate with them.",
+            loc.userSettingsScreen_profileDescription,
           ),
         ),
       ],
@@ -142,42 +147,28 @@ class _UserHandles extends StatelessWidget {
       (UserCubit cubit) => cubit.state.userHandles,
     );
 
+    final loc = AppLocalizations.of(context);
+
     return ListView(
       shrinkWrap: true,
-      children:
-          userHandles.isEmpty
-              // no user handles yet
-              ? [
-                const _UserHandlePlaceholder(),
-                const SizedBox(height: Spacings.xs),
-                ListTile(
-                  subtitle: Text(
-                    style: TextStyle(color: Theme.of(context).hintColor),
-                    "Share usernames with others so they can connect with you.\nAfter the connection, usernames are not visible to others anymore.\nYou can have up to 5 usernames.",
-                  ),
-                ),
-              ]
-              // user handles
-              : [
-                ...userHandles.expand(
-                  (handle) => [
-                    _UserHandle(handle: handle),
-                    const SizedBox(height: Spacings.xs),
-                  ],
-                ),
-                if (userHandles.length < 5) ...[
-                  const _UserHandlePlaceholder(),
-                  const SizedBox(height: Spacings.xs),
-                ],
-                ListTile(
-                  subtitle: Text(
-                    style: TextStyle(color: Theme.of(context).hintColor),
-                    "Share usernames with others so they can connect with you. After the connection, "
-                    "usernames are not visible to others anymore. "
-                    "You can have up to 5 usernames.",
-                  ),
-                ),
-              ],
+      children: [
+        ...userHandles.expand(
+          (handle) => [
+            _UserHandle(handle: handle),
+            const SizedBox(height: Spacings.xs),
+          ],
+        ),
+        if (userHandles.isEmpty || userHandles.length < 5) ...[
+          const _UserHandlePlaceholder(),
+          const SizedBox(height: Spacings.xs),
+        ],
+        ListTile(
+          subtitle: Text(
+            style: TextStyle(color: Theme.of(context).hintColor),
+            loc.userSettingsScreen_userNamesDescription,
+          ),
+        ),
+      ],
     );
   }
 }
@@ -197,22 +188,20 @@ class _UserHandle extends StatelessWidget {
   }
 
   void _removeHandle(BuildContext context) async {
+    final loc = AppLocalizations.of(context);
     await showDialog(
       context: context,
       builder: (BuildContext context) {
         return AlertDialog(
-          title: const Text("Remove Username"),
-          content: const Text(
-            "If you continue, your username will be removed and may be claimed by someone else. "
-            "You’ll no longer be reachable through it.",
-          ),
+          title: Text(loc.removeUsernameDialog_title),
+          content: Text(loc.removeUsernameDialog_content),
           actions: [
             TextButton(
               onPressed: () {
                 Navigator.of(context).pop(false);
               },
               style: textButtonStyle(context),
-              child: const Text("Cancel"),
+              child: Text(loc.removeUsernameDialog_cancel),
             ),
             TextButton(
               onPressed: () async {
@@ -222,7 +211,7 @@ class _UserHandle extends StatelessWidget {
                 }
               },
               style: textButtonStyle(context),
-              child: const Text("Remove"),
+              child: Text(loc.removeUsernameDialog_remove),
             ),
           ],
         );
@@ -236,11 +225,13 @@ class _UserHandlePlaceholder extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final loc = AppLocalizations.of(context);
+
     return ListTile(
       leading: const Icon(Icons.alternate_email, size: _listIconSize),
       title: Text(
         style: TextStyle(color: Theme.of(context).hintColor),
-        "Username",
+        loc.userSettingsScreen_userHandlePlaceholder,
       ),
       onTap:
           () => context.read<NavigationCubit>().openUserSettings(

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -371,6 +371,11 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.0.0"
+  flutter_localizations:
+    dependency: "direct main"
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   flutter_plugin_android_lifecycle:
     dependency: transitive
     description:
@@ -547,10 +552,10 @@ packages:
     dependency: "direct main"
     description:
       name: intl
-      sha256: "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5"
+      sha256: d6f56758b7d3014a48af9701c085700aac781a92a87a62b1333b46d8879661cf
       url: "https://pub.dev"
     source: hosted
-    version: "0.20.2"
+    version: "0.19.0"
   io:
     dependency: transitive
     description:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -27,6 +27,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  flutter_localizations:
+    sdk: flutter
   convert: ^3.0.0
   flutter_rust_bridge: 2.9.0
   freezed_annotation: ^2.2.0
@@ -36,7 +38,7 @@ dependencies:
   phnxapplogic:
     path: rust_builder
   permission_handler: ^11.3.1
-  intl: ^0.20.1
+  intl: ^0.19.0
   uuid: ^4.4.2
   provider: ^6.1.2
   logging: ^1.3.0
@@ -66,6 +68,8 @@ dev_dependencies:
 
 # The following section is specific to Flutter.
 flutter:
+  generate: true
+
   # The following line ensures that the Material Icons font is
   # included with your application, so that you can use the icons in
   # the material Icons class.

--- a/app/test/conversation/conversation_screen_view_test.dart
+++ b/app/test/conversation/conversation_screen_view_test.dart
@@ -8,6 +8,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:prototype/conversation_details/conversation_details.dart';
 import 'package:prototype/core/core.dart';
+import 'package:prototype/l10n/l10n.dart';
 import 'package:prototype/message_list/message_list.dart';
 import 'package:prototype/navigation/navigation.dart';
 import 'package:prototype/theme/theme.dart';
@@ -72,6 +73,7 @@ void main() {
           return MaterialApp(
             debugShowCheckedModeBanner: false,
             theme: themeData(context),
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
             home: const Scaffold(
               body: ConversationScreenView(
                 createMessageCubit: createMockMessageCubit,

--- a/app/test/home_screen_test.dart
+++ b/app/test/home_screen_test.dart
@@ -11,6 +11,7 @@ import 'package:prototype/conversation_list/conversation_list.dart';
 import 'package:prototype/conversation_list/conversation_list_cubit.dart';
 import 'package:prototype/core/core.dart';
 import 'package:prototype/home_screen.dart';
+import 'package:prototype/l10n/l10n.dart';
 import 'package:prototype/message_list/message_list.dart';
 import 'package:prototype/navigation/navigation.dart';
 import 'package:prototype/theme/theme.dart';
@@ -78,6 +79,7 @@ void main() {
           return MaterialApp(
             debugShowCheckedModeBanner: false,
             theme: themeData(context),
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
             home: const HomeScreenDesktopLayout(
               conversationList: ConversationListView(),
               conversation: ConversationScreenView(

--- a/app/test/user/add_user_handle_screen_test.dart
+++ b/app/test/user/add_user_handle_screen_test.dart
@@ -6,6 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:prototype/l10n/l10n.dart';
 import 'package:prototype/theme/theme.dart';
 import 'package:prototype/user/user.dart';
 
@@ -26,6 +27,7 @@ void main() {
           return MaterialApp(
             debugShowCheckedModeBanner: false,
             theme: themeData(context),
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
             home: const AddUserHandleScreen(),
           );
         },

--- a/app/test/user/edit_display_name_screen_test.dart
+++ b/app/test/user/edit_display_name_screen_test.dart
@@ -6,6 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:prototype/l10n/l10n.dart';
 import 'package:prototype/theme/theme.dart';
 import 'package:prototype/user/user.dart';
 
@@ -26,6 +27,7 @@ void main() {
           return MaterialApp(
             debugShowCheckedModeBanner: false,
             theme: themeData(context),
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
             home: const EditDisplayNameScreen(),
           );
         },

--- a/app/test/user/goldens/user_settings_screen_no_handles.png
+++ b/app/test/user/goldens/user_settings_screen_no_handles.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7c586bff267e545cfb1c99a8c58af427bcd51f2a6715fc55c333bf83f195bfc8
-size 113277
+oid sha256:c144fdf2cf6862fa353ebcd4e2f39b2dde8d64bc2863f63e33fa61601d1d643f
+size 110489

--- a/app/test/user/user_settings_screen_test.dart
+++ b/app/test/user/user_settings_screen_test.dart
@@ -7,6 +7,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:prototype/core/core.dart';
+import 'package:prototype/l10n/l10n.dart';
 import 'package:prototype/theme/theme.dart';
 import 'package:prototype/user/user.dart';
 
@@ -27,6 +28,7 @@ void main() {
           return MaterialApp(
             debugShowCheckedModeBanner: false,
             theme: themeData(context),
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
             home: const UserSettingsScreen(),
           );
         },

--- a/justfile
+++ b/justfile
@@ -79,6 +79,23 @@ check-frb-ci: install-cargo-binstall
     cargo binstall flutter_rust_bridge_codegen@2.9.0 cargo-expand
     just check-frb
 
+# generate localization files
+[working-directory: 'app']
+gen-l10n:
+    flutter gen-l10n
+
+# check that the localization files are up to date
+[working-directory: 'app']
+check-l10n: gen-l10n
+    #!/usr/bin/env -S bash -eu
+    if [ -n "$(git status --porcelain)" ]; then
+        git add -N .
+        git --no-pager diff
+        echo -e "\x1b[1;31mFound uncommitted changes. Did you forget to check in generated localization?"
+        echo -e "\x1b[1;31mConsider to run 'just gen-l10n' manually."
+        exit 1
+    fi
+
 # set up the CI environment for the app
 install-cargo-binstall:
     curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash


### PR DESCRIPTION
This commit adds support for localizing the app's UI text.  It introduces the `intl` package and generates localized strings for English. All relevant UI text has been updated to use localized strings.

The generated localization files are checked in to the repository. CI checks that the localization files are up to date.

Closes #509 