### PR TITLE
feat: use the user handles management API in the app

### DIFF
--- a/apiclient/src/as_api/mod.rs
+++ b/apiclient/src/as_api/mod.rs
@@ -4,12 +4,15 @@
 
 use phnxcommon::{
     LibraryError,
-    credentials::{ClientCredentialPayload, keys::ClientSigningKey},
+    credentials::{
+        ClientCredentialPayload,
+        keys::{ClientSigningKey, HandleSigningKey},
+    },
     crypto::{
         RatchetEncryptionKey, indexed_aead::keys::UserProfileKeyIndex, kdf::keys::RatchetSecret,
         signatures::signable::Signable,
     },
-    identifiers::UserId,
+    identifiers::{UserHandle, UserHandleHash, UserId},
     messages::{
         QueueMessage,
         client_as::{ConnectionPackage, EncryptedConnectionOffer, UserConnectionPackagesParams},
@@ -20,10 +23,11 @@ use phnxcommon::{
     },
 };
 use phnxprotos::auth_service::v1::{
-    AckListenRequest, AsCredentialsRequest, DeleteUserPayload, EnqueueMessagesRequest,
-    GetUserConnectionPackagesRequest, GetUserProfileRequest, InitListenPayload, ListenRequest,
-    MergeUserProfilePayload, PublishConnectionPackagesPayload, RegisterUserRequest,
-    StageUserProfilePayload, listen_request, publish_connection_packages_payload,
+    AckListenRequest, AsCredentialsRequest, CreateHandlePayload, DeleteHandlePayload,
+    DeleteUserPayload, EnqueueMessagesRequest, GetUserConnectionPackagesRequest,
+    GetUserProfileRequest, InitListenPayload, ListenRequest, MergeUserProfilePayload,
+    PublishConnectionPackagesPayload, RegisterUserRequest, StageUserProfilePayload, listen_request,
+    publish_connection_packages_payload,
 };
 use thiserror::Error;
 use tokio::sync::mpsc;
@@ -318,6 +322,38 @@ impl ApiClient {
                 .map(From::from)
                 .collect(),
         })
