### PR TITLE
feat: add delete and leave conversations

### DIFF
--- a/app/lib/conversation_details/connection_details.dart
+++ b/app/lib/conversation_details/connection_details.dart
@@ -5,6 +5,7 @@
 import 'package:flutter/material.dart';
 import 'package:prototype/core/core.dart';
 import 'package:prototype/theme/theme.dart';
+import 'package:prototype/user/user.dart';
 import 'package:prototype/widgets/widgets.dart';
 import 'package:provider/provider.dart';
 
@@ -24,26 +25,80 @@ class ConnectionDetails extends StatelessWidget {
       return const SizedBox.shrink();
     }
 
-    return Center(
-      child: Column(
-        spacing: Spacings.l,
-        children: [
-          const SizedBox(height: Spacings.l),
-          UserAvatar(
-            size: 64,
-            displayName: conversation.title,
-            image: conversation.picture,
-          ),
-          Text(
-            conversation.title,
-            style: Theme.of(context).textTheme.labelMedium,
-          ),
-          Text(
-            conversation.conversationType.description,
-            style: Theme.of(context).textTheme.labelMedium,
-          ),
-        ],
+    return Align(
+      alignment: Alignment.topCenter,
+      child: Container(
+        constraints: isPointer() ? const BoxConstraints(maxWidth: 800) : null,
+        padding: const EdgeInsets.all(Spacings.s),
+        child: Column(
+          children: [
+            UserAvatar(
+              size: 100,
+              displayName: conversation.title,
+              image: conversation.picture,
+            ),
+            const SizedBox(height: Spacings.m),
+            Text(
+              conversation.title,
+              style: Theme.of(context).textTheme.labelMedium,
+            ),
+            const SizedBox(height: Spacings.s),
+            Text(
+              conversation.conversationType.description,
+              style: Theme.of(context).textTheme.labelMedium,
+            ),
+            const Spacer(),
+            OutlinedButton(
+              onPressed: () => _delete(context, conversation.id),
+              style: dangerButtonStyle(context),
+              child: const Text('Delete'),
+            ),
+          ],
+        ),
       ),
     );
+  }
+
+  void _delete(BuildContext context, ConversationId conversationId) async {
+    bool confirmed = await showDialog(
+      context: context,
+      builder: (BuildContext context) {
+        return AlertDialog(
+          title: const Text("Delete"),
+          content: const Text(
+            "Are you sure you want to remove this connection? The message history will be deleted.",
+          ),
+          actions: [
+            TextButton(
+              onPressed: () {
+                Navigator.of(context).pop(false);
+              },
+              style: textButtonStyle(context),
+              child: const Text("Cancel"),
+            ),
+            TextButton(
+              onPressed: () async {
+                if (context.mounted) {
+                  Navigator.of(context).pop(true);
+                }
+              },
+              style: textButtonStyle(context),
+              child: const Text("Delete connection"),
+            ),
+          ],
+        );
+      },
+    );
+
+    if (!confirmed) {
+      return;
+    }
+
+    if (context.mounted) {
+      await context.read<UserCubit>().deleteConversation(conversationId);
+    }
+    if (context.mounted) {
+      Navigator.of(context).pop(true);
+    }
   }
 }

--- a/app/lib/conversation_details/connection_details.dart
+++ b/app/lib/conversation_details/connection_details.dart
@@ -4,8 +4,10 @@
 
 import 'package:flutter/material.dart';
 import 'package:prototype/core/core.dart';
+import 'package:prototype/navigation/navigation.dart' show NavigationCubit;
 import 'package:prototype/theme/theme.dart';
 import 'package:prototype/user/user.dart';
+import 'package:prototype/util/dialog.dart';
 import 'package:prototype/widgets/widgets.dart';
 import 'package:provider/provider.dart';
 
@@ -60,45 +62,19 @@ class ConnectionDetails extends StatelessWidget {
   }
 
   void _delete(BuildContext context, ConversationId conversationId) async {
-    bool confirmed = await showDialog(
-      context: context,
-      builder: (BuildContext context) {
-        return AlertDialog(
-          title: const Text("Delete"),
-          content: const Text(
-            "Are you sure you want to remove this connection? The message history will be deleted.",
-          ),
-          actions: [
-            TextButton(
-              onPressed: () {
-                Navigator.of(context).pop(false);
-              },
-              style: textButtonStyle(context),
-              child: const Text("Cancel"),
-            ),
-            TextButton(
-              onPressed: () async {
-                if (context.mounted) {
-                  Navigator.of(context).pop(true);
-                }
-              },
-              style: textButtonStyle(context),
-              child: const Text("Delete connection"),
-            ),
-          ],
-        );
-      },
-    );
-
-    if (!confirmed) {
-      return;
-    }
-
-    if (context.mounted) {
-      await context.read<UserCubit>().deleteConversation(conversationId);
-    }
-    if (context.mounted) {
-      Navigator.of(context).pop(true);
+    final userCubit = context.read<UserCubit>();
+    final navigationCubit = context.read<NavigationCubit>();
+    if (await showConfirmationDialog(
+      context,
+      title: "Delete",
+      message:
+          "Are you sure you want to remove this connection? "
+          "The message history will be also deleted.",
+      positiveButtonText: "Delete",
+      negativeButtonText: "Cancel",
+    )) {
+      userCubit.deleteConversation(conversationId);
+      navigationCubit.closeConversation();
     }
   }
 }

--- a/app/lib/conversation_details/conversation_details_screen.dart
+++ b/app/lib/conversation_details/conversation_details_screen.dart
@@ -42,12 +42,14 @@ class ConversationDetailsScreenView extends StatelessWidget {
         leading: const AppBarBackButton(),
         title: const Text("Details"),
       ),
-      body: switch (conversationType) {
-        UiConversationType_UnconfirmedConnection() ||
-        UiConversationType_Connection() => const ConnectionDetails(),
-        UiConversationType_Group() => const GroupDetails(),
-        null => const Center(child: Text("Unknown conversation")),
-      },
+      body: SafeArea(
+        child: switch (conversationType) {
+          UiConversationType_UnconfirmedConnection() ||
+          UiConversationType_Connection() => const ConnectionDetails(),
+          UiConversationType_Group() => const GroupDetails(),
+          null => const Center(child: Text("Unknown conversation")),
+        },
+      ),
     );
   }
 }

--- a/app/lib/conversation_details/group_details.dart
+++ b/app/lib/conversation_details/group_details.dart
@@ -8,6 +8,7 @@ import 'package:prototype/core/core.dart';
 import 'package:prototype/navigation/navigation.dart';
 import 'package:prototype/theme/theme.dart';
 import 'package:prototype/user/user.dart';
+import 'package:prototype/util/dialog.dart';
 import 'package:prototype/widgets/widgets.dart';
 import 'package:provider/provider.dart';
 
@@ -136,7 +137,7 @@ class GroupDetails extends StatelessWidget {
   void _leave(BuildContext context, ConversationId id) async {
     final userCubit = context.read<UserCubit>();
     final navigationCubit = context.read<NavigationCubit>();
-    if (await _showConfirmationDialog(
+    if (await showConfirmationDialog(
       context,
       title: "Leave conversation",
       message: "Are you sure you want to leave this conversation?",
@@ -151,7 +152,7 @@ class GroupDetails extends StatelessWidget {
   void _delete(BuildContext context, ConversationId id) async {
     final userCubit = context.read<UserCubit>();
     final navigationCubit = context.read<NavigationCubit>();
-    if (await _showConfirmationDialog(
+    if (await showConfirmationDialog(
       context,
       title: "Leave conversation",
       message:
@@ -164,39 +165,4 @@ class GroupDetails extends StatelessWidget {
       navigationCubit.closeConversation();
     }
   }
-}
-
-Future<bool> _showConfirmationDialog(
-  BuildContext context, {
-  required String title,
-  required String message,
-  required String positiveButtonText,
-  required String negativeButtonText,
-}) async {
-  bool confirmed = await showDialog(
-    context: context,
-    builder: (BuildContext context) {
-      return AlertDialog(
-        title: Text(title),
-        content: Text(message),
-        actions: [
-          TextButton(
-            onPressed: () {
-              Navigator.of(context).pop(false);
-            },
-            style: textButtonStyle(context),
-            child: Text(negativeButtonText),
-          ),
-          TextButton(
-            onPressed: () {
-              Navigator.of(context).pop(true);
-            },
-            style: textButtonStyle(context),
-            child: Text(positiveButtonText),
-          ),
-        ],
-      );
-    },
-  );
-  return confirmed;
 }

--- a/app/lib/core/api/user_cubit.dart
+++ b/app/lib/core/api/user_cubit.dart
@@ -45,7 +45,11 @@ abstract class UserCubitBase implements RustOpaqueInterface {
 
   Future<List<UiContact>> get contacts;
 
+  Future<void> deleteConversation(ConversationId conversationId);
+
   bool get isClosed;
+
+  Future<void> leaveConversation(ConversationId conversationId);
 
   factory UserCubitBase({
     required User user,

--- a/app/lib/core/frb_generated.dart
+++ b/app/lib/core/frb_generated.dart
@@ -78,7 +78,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.9.0';
 
   @override
-  int get rustContentHash => 1152521707;
+  int get rustContentHash => 1395048075;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -344,7 +344,17 @@ abstract class RustLibApi extends BaseApi {
     required UserCubitBase that,
   });
 
+  Future<void> crateApiUserCubitUserCubitBaseDeleteConversation({
+    required UserCubitBase that,
+    required ConversationId conversationId,
+  });
+
   bool crateApiUserCubitUserCubitBaseIsClosed({required UserCubitBase that});
+
+  Future<void> crateApiUserCubitUserCubitBaseLeaveConversation({
+    required UserCubitBase that,
+    required ConversationId conversationId,
+  });
 
   UserCubitBase crateApiUserCubitUserCubitBaseNew({
     required User user,
@@ -2643,6 +2653,45 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
+  Future<void> crateApiUserCubitUserCubitBaseDeleteConversation({
+    required UserCubitBase that,
+    required ConversationId conversationId,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerUserCubitBase(
+            that,
+            serializer,
+          );
+          sse_encode_box_autoadd_conversation_id(conversationId, serializer);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 58,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_unit,
+          decodeErrorData: sse_decode_AnyhowException,
+        ),
+        constMeta: kCrateApiUserCubitUserCubitBaseDeleteConversationConstMeta,
+        argValues: [that, conversationId],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta
+  get kCrateApiUserCubitUserCubitBaseDeleteConversationConstMeta =>
+      const TaskConstMeta(
+        debugName: "UserCubitBase_delete_conversation",
+        argNames: ["that", "conversationId"],
+      );
+
+  @override
   bool crateApiUserCubitUserCubitBaseIsClosed({required UserCubitBase that}) {
     return handler.executeSync(
       SyncTask(
@@ -2652,7 +2701,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             that,
             serializer,
           );
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 58)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 59)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_bool,
@@ -2672,6 +2721,44 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
+  Future<void> crateApiUserCubitUserCubitBaseLeaveConversation({
+    required UserCubitBase that,
+    required ConversationId conversationId,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerUserCubitBase(
+            that,
+            serializer,
+          );
+          sse_encode_box_autoadd_conversation_id(conversationId, serializer);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 60,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_unit,
+          decodeErrorData: sse_decode_AnyhowException,
+        ),
+        constMeta: kCrateApiUserCubitUserCubitBaseLeaveConversationConstMeta,
+        argValues: [that, conversationId],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiUserCubitUserCubitBaseLeaveConversationConstMeta =>
+      const TaskConstMeta(
+        debugName: "UserCubitBase_leave_conversation",
+        argNames: ["that", "conversationId"],
+      );
+
+  @override
   UserCubitBase crateApiUserCubitUserCubitBaseNew({
     required User user,
     required NavigationCubitBase navigation,
@@ -2688,7 +2775,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             navigation,
             serializer,
           );
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 59)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 61)!;
         },
         codec: SseCodec(
           decodeSuccessData:
@@ -2727,7 +2814,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 60,
+            funcId: 62,
             port: port_,
           );
         },
@@ -2767,7 +2854,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 61,
+            funcId: 63,
             port: port_,
           );
         },
@@ -2805,7 +2892,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 62,
+            funcId: 64,
             port: port_,
           );
         },
@@ -2845,7 +2932,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 63,
+            funcId: 65,
             port: port_,
           );
         },
@@ -2876,7 +2963,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             that,
             serializer,
           );
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 64)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 66)!;
         },
         codec: SseCodec(
           decodeSuccessData:
@@ -2914,7 +3001,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 65,
+              funcId: 67,
               port: port_,
             );
           },
@@ -2954,7 +3041,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 66,
+            funcId: 68,
             port: port_,
           );
         },