+    }
+
+    pub async fn as_create_handle(
+        &self,
+        user_handle: &UserHandle,
+        hash: UserHandleHash,
+        signing_key: &HandleSigningKey,
+    ) -> Result<bool, AsRequestError> {
+        let payload = CreateHandlePayload {
+            verifying_key: Some(signing_key.verifying_key().clone().into()),
+            plaintext: user_handle.plaintext().into(),
+            hash: Some(hash.into()),
+        };
+        let request = payload.sign(signing_key)?;
+        match self.as_grpc_client.client().create_handle(request).await {
+            Ok(_) => Ok(true),
+            Err(e) if e.code() == tonic::Code::AlreadyExists => Ok(false),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    pub async fn as_delete_handle(
+        &self,
+        hash: UserHandleHash,
+        signing_key: &HandleSigningKey,
+    ) -> Result<(), AsRequestError> {
+        let payload = DeleteHandlePayload {
+            hash: Some(hash.into()),
+        };
+        let request = payload.sign(signing_key)?;
+        self.as_grpc_client.client().delete_handle(request).await?;
+        Ok(())
     }
 }
 

--- a/app/lib/core/api/user_cubit.dart
+++ b/app/lib/core/api/user_cubit.dart
@@ -30,7 +30,7 @@ abstract class UiUser implements RustOpaqueInterface {
 
 // Rust type: RustOpaqueMoi<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<UserCubitBase>>
 abstract class UserCubitBase implements RustOpaqueInterface {
-  Future<void> addUserHandle({required UiUserHandle userHandle});
+  Future<bool> addUserHandle({required UiUserHandle userHandle});
 
   Future<void> addUserToConversation(
     ConversationId conversationId,

--- a/app/lib/core/frb_generated.dart
+++ b/app/lib/core/frb_generated.dart
@@ -320,7 +320,7 @@ abstract class RustLibApi extends BaseApi {
 
   UiUserId crateApiUserCubitUiUserUserId({required UiUser that});
 
-  Future<void> crateApiUserCubitUserCubitBaseAddUserHandle({
+  Future<bool> crateApiUserCubitUserCubitBaseAddUserHandle({
     required UserCubitBase that,
     required UiUserHandle userHandle,
   });
@@ -2456,7 +2456,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       const TaskConstMeta(debugName: "UiUser_user_id", argNames: ["that"]);
 
   @override
-  Future<void> crateApiUserCubitUserCubitBaseAddUserHandle({
+  Future<bool> crateApiUserCubitUserCubitBaseAddUserHandle({
     required UserCubitBase that,
     required UiUserHandle userHandle,
   }) {
@@ -2477,7 +2477,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           );
         },
         codec: SseCodec(
-          decodeSuccessData: sse_decode_unit,
+          decodeSuccessData: sse_decode_bool,
           decodeErrorData: sse_decode_AnyhowException,
         ),
         constMeta: kCrateApiUserCubitUserCubitBaseAddUserHandleConstMeta,
@@ -9577,7 +9577,7 @@ class UserCubitBaseImpl extends RustOpaque implements UserCubitBase {
         RustLib.instance.api.rust_arc_decrement_strong_count_UserCubitBasePtr,
   );
 
-  Future<void> addUserHandle({required UiUserHandle userHandle}) =>
+  Future<bool> addUserHandle({required UiUserHandle userHandle}) =>
       RustLib.instance.api.crateApiUserCubitUserCubitBaseAddUserHandle(
         that: this,
         userHandle: userHandle,

--- a/app/lib/user/add_user_handle_screen.dart
+++ b/app/lib/user/add_user_handle_screen.dart
@@ -20,6 +20,20 @@ class AddUserHandleScreen extends StatefulWidget {
 class _AddUserHandleScreenState extends State<AddUserHandleScreen> {
   final _formKey = GlobalKey<FormState>();
   final _controller = TextEditingController();
+  bool _alreadyExists = false;
+
+  @override
+  void initState() {
+    super.initState();
+    // Clear already exists flag when the text field changes
+    _controller.addListener(() {
+      if (_alreadyExists) {
+        setState(() {
+          _alreadyExists = false;
+        });
+      }
+    });
+  }
 
   @override
   void dispose() {
@@ -55,6 +69,9 @@ class _AddUserHandleScreenState extends State<AddUserHandleScreen> {
                     decoration: const InputDecoration(hintText: "Username"),
                     style: inputTextStyle(context),
                     validator: (value) {
+                      if (_alreadyExists) {
+                        return 'Username already exists';
+                      }
                       if (value == null || value.trim().isEmpty) {
                         return 'User handle cannot be empty';
                       }
@@ -103,7 +120,13 @@ class _AddUserHandleScreenState extends State<AddUserHandleScreen> {
     );
     final userCubit = context.read<UserCubit>();
     final navigationCubit = context.read<NavigationCubit>();
-    await userCubit.addUserHandle(handle);
+    if (!await userCubit.addUserHandle(handle)) {
+      setState(() {
+        _alreadyExists = true;
+      });
+      _formKey.currentState!.validate();
+      return;
+    }
     navigationCubit.pop();
   }
 }

--- a/app/lib/user/user_cubit.dart
+++ b/app/lib/user/user_cubit.dart
@@ -69,7 +69,7 @@ class UserCubit implements StateStreamableSource<UiUser> {
 
   Future<List<UiContact>> get contacts => _impl.contacts;
 
-  Future<void> addUserHandle(UiUserHandle userHandle) =>
+  Future<bool> addUserHandle(UiUserHandle userHandle) =>
       _impl.addUserHandle(userHandle: userHandle);
 
   Future<void> removeUserHandle(UiUserHandle userHandle) =>

--- a/common/src/credentials/keys.rs
+++ b/common/src/credentials/keys.rs
@@ -235,6 +235,8 @@ pub struct HandleKeyType;
 
 impl RawKey for HandleKeyType {}
 
+pub type HandleSigningKey = SigningKey<HandleKeyType>;
+
 pub type HandleVerifyingKey = VerifyingKey<HandleKeyType>;
 
 pub type HandleSignature = Signature<HandleKeyType>;

--- a/common/src/identifiers/user_handle.rs
+++ b/common/src/identifiers/user_handle.rs
@@ -62,6 +62,10 @@ impl UserHandle {
         Ok(UserHandleHash { hash })
     }
 
+    pub fn plaintext(&self) -> &str {
+        &self.plaintext
+    }
+
     pub fn into_plaintext(self) -> String {
         self.plaintext
     }
@@ -102,6 +106,48 @@ pub enum UserHandleValidationError {
 pub enum UserHandleHashError {
     #[error(transparent)]
     Argon2(#[from] argon2::Error),
+}
+
+mod sqlx_impls {
+    use sqlx::{Database, Decode, Encode, Type, encode::IsNull, error::BoxDynError};
+
+    use super::*;
+
+    impl<DB> Type<DB> for UserHandleHash
+    where
+        DB: Database,
+        Vec<u8>: Type<DB>,
+    {
+        fn type_info() -> <DB as Database>::TypeInfo {
+            <Vec<u8> as Type<DB>>::type_info()
+        }
+    }
+
+    impl<'q, DB> Encode<'q, DB> for UserHandleHash
+    where
+        DB: Database,
+        Vec<u8>: Encode<'q, DB>,
+    {
+        fn encode_by_ref(
+            &self,
+            buf: &mut <DB as Database>::ArgumentBuffer<'q>,
+        ) -> Result<IsNull, BoxDynError> {
+            let bytes = self.as_bytes().to_vec();
+            Encode::<DB>::encode(bytes, buf)
+        }
+    }
+
+    impl<'r, DB> Decode<'r, DB> for UserHandleHash
+    where
+        DB: Database,
+        for<'a> &'a [u8]: Decode<'a, DB>,
+    {
+        fn decode(value: <DB as Database>::ValueRef<'r>) -> Result<Self, BoxDynError> {
+            let bytes: &[u8] = Decode::<DB>::decode(value)?;
+            let value = UserHandleHash::new(bytes.try_into()?);
+            Ok(value)
+        }
+    }
 }
 
 #[cfg(test)]

--- a/coreclient/.sqlx/query-3b2fb984a81588fd9107849cba9d6b3d8d23c87907b4d10aec552db8616adf0d.json
+++ b/coreclient/.sqlx/query-3b2fb984a81588fd9107849cba9d6b3d8d23c87907b4d10aec552db8616adf0d.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "\n                DELETE FROM user_handles\n                WHERE handle = ?\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": []
+  },
+  "hash": "3b2fb984a81588fd9107849cba9d6b3d8d23c87907b4d10aec552db8616adf0d"
+}

--- a/coreclient/.sqlx/query-6322c9dd51d3a71829516d3b49b30d384417cc381de50f64a9f96aa447e2c31c.json
+++ b/coreclient/.sqlx/query-6322c9dd51d3a71829516d3b49b30d384417cc381de50f64a9f96aa447e2c31c.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "SQLite",
+  "query": "\n                SELECT\n                    handle\n                FROM user_handles\n            ",
+  "describe": {
+    "columns": [
+      {
+        "name": "handle",
+        "ordinal": 0,
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Right": 0
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "6322c9dd51d3a71829516d3b49b30d384417cc381de50f64a9f96aa447e2c31c"
+}

--- a/coreclient/.sqlx/query-78bfa2ef9ef70b612c495c8249b4f7b5438c1296607c16aedd60da12c4bf72bf.json
+++ b/coreclient/.sqlx/query-78bfa2ef9ef70b612c495c8249b4f7b5438c1296607c16aedd60da12c4bf72bf.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "\n                INSERT INTO user_handles (\n                    handle,\n                    hash,\n                    signature_key,\n                    created_at,\n                    refreshed_at\n                ) VALUES (?, ?, ?, ?, ?)\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 5
+    },
+    "nullable": []
+  },
+  "hash": "78bfa2ef9ef70b612c495c8249b4f7b5438c1296607c16aedd60da12c4bf72bf"
+}

--- a/coreclient/.sqlx/query-b8043dd6ee3e4eb3ad2bf67ba168df3e5e581522e067bff8bc658e57fd851fd7.json
+++ b/coreclient/.sqlx/query-b8043dd6ee3e4eb3ad2bf67ba168df3e5e581522e067bff8bc658e57fd851fd7.json
@@ -1,0 +1,26 @@
+{
+  "db_name": "SQLite",
+  "query": "\n                SELECT\n                    hash AS \"hash: _\",\n                    signature_key AS \"signature_key: _\"\n                FROM user_handles\n                WHERE handle = ?\n            ",
+  "describe": {
+    "columns": [
+      {
+        "name": "hash: _",
+        "ordinal": 0,
+        "type_info": "Blob"
+      },
+      {
+        "name": "signature_key: _",
+        "ordinal": 1,
+        "type_info": "Blob"
+      }
+    ],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": [
+      false,
+      false
+    ]
+  },
+  "hash": "b8043dd6ee3e4eb3ad2bf67ba168df3e5e581522e067bff8bc658e57fd851fd7"
+}

--- a/coreclient/migrations/20250604135306_user_handles.sql
+++ b/coreclient/migrations/20250604135306_user_handles.sql
@@ -1,0 +1,13 @@
+-- SPDX-FileCopyrightText: 2025 Phoenix R&D GmbH <hello@phnx.im>
+--
+-- SPDX-License-Identifier: AGPL-3.0-or-later
+--
+-- Adds support for user handles in the client database.
+--
+CREATE TABLE IF NOT EXISTS user_handles (
+    handle TEXT NOT NULL PRIMARY KEY,
+    hash BLOB NOT NULL,
+    signature_key BLOB NOT NULL,
+    created_at DATETIME NOT NULL,
+    refreshed_at DATETIME NOT NULL
+);

--- a/coreclient/src/clients/mod.rs
+++ b/coreclient/src/clients/mod.rs
@@ -245,6 +245,10 @@ impl CoreUser {
         &self.inner.key_store.signing_key
     }
 
+    pub(crate) fn api_client(&self) -> anyhow::Result<ApiClient> {
+        Ok(self.inner.api_clients.default_client()?)
+    }
+
     pub(crate) fn send_store_notification(&self, notification: StoreNotification) {
         if !notification.is_empty() {
             self.inner.store_notifications_tx.notify(notification);

--- a/coreclient/src/lib.rs
+++ b/coreclient/src/lib.rs
@@ -10,6 +10,7 @@ mod conversations;
 mod groups;
 mod key_stores;
 pub mod store;
+mod user_handles;
 mod user_profiles;
 mod utils;
 

--- a/coreclient/src/store/impl.rs
+++ b/coreclient/src/store/impl.rs
@@ -5,7 +5,7 @@
 use std::{collections::HashSet, sync::Arc};
 
 use mimi_room_policy::VerifiedRoomState;
-use phnxcommon::identifiers::UserId;
+use phnxcommon::identifiers::{UserHandle, UserId};
 use tokio_stream::Stream;
 use uuid::Uuid;
 
@@ -23,6 +23,18 @@ impl Store for CoreUser {
 
     async fn set_own_user_profile(&self, user_profile: UserProfile) -> StoreResult<UserProfile> {
         self.set_own_user_profile(user_profile).await
+    }
+
+    async fn user_handles(&self) -> StoreResult<Vec<UserHandle>> {
+        self.user_handles().await
+    }
+
+    async fn add_user_handle(&self, user_handle: &UserHandle) -> StoreResult<bool> {
+        self.add_user_handle(user_handle).await
+    }
+
+    async fn remove_user_handle(&self, user_handle: &UserHandle) -> StoreResult<()> {
+        self.remove_user_handle(user_handle).await
     }
 
     async fn create_conversation(

--- a/coreclient/src/store/mod.rs
+++ b/coreclient/src/store/mod.rs
@@ -6,7 +6,7 @@ use std::collections::HashSet;
 use std::sync::Arc;
 
 use mimi_room_policy::VerifiedRoomState;
-use phnxcommon::identifiers::UserId;
+use phnxcommon::identifiers::{UserHandle, UserId};
 use tokio_stream::Stream;
 use uuid::Uuid;
 
@@ -31,13 +31,21 @@ pub type StoreResult<T> = anyhow::Result<T>;
 /// the messages. Additionaly, it is used to listen to changes in the client data via the
 /// [`Self::subscribe`] method and the [`StoreNotification`] type.
 #[allow(async_fn_in_trait, reason = "trait is only used in the workspace")]
-#[trait_variant::make(Store: Send)]
-pub trait LocalStore {
+#[trait_variant::make(Send)]
+pub trait Store {
     // user
 
     async fn own_user_profile(&self) -> StoreResult<UserProfile>;
 
     async fn set_own_user_profile(&self, user_profile: UserProfile) -> StoreResult<UserProfile>;
+
+    // user handles
+
+    async fn user_handles(&self) -> StoreResult<Vec<UserHandle>>;
+
+    async fn add_user_handle(&self, user_handle: &UserHandle) -> StoreResult<bool>;
+
+    async fn remove_user_handle(&self, user_handle: &UserHandle) -> StoreResult<()>;
 
     // conversations
 

--- a/coreclient/src/user_handles/mod.rs
+++ b/coreclient/src/user_handles/mod.rs
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: 2025 Phoenix R&D GmbH <hello@phnx.im>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+use anyhow::Context;
+use persistence::UserHandleRecord;
+use phnxcommon::{credentials::keys::HandleSigningKey, identifiers::UserHandle};
+use tracing::error;
+
+use crate::{clients::CoreUser, store::StoreResult};
+
+mod persistence;
+
+impl CoreUser {
+    pub(crate) async fn user_handles(&self) -> StoreResult<Vec<UserHandle>> {
+        Ok(UserHandleRecord::load_all_handles(self.pool()).await?)
+    }
+
+    /// Registers a new user handle on the server and adds it locally.
+    ///
+    /// Returns `true` on success, or `false` if the handle was already present.
+    pub(crate) async fn add_user_handle(&self, handle: &UserHandle) -> StoreResult<bool> {
+        let signing_key = HandleSigningKey::generate()?;
+        let hash = handle.hash()?;
+
+        let api_client = self.api_client()?;
+        let created = api_client
+            .as_create_handle(handle, hash, &signing_key)
+            .await?;
+        if !created {
+            return Ok(false);
+        }
+
+        if let Err(error) = UserHandleRecord::store(self.pool(), handle, &hash, &signing_key).await
+        {
+            error!(%error, "failed to store user handle; rollback on the server");
+            api_client
+                .as_delete_handle(hash, &signing_key)
+                .await
+                .inspect_err(|error| {
+                    error!(%error, "failed to delete user handle after error");
+                })
+                .ok();
+            return Err(error.into());
+        }
+
+        Ok(true)
+    }
+
+    /// Deletes the user handle on the server and removes it locally.
+    pub(crate) async fn remove_user_handle(&self, handle: &UserHandle) -> StoreResult<()> {
+        let mut txn = self.pool().begin().await?;
+        let record = UserHandleRecord::load(txn.as_mut(), handle)
+            .await?
+            .context("no user handle found")?;
+        let api_client = self.api_client()?;
+        api_client
+            .as_delete_handle(record.hash, &record.signature_key)
+            .await?;
+        UserHandleRecord::delete(txn.as_mut(), handle).await?;
+        txn.commit().await?;
+        Ok(())
+    }
+}

--- a/coreclient/src/user_handles/persistence.rs
+++ b/coreclient/src/user_handles/persistence.rs
@@ -1,0 +1,164 @@
+// SPDX-FileCopyrightText: 2025 Phoenix R&D GmbH <hello@phnx.im>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+use chrono::{SubsecRound, Utc};
+use phnxcommon::{
+    codec::{BlobDecoded, BlobEncoded},
+    credentials::keys::HandleSigningKey,
+    identifiers::{UserHandle, UserHandleHash},
+};
+use sqlx::{SqliteExecutor, query};
+use tracing::error;
+
+/// A user handle record stored in the client database.
+///
+/// Contains additional information about the handle, such as hash and signature key.
+pub(super) struct UserHandleRecord {
+    pub(super) hash: UserHandleHash,
+    pub(super) signature_key: HandleSigningKey,
+}
+
+struct SqlUserHandleRecord {
+    hash: UserHandleHash,
+    signature_key: BlobDecoded<HandleSigningKey>,
+}
+
+impl From<SqlUserHandleRecord> for UserHandleRecord {
+    fn from(record: SqlUserHandleRecord) -> Self {
+        Self {
+            hash: record.hash,
+            signature_key: record.signature_key.into_inner(),
+        }
+    }
+}
+
+impl UserHandleRecord {
+    pub(super) async fn load(
+        executor: impl SqliteExecutor<'_>,
+        handle: &UserHandle,
+    ) -> sqlx::Result<Option<Self>> {
+        let plaintext = handle.plaintext();
+        let record = sqlx::query_as!(
+            SqlUserHandleRecord,
+            r#"
+                SELECT
+                    hash AS "hash: _",
+                    signature_key AS "signature_key: _"
+                FROM user_handles
+                WHERE handle = ?
+            "#,
+            plaintext
+        )
+        .fetch_optional(executor)
+        .await?;
+        Ok(record.map(From::from))
+    }
+
+    pub(super) async fn load_all_handles(
+        executor: impl SqliteExecutor<'_>,
+    ) -> sqlx::Result<Vec<UserHandle>> {
+        let plaintext = sqlx::query_scalar!(
+            r#"
+                SELECT
+                    handle
+                FROM user_handles
+            "#
+        )
+        .fetch_all(executor)
+        .await?;
+        Ok(plaintext
+            .into_iter()
+            .filter_map(|plaintext| {
+                UserHandle::new(plaintext)
+                    .inspect_err(
+                        |error| error!(%error,"failed to parse user handle from plaintext"),
+                    )
+                    .ok()
+            })
+            .collect())
+    }
+
+    pub(super) async fn store(
+        executor: impl SqliteExecutor<'_>,
+        handle: &UserHandle,
+        hash: &UserHandleHash,
+        signing_key: &HandleSigningKey,
+    ) -> sqlx::Result<()> {
+        let plaintext = handle.plaintext();
+        let signing_key = BlobEncoded(signing_key);
+        let created_at = Utc::now().round_subsecs(6);
+        let refreshed_at = created_at;
+        query!(
+            r#"
+                INSERT INTO user_handles (
+                    handle,
+                    hash,
+                    signature_key,
+                    created_at,
+                    refreshed_at
+                ) VALUES (?, ?, ?, ?, ?)
+            "#,
+            plaintext,
+            hash,
+            signing_key,
+            created_at,
+            refreshed_at,
+        )
+        .execute(executor)
+        .await?;
+        Ok(())
+    }
+
+    pub(super) async fn delete(
+        executor: impl SqliteExecutor<'_>,
+        handle: &UserHandle,
+    ) -> sqlx::Result<()> {
+        let plaintext = handle.plaintext();
+        query!(
+            r#"
+                DELETE FROM user_handles
+                WHERE handle = ?
+            "#,
+            plaintext,
+        )
+        .execute(executor)
+        .await?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use sqlx::SqlitePool;
+
+    use super::*;
+
+    #[sqlx::test]
+    async fn user_handle_persistence(pool: SqlitePool) -> anyhow::Result<()> {
+        let handle = UserHandle::new("ellie_03".to_owned())?;
+        let hash = handle.hash()?;
+        let signing_key = HandleSigningKey::generate()?;
+
+        // Store a user handle
+        UserHandleRecord::store(&pool, &handle, &hash, &signing_key).await?;
+
+        // Load the user handle
+        let loaded_handle = UserHandleRecord::load(&pool, &handle).await?.unwrap();
+        assert_eq!(loaded_handle.hash, hash);
+
+        // Load all handles (should only be one)
+        let all_handles = UserHandleRecord::load_all_handles(&pool).await?;
+        assert_eq!(all_handles.len(), 1);
+        assert_eq!(all_handles[0], handle);
+
+        // Delete the user handle
+        UserHandleRecord::delete(&pool, &handle).await?;
+
+        // Verify deletion
+        let loaded_handle = UserHandleRecord::load(&pool, &handle).await?;
+        assert!(loaded_handle.is_none());
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
This commit connects the client-side user handles management API to the
server-side API. It also adds support for storing user handles in the
client database. UI shows a validation error if a user handle is already
exists on the server when adding a new user handle.