@@ -2988,7 +3075,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 67,
+            funcId: 69,
             port: port_,
           );
         },
@@ -3023,7 +3110,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 68,
+            funcId: 70,
             port: port_,
           );
         },
@@ -3056,7 +3143,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 69,
+            funcId: 71,
             port: port_,
           );
         },
@@ -3087,7 +3174,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 70,
+            funcId: 72,
             port: port_,
           );
         },
@@ -3126,7 +3213,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 71,
+            funcId: 73,
             port: port_,
           );
         },
@@ -3164,7 +3251,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 72,
+            funcId: 74,
             port: port_,
           );
         },
@@ -3195,7 +3282,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             that,
             serializer,
           );
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 73)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 75)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_ui_user_id,
@@ -3220,7 +3307,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 74,
+            funcId: 76,
             port: port_,
           );
         },
@@ -3248,7 +3335,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 75,
+            funcId: 77,
             port: port_,
           );
         },
@@ -3279,7 +3366,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 76,
+            funcId: 78,
             port: port_,
           );
         },
@@ -3312,7 +3399,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 77,
+            funcId: 79,
             port: port_,
           );
         },
@@ -3347,7 +3434,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 78,
+              funcId: 80,
               port: port_,
             );
           },
@@ -3381,7 +3468,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 79,
+            funcId: 81,
             port: port_,
           );
         },
@@ -3412,7 +3499,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 80,
+            funcId: 82,
             port: port_,
           );
         },
@@ -3440,7 +3527,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 81,
+            funcId: 83,
             port: port_,
           );
         },
@@ -3469,7 +3556,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_list_prim_u_8_loose(bytes, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 82)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 84)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -3495,7 +3582,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(logFile, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 83)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 85)!;
         },
         codec: SseCodec(
           decodeSuccessData:
@@ -3527,7 +3614,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 84,
+            funcId: 86,
             port: port_,
           );
         },
@@ -3560,7 +3647,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 85,
+            funcId: 87,
             port: port_,
           );
         },
@@ -3590,7 +3677,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_list_prim_u_8_loose(string, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 86)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 88)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_message_content,
@@ -3618,7 +3705,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 87,
+            funcId: 89,
             port: port_,
           );
         },
@@ -3646,7 +3733,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 88,
+            funcId: 90,
             port: port_,
           );
         },
@@ -3677,7 +3764,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 89,
+            funcId: 91,
             port: port_,
           );
         },
@@ -3704,7 +3791,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_box_autoadd_ui_user_handle(that, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 90)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 92)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_opt_String,
@@ -9605,8 +9692,20 @@ class UserCubitBaseImpl extends RustOpaque implements UserCubitBase {
   Future<List<UiContact>> get contacts =>
       RustLib.instance.api.crateApiUserCubitUserCubitBaseContacts(that: this);
 
+  Future<void> deleteConversation(ConversationId conversationId) =>
+      RustLib.instance.api.crateApiUserCubitUserCubitBaseDeleteConversation(
+        that: this,
+        conversationId: conversationId,
+      );
+
   bool get isClosed =>
       RustLib.instance.api.crateApiUserCubitUserCubitBaseIsClosed(that: this);
+
+  Future<void> leaveConversation(ConversationId conversationId) =>
+      RustLib.instance.api.crateApiUserCubitUserCubitBaseLeaveConversation(
+        that: this,
+        conversationId: conversationId,
+      );
 
   Future<void> removeUserFromConversation(
     ConversationId conversationId,

--- a/app/lib/theme/styles.dart
+++ b/app/lib/theme/styles.dart
@@ -165,6 +165,16 @@ ButtonStyle buttonStyle(BuildContext context, bool isActive) {
   );
 }
 
+ButtonStyle dangerButtonStyle(BuildContext context) =>
+    buttonStyle(context, true).copyWith(
+      backgroundColor: WidgetStateProperty.all(
+        Theme.of(context).colorScheme.errorContainer,
+      ),
+      overlayColor: WidgetStateProperty.all(
+        Theme.of(context).colorScheme.errorContainer,
+      ),
+    );
+
 // === Left pane ===
 
 const convPaneBackgroundColor = colorDMBSuperLight;

--- a/app/lib/user/user_cubit.dart
+++ b/app/lib/user/user_cubit.dart
@@ -67,6 +67,12 @@ class UserCubit implements StateStreamableSource<UiUser> {
     UiUserId userId,
   ) => _impl.removeUserFromConversation(conversationId, userId);
 
+  Future<void> leaveConversation(ConversationId conversationId) =>
+      _impl.leaveConversation(conversationId);
+
+  Future<void> deleteConversation(ConversationId conversationId) =>
+      _impl.deleteConversation(conversationId);
+
   Future<List<UiContact>> get contacts => _impl.contacts;
 
   Future<void> addUserHandle(UiUserHandle userHandle) =>

--- a/app/lib/util/dialog.dart
+++ b/app/lib/util/dialog.dart
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: 2025 Phoenix R&D GmbH <hello@phnx.im>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import 'package:flutter/material.dart';
+import 'package:prototype/theme/theme.dart';
+
+/// Shows a confirmation dialog with the given [title], [message],
+/// [positiveButtonText] and [negativeButtonText].
+///
+/// Returns true if the user confirmed the action, false otherwise.
+Future<bool> showConfirmationDialog(
+  BuildContext context, {
+  required String title,
+  required String message,
+  required String positiveButtonText,
+  required String negativeButtonText,
+}) async {
+  bool confirmed = await showDialog(
+    context: context,
+    builder: (BuildContext context) {
+      return AlertDialog(
+        title: Text(title),
+        content: Text(message),
+        actions: [
+          TextButton(
+            onPressed: () {
+              Navigator.of(context).pop(false);
+            },
+            style: textButtonStyle(context),
+            child: Text(negativeButtonText),
+          ),
+          TextButton(
+            onPressed: () {
+              Navigator.of(context).pop(true);
+            },
+            style: textButtonStyle(context),
+            child: Text(positiveButtonText),
+          ),
+        ],
+      );
+    },
+  );
+  return confirmed;
+}

--- a/applogic/src/api/navigation_cubit.rs
+++ b/applogic/src/api/navigation_cubit.rs
@@ -196,7 +196,10 @@ impl NavigationCubitBase {
     pub fn close_conversation(&self) {
         self.core.state_tx().send_if_modified(|state| match state {
             NavigationState::Intro { .. } => false,
-            NavigationState::Home { home } => mem::replace(&mut home.conversation_open, false),
+            NavigationState::Home { home } => {
+                home.conversation_details_open = false;
+                mem::replace(&mut home.conversation_open, false)
+            }
         });
     }
 

--- a/applogic/src/api/user_cubit.rs
+++ b/applogic/src/api/user_cubit.rs
@@ -271,6 +271,24 @@ impl UserCubitBase {
         Ok(())
     }
 
+    #[frb(positional)]
+    pub async fn delete_conversation(&self, conversation_id: ConversationId) -> anyhow::Result<()> {
+        self.core_user
+            .delete_conversation(conversation_id)
+            .await
+            .inspect_err(|error| {
+                error!(%error, "failed to delete conversion; skipping");
+            })
+            .ok();
+        self.core_user.erase_conversation(conversation_id).await?;
+        Ok(())
+    }
+
+    #[frb(positional)]
+    pub async fn leave_conversation(&self, conversation_id: ConversationId) -> anyhow::Result<()> {
+        self.core_user.leave_conversation(conversation_id).await
+    }
+
     #[frb(getter)]
     pub async fn contacts(&self) -> anyhow::Result<Vec<UiContact>> {
         let contacts = self.core_user.contacts().await?;

--- a/applogic/src/frb_generated.rs
+++ b/applogic/src/frb_generated.rs
@@ -46,7 +46,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.9.0";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 1152521707;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 1395048075;
 
 // Section: executor
 
@@ -2891,6 +2891,67 @@ fn wire__crate__api__user_cubit__UserCubitBase_contacts_impl(
         },
     )
 }
+fn wire__crate__api__user_cubit__UserCubitBase_delete_conversation_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_async::<flutter_rust_bridge::for_generated::SseCodec, _, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "UserCubitBase_delete_conversation",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_that = <RustOpaqueMoi<
+                flutter_rust_bridge::for_generated::RustAutoOpaqueInner<UserCubitBase>,
+            >>::sse_decode(&mut deserializer);
+            let api_conversation_id =
+                <crate::api::types::ConversationId>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| async move {
+                transform_result_sse::<_, flutter_rust_bridge::for_generated::anyhow::Error>(
+                    (move || async move {
+                        let mut api_that_guard = None;
+                        let decode_indices_ =
+                            flutter_rust_bridge::for_generated::lockable_compute_decode_order(
+                                vec![flutter_rust_bridge::for_generated::LockableOrderInfo::new(
+                                    &api_that, 0, false,
+                                )],
+                            );
+                        for i in decode_indices_ {
+                            match i {
+                                0 => {
+                                    api_that_guard =
+                                        Some(api_that.lockable_decode_async_ref().await)
+                                }
+                                _ => unreachable!(),
+                            }
+                        }
+                        let api_that_guard = api_that_guard.unwrap();
+                        let output_ok = crate::api::user_cubit::UserCubitBase::delete_conversation(
+                            &*api_that_guard,
+                            api_conversation_id,
+                        )
+                        .await?;
+                        Ok(output_ok)
+                    })()
+                    .await,
+                )
+            }
+        },
+    )
+}
 fn wire__crate__api__user_cubit__UserCubitBase_is_closed_impl(
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
     rust_vec_len_: i32,
@@ -2936,6 +2997,67 @@ fn wire__crate__api__user_cubit__UserCubitBase_is_closed_impl(
                 )?;
                 Ok(output_ok)
             })())
+        },
+    )
+}
+fn wire__crate__api__user_cubit__UserCubitBase_leave_conversation_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_async::<flutter_rust_bridge::for_generated::SseCodec, _, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "UserCubitBase_leave_conversation",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_that = <RustOpaqueMoi<
+                flutter_rust_bridge::for_generated::RustAutoOpaqueInner<UserCubitBase>,
+            >>::sse_decode(&mut deserializer);
+            let api_conversation_id =
+                <crate::api::types::ConversationId>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| async move {
+                transform_result_sse::<_, flutter_rust_bridge::for_generated::anyhow::Error>(
+                    (move || async move {
+                        let mut api_that_guard = None;
+                        let decode_indices_ =
+                            flutter_rust_bridge::for_generated::lockable_compute_decode_order(
+                                vec![flutter_rust_bridge::for_generated::LockableOrderInfo::new(
+                                    &api_that, 0, false,
+                                )],
+                            );
+                        for i in decode_indices_ {
+                            match i {
+                                0 => {
+                                    api_that_guard =
+                                        Some(api_that.lockable_decode_async_ref().await)
+                                }
+                                _ => unreachable!(),
+                            }
+                        }
+                        let api_that_guard = api_that_guard.unwrap();
+                        let output_ok = crate::api::user_cubit::UserCubitBase::leave_conversation(
+                            &*api_that_guard,
+                            api_conversation_id,
+                        )
+                        .await?;
+                        Ok(output_ok)
+                    })()
+                    .await,
+                )
+            }
         },
     )
 }
@@ -6013,31 +6135,33 @@ fn pde_ffi_dispatcher_primary_impl(
 55 => wire__crate__api__user_cubit__UserCubitBase_addable_contacts_impl(port, ptr, rust_vec_len, data_len),
 56 => wire__crate__api__user_cubit__UserCubitBase_close_impl(port, ptr, rust_vec_len, data_len),
 57 => wire__crate__api__user_cubit__UserCubitBase_contacts_impl(port, ptr, rust_vec_len, data_len),
-60 => wire__crate__api__user_cubit__UserCubitBase_remove_user_from_conversation_impl(port, ptr, rust_vec_len, data_len),
-61 => wire__crate__api__user_cubit__UserCubitBase_remove_user_handle_impl(port, ptr, rust_vec_len, data_len),
-62 => wire__crate__api__user_cubit__UserCubitBase_set_app_state_impl(port, ptr, rust_vec_len, data_len),
-63 => wire__crate__api__user_cubit__UserCubitBase_set_profile_impl(port, ptr, rust_vec_len, data_len),
-65 => wire__crate__api__user_cubit__UserCubitBase_stream_impl(port, ptr, rust_vec_len, data_len),
-66 => wire__crate__api__user_cubit__UserCubitBase_user_profile_impl(port, ptr, rust_vec_len, data_len),
-67 => wire__crate__api__user__User_global_unread_messages_count_impl(port, ptr, rust_vec_len, data_len),
-68 => wire__crate__api__user__User_load_impl(port, ptr, rust_vec_len, data_len),
-69 => wire__crate__api__user__User_load_client_records_impl(port, ptr, rust_vec_len, data_len),
-70 => wire__crate__api__user__User_load_default_impl(port, ptr, rust_vec_len, data_len),
-71 => wire__crate__api__user__User_new_impl(port, ptr, rust_vec_len, data_len),
-72 => wire__crate__api__user__User_update_push_token_impl(port, ptr, rust_vec_len, data_len),
-74 => wire__crate__api__logging__clear_app_logs_impl(port, ptr, rust_vec_len, data_len),
-75 => wire__crate__api__logging__clear_background_logs_impl(port, ptr, rust_vec_len, data_len),
-76 => wire__crate__api__conversation_details_cubit__conversation_details_state_default_impl(port, ptr, rust_vec_len, data_len),
-77 => wire__crate__api__conversation_list_cubit__conversation_list_state_default_impl(port, ptr, rust_vec_len, data_len),
-78 => wire__crate__api__logging__create_log_stream_impl(port, ptr, rust_vec_len, data_len),
-79 => wire__crate__api__utils__delete_client_database_impl(port, ptr, rust_vec_len, data_len),
-80 => wire__crate__api__utils__delete_databases_impl(port, ptr, rust_vec_len, data_len),
-81 => wire__crate__api__navigation_cubit__home_navigation_state_default_impl(port, ptr, rust_vec_len, data_len),
-84 => wire__crate__api__markdown__message_content_error_impl(port, ptr, rust_vec_len, data_len),
-85 => wire__crate__api__markdown__message_content_parse_markdown_impl(port, ptr, rust_vec_len, data_len),
-87 => wire__crate__api__logging__read_app_logs_impl(port, ptr, rust_vec_len, data_len),
-88 => wire__crate__api__logging__read_background_logs_impl(port, ptr, rust_vec_len, data_len),
-89 => wire__crate__api__logging__tar_logs_impl(port, ptr, rust_vec_len, data_len),
+58 => wire__crate__api__user_cubit__UserCubitBase_delete_conversation_impl(port, ptr, rust_vec_len, data_len),
+60 => wire__crate__api__user_cubit__UserCubitBase_leave_conversation_impl(port, ptr, rust_vec_len, data_len),
+62 => wire__crate__api__user_cubit__UserCubitBase_remove_user_from_conversation_impl(port, ptr, rust_vec_len, data_len),
+63 => wire__crate__api__user_cubit__UserCubitBase_remove_user_handle_impl(port, ptr, rust_vec_len, data_len),
+64 => wire__crate__api__user_cubit__UserCubitBase_set_app_state_impl(port, ptr, rust_vec_len, data_len),
+65 => wire__crate__api__user_cubit__UserCubitBase_set_profile_impl(port, ptr, rust_vec_len, data_len),
+67 => wire__crate__api__user_cubit__UserCubitBase_stream_impl(port, ptr, rust_vec_len, data_len),
+68 => wire__crate__api__user_cubit__UserCubitBase_user_profile_impl(port, ptr, rust_vec_len, data_len),
+69 => wire__crate__api__user__User_global_unread_messages_count_impl(port, ptr, rust_vec_len, data_len),
+70 => wire__crate__api__user__User_load_impl(port, ptr, rust_vec_len, data_len),
+71 => wire__crate__api__user__User_load_client_records_impl(port, ptr, rust_vec_len, data_len),
+72 => wire__crate__api__user__User_load_default_impl(port, ptr, rust_vec_len, data_len),
+73 => wire__crate__api__user__User_new_impl(port, ptr, rust_vec_len, data_len),
+74 => wire__crate__api__user__User_update_push_token_impl(port, ptr, rust_vec_len, data_len),
+76 => wire__crate__api__logging__clear_app_logs_impl(port, ptr, rust_vec_len, data_len),
+77 => wire__crate__api__logging__clear_background_logs_impl(port, ptr, rust_vec_len, data_len),
+78 => wire__crate__api__conversation_details_cubit__conversation_details_state_default_impl(port, ptr, rust_vec_len, data_len),
+79 => wire__crate__api__conversation_list_cubit__conversation_list_state_default_impl(port, ptr, rust_vec_len, data_len),
+80 => wire__crate__api__logging__create_log_stream_impl(port, ptr, rust_vec_len, data_len),
+81 => wire__crate__api__utils__delete_client_database_impl(port, ptr, rust_vec_len, data_len),
+82 => wire__crate__api__utils__delete_databases_impl(port, ptr, rust_vec_len, data_len),
+83 => wire__crate__api__navigation_cubit__home_navigation_state_default_impl(port, ptr, rust_vec_len, data_len),
+86 => wire__crate__api__markdown__message_content_error_impl(port, ptr, rust_vec_len, data_len),
+87 => wire__crate__api__markdown__message_content_parse_markdown_impl(port, ptr, rust_vec_len, data_len),
+89 => wire__crate__api__logging__read_app_logs_impl(port, ptr, rust_vec_len, data_len),
+90 => wire__crate__api__logging__read_background_logs_impl(port, ptr, rust_vec_len, data_len),
+91 => wire__crate__api__logging__tar_logs_impl(port, ptr, rust_vec_len, data_len),
                         _ => unreachable!(),
                     }
 }
@@ -6075,14 +6199,14 @@ fn pde_ffi_dispatcher_sync_impl(
 50 => wire__crate__api__user_cubit__UiUser_profile_picture_impl(ptr, rust_vec_len, data_len),
 51 => wire__crate__api__user_cubit__UiUser_user_handles_impl(ptr, rust_vec_len, data_len),
 52 => wire__crate__api__user_cubit__UiUser_user_id_impl(ptr, rust_vec_len, data_len),
-58 => wire__crate__api__user_cubit__UserCubitBase_is_closed_impl(ptr, rust_vec_len, data_len),
-59 => wire__crate__api__user_cubit__UserCubitBase_new_impl(ptr, rust_vec_len, data_len),
-64 => wire__crate__api__user_cubit__UserCubitBase_state_impl(ptr, rust_vec_len, data_len),
-73 => wire__crate__api__user__User_user_id_impl(ptr, rust_vec_len, data_len),
-82 => wire__crate__api__types__image_data_compute_hash_impl(ptr, rust_vec_len, data_len),
-83 => wire__crate__api__logging__init_rust_logging_impl(ptr, rust_vec_len, data_len),
-86 => wire__crate__api__markdown__message_content_parse_markdown_raw_impl(ptr, rust_vec_len, data_len),
-90 => wire__crate__api__types__ui_user_handle_validation_error_impl(ptr, rust_vec_len, data_len),
+59 => wire__crate__api__user_cubit__UserCubitBase_is_closed_impl(ptr, rust_vec_len, data_len),
+61 => wire__crate__api__user_cubit__UserCubitBase_new_impl(ptr, rust_vec_len, data_len),
+66 => wire__crate__api__user_cubit__UserCubitBase_state_impl(ptr, rust_vec_len, data_len),
+75 => wire__crate__api__user__User_user_id_impl(ptr, rust_vec_len, data_len),
+84 => wire__crate__api__types__image_data_compute_hash_impl(ptr, rust_vec_len, data_len),
+85 => wire__crate__api__logging__init_rust_logging_impl(ptr, rust_vec_len, data_len),
+88 => wire__crate__api__markdown__message_content_parse_markdown_raw_impl(ptr, rust_vec_len, data_len),
+92 => wire__crate__api__types__ui_user_handle_validation_error_impl(ptr, rust_vec_len, data_len),
                         _ => unreachable!(),
                     }
 }

--- a/applogic/src/messages.rs
+++ b/applogic/src/messages.rs
@@ -22,13 +22,7 @@ impl User {
         // notifications to the UI in case a new conversation is created.
         let mut new_connections = vec![];
         for as_message in as_messages {
-            let as_message_plaintext = match self.user.decrypt_as_queue_message(as_message).await {
-                Ok(plaintext) => plaintext,
-                Err(error) => {
-                    tracing::error!(%error, "Failed to decrypt AS message; skipping");
-                    continue;
-                }
-            };
+            let as_message_plaintext = self.user.decrypt_as_queue_message(as_message).await?;
             let conversation_id = self.user.process_as_message(as_message_plaintext).await?;
             new_connections.push(conversation_id);
         }

--- a/applogic/src/messages.rs
+++ b/applogic/src/messages.rs
@@ -22,7 +22,13 @@ impl User {
         // notifications to the UI in case a new conversation is created.
         let mut new_connections = vec![];
         for as_message in as_messages {
-            let as_message_plaintext = self.user.decrypt_as_queue_message(as_message).await?;
+            let as_message_plaintext = match self.user.decrypt_as_queue_message(as_message).await {
+                Ok(plaintext) => plaintext,
+                Err(error) => {
+                    tracing::error!(%error, "Failed to decrypt AS message; skipping");
+                    continue;
+                }
+            };
             let conversation_id = self.user.process_as_message(as_message_plaintext).await?;
             new_connections.push(conversation_id);
         }

--- a/coreclient/migrations/20250604111637_delete_cascade_conversations.sql
+++ b/coreclient/migrations/20250604111637_delete_cascade_conversations.sql
@@ -1,0 +1,182 @@
+-- SPDX-FileCopyrightText: 2025 Phoenix R&D GmbH <hello@phnx.im>
+--
+-- SPDX-License-Identifier: AGPL-3.0-or-later
+--
+-- 1. Add ON DELETE CASCADE to the foreign key constraints referencing the
+-- conversations table.
+-- 2. Fix invalid TRIGGER reference to indexed_keys table (replaced fingerprint
+-- with key_index).
+--
+PRAGMA foreign_keys = ON;
+
+DROP TRIGGER IF EXISTS no_partial_contact_overlap_on_insert;
+
+DROP TRIGGER IF EXISTS no_partial_contact_overlap_on_update;
+
+DROP TRIGGER IF EXISTS no_contact_overlap_on_insert;
+
+DROP TRIGGER IF EXISTS no_contact_overlap_on_update;
+
+DROP TRIGGER IF EXISTS delete_keys;
+
+-- Migration for 'contacts' table
+ALTER TABLE contacts
+RENAME TO contacts_old;
+
+CREATE TABLE IF NOT EXISTS contacts (
+    user_uuid BLOB NOT NULL,
+    user_domain TEXT NOT NULL,
+    conversation_id BLOB NOT NULL,
+    wai_ear_key BLOB NOT NULL,
+    friendship_token BLOB NOT NULL,
+    connection_key BLOB NOT NULL,
+    user_profile_key_index BLOB NOT NULL,
+    PRIMARY KEY (user_uuid, user_domain),
+    FOREIGN KEY (conversation_id) REFERENCES conversations (conversation_id) ON DELETE CASCADE,
+    FOREIGN KEY (user_profile_key_index) REFERENCES indexed_keys (key_index)
+);
+
+INSERT INTO
+    contacts
+SELECT
+    co.*
+FROM
+    contacts_old co
+    INNER JOIN conversations conv ON co.conversation_id = conv.conversation_id;
+
+DROP TABLE contacts_old;
+
+-- Migration for 'partial_contacts' table
+ALTER TABLE partial_contacts
+RENAME TO partial_contacts_old;
+
+CREATE TABLE IF NOT EXISTS partial_contacts (
+    user_uuid BLOB NOT NULL,
+    user_domain TEXT NOT NULL,
+    conversation_id BLOB NOT NULL,
+    friendship_package_ear_key BLOB NOT NULL,
+    PRIMARY KEY (user_uuid, user_domain),
+    FOREIGN KEY (conversation_id) REFERENCES conversations (conversation_id) ON DELETE CASCADE
+);
+
+INSERT INTO
+    partial_contacts
+SELECT
+    pc.*
+FROM
+    partial_contacts_old pc
+    INNER JOIN conversations conv ON pc.conversation_id = conv.conversation_id;
+
+DROP TABLE partial_contacts_old;
+
+-- Migration for 'conversation_messages' table
+ALTER TABLE conversation_messages
+RENAME TO conversation_messages_old;
+
+CREATE TABLE IF NOT EXISTS conversation_messages (
+    message_id BLOB NOT NULL PRIMARY KEY,
+    conversation_id BLOB NOT NULL,
+    timestamp TEXT NOT NULL,
+    sender_user_uuid BLOB,
+    sender_user_domain TEXT,
+    content BLOB NOT NULL,
+    sent BOOLEAN NOT NULL,
+    FOREIGN KEY (conversation_id) REFERENCES conversations (conversation_id) ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED
+);
+
+INSERT INTO
+    conversation_messages
+SELECT
+    *
+FROM
+    conversation_messages_old;
+
+DROP TABLE conversation_messages_old;
+
+CREATE TRIGGER IF NOT EXISTS no_partial_contact_overlap_on_insert BEFORE INSERT ON contacts FOR EACH ROW BEGIN
+SELECT
+    CASE
+        WHEN EXISTS (
+            SELECT
+                1
+            FROM
+                partial_contacts
+            WHERE
+                user_uuid = NEW.user_uuid
+                AND user_domain = NEW.user_domain
+        ) THEN RAISE (
+            FAIL,
+            'Can''t insert Contact: There already exists a partial contact with this client_id and domain'
+        )
+    END;
+
+END;
+
+CREATE TRIGGER IF NOT EXISTS no_partial_contact_overlap_on_update BEFORE
+UPDATE ON contacts FOR EACH ROW BEGIN
+SELECT
+    CASE
+        WHEN EXISTS (
+            SELECT
+                1
+            FROM
+                partial_contacts
+            WHERE
+                user_uuid = NEW.user_uuid
+                AND user_domain = NEW.user_domain
+        ) THEN RAISE (
+            FAIL,
+            'Can''t update Contact: There already exists a partial contact with this client_id and domain'
+        )
+    END;
+
+END;
+
+CREATE TRIGGER IF NOT EXISTS no_contact_overlap_on_insert BEFORE INSERT ON partial_contacts FOR EACH ROW BEGIN
+SELECT
+    CASE
+        WHEN EXISTS (
+            SELECT
+                1
+            FROM
+                contacts
+            WHERE
+                user_uuid = NEW.user_uuid
+                AND user_domain = NEW.user_domain
+        ) THEN RAISE (
+            FAIL,
+            'Can''t insert PartialContact: There already exists a contact with this client_id and domain'
+        )
+    END;
+
+END;
+
+CREATE TRIGGER IF NOT EXISTS no_contact_overlap_on_update BEFORE
+UPDATE ON partial_contacts FOR EACH ROW BEGIN
+SELECT
+    CASE
+        WHEN EXISTS (
+            SELECT
+                1
+            FROM
+                contacts
+            WHERE
+                user_uuid = NEW.user_uuid
+                AND user_domain = NEW.user_domain
+        ) THEN RAISE (
+            FAIL,
+            'Can''t update PartialContact: There already exists a contact with this client_id and domain'
+        )
+    END;
+
+END;
+
+CREATE TRIGGER IF NOT EXISTS delete_keys AFTER DELETE ON contacts FOR EACH ROW BEGIN
+-- Delete user profile keys if the corresponding contact is deleted. Since key
+-- indexes include the user id in their derivation, they are unique per user
+-- and we don't need to check if they are used by another user (or ourselves).
+DELETE FROM indexed_keys
+WHERE
+    key_index = OLD.user_profile_key_index;
+
+END;

--- a/coreclient/src/contacts/persistence.rs
+++ b/coreclient/src/contacts/persistence.rs
@@ -239,12 +239,12 @@ impl PartialContact {
     }
 
     pub(crate) async fn delete(
-        self,
         executor: impl SqliteExecutor<'_>,
         notifier: &mut StoreNotifier,
+        user_id: &UserId,
     ) -> sqlx::Result<()> {
-        let uuid = self.user_id.uuid();
-        let domain = self.user_id.domain();
+        let uuid = user_id.uuid();
+        let domain = user_id.domain();
         query!(
             "DELETE FROM partial_contacts
             WHERE user_uuid = ? AND user_domain = ?",
@@ -253,7 +253,7 @@ impl PartialContact {
         )
         .execute(executor)
         .await?;
-        notifier.remove(self.user_id.clone());
+        notifier.remove(user_id.clone());
         Ok(())
     }
 
@@ -275,7 +275,7 @@ impl PartialContact {
             user_profile_key_index,
         };
 
-        self.delete(txn.as_mut(), notifier).await?;
+        PartialContact::delete(txn.as_mut(), notifier, &self.user_id).await?;
         contact.store(txn.as_mut(), notifier).await?;
 
         Ok(contact)

--- a/coreclient/src/store/impl.rs
+++ b/coreclient/src/store/impl.rs
@@ -64,6 +64,10 @@ impl Store for CoreUser {
         self.leave_conversation(conversation_id).await
     }
 
+    async fn erase_conversation(&self, conversation_id: ConversationId) -> StoreResult<()> {
+        self.erase_conversation(conversation_id).await
+    }
+
     async fn update_key(
         &self,
         conversation_id: ConversationId,

--- a/coreclient/src/store/mod.rs
+++ b/coreclient/src/store/mod.rs
@@ -82,6 +82,11 @@ pub trait LocalStore {
 
     async fn leave_conversation(&self, conversation_id: ConversationId) -> StoreResult<()>;
 
+    /// Erases the conversation data with the given [`ConversationId`].
+    ///
+    /// Must not be called before the conversation is deleted.
+    async fn erase_conversation(&self, conversation_id: ConversationId) -> StoreResult<()>;
+
     // user management
 
     /// Update the user's key material in the conversation with the given


### PR DESCRIPTION
This commit adds and implements delete and delete/leave conversation
buttons to the details of a connection resp. group.

Also fixed the database schema to ensure that deleting a conversation
cascades to the related data. Also fixed an invalid trigger which was
referencing a non-existent field in the `indexed_keys` table.

Closes #510, closes #511