### PR TITLE
feat: add attachments backend API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -412,6 +412,326 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-config"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "455e9fb7743c6f6267eb2830ccc08686fbb3d13c9a689369562fd4d4ef9ea462"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-sdk-sts",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 1.3.1",
+ "time",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "aws-credential-types"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "687bc16bc431a8533fe0097c7f0182874767f920989d7260950172ae8e3c4465"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-runtime"
+version = "1.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f6c68419d8ba16d9a7463671593c54f81ba58cab466e9b759418da606dcc2e2"
+dependencies = [
+ "aws-credential-types",
+ "aws-sigv4",
+ "aws-smithy-async",
+ "aws-smithy-eventstream",
+ "aws-smithy-http",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "percent-encoding",
+ "pin-project-lite",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "aws-sdk-s3"
+version = "1.93.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b9734dc8145b417a3c22eae8769a2879851690982dba718bdc52bd28ad04ce"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-sigv4",
+ "aws-smithy-async",
+ "aws-smithy-checksums",
+ "aws-smithy-eventstream",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "hex",
+ "hmac",
+ "http 0.2.12",
+ "http 1.3.1",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "lru",
+ "percent-encoding",
+ "regex-lite",
+ "sha2",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "aws-sdk-sts"
+version = "1.75.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3258fa707f2f585ee3049d9550954b959002abd59176975150a01d5cf38ae3f"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-query",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "aws-types",
+ "fastrand",
+ "http 0.2.12",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sigv4"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddfb9021f581b71870a17eac25b52335b82211cdc092e02b6876b2bcefa61666"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-eventstream",
+ "aws-smithy-http",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "form_urlencoded",
+ "hex",
+ "hmac",
+ "http 0.2.12",
+ "http 1.3.1",
+ "percent-encoding",
+ "sha2",
+ "time",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-async"
+version = "1.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e190749ea56f8c42bf15dd76c65e14f8f765233e6df9b0506d9d934ebef867c"
+dependencies = [
+ "futures-util",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "aws-smithy-checksums"
+version = "0.63.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f77a921dbd2c78ebe70726799787c1d110a2245dd65e39b20923dfdfb2deee"
+dependencies = [
+ "aws-smithy-http",
+ "aws-smithy-types",
+ "bytes",
+ "crc-fast",
+ "hex",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "md-5",
+ "pin-project-lite",
+ "sha1",
+ "sha2",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-eventstream"
+version = "0.60.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "338a3642c399c0a5d157648426110e199ca7fd1c689cc395676b81aa563700c4"
+dependencies = [
+ "aws-smithy-types",
+ "bytes",
+ "crc32fast",
+]
+
+[[package]]
+name = "aws-smithy-http"
+version = "0.62.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99335bec6cdc50a346fda1437f9fefe33abf8c99060739a546a16457f2862ca9"
+dependencies = [
+ "aws-smithy-eventstream",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "http 0.2.12",
+ "http 1.3.1",
+ "http-body 0.4.6",
+ "percent-encoding",
+ "pin-project-lite",
+ "pin-utils",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-json"
+version = "0.61.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a16e040799d29c17412943bdbf488fd75db04112d0c0d4b9290bacf5ae0014b9"
+dependencies = [
+ "aws-smithy-types",
+]
+
+[[package]]
+name = "aws-smithy-observability"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9364d5989ac4dd918e5cc4c4bdcc61c9be17dcd2586ea7f69e348fc7c6cab393"
+dependencies = [
+ "aws-smithy-runtime-api",
+]
+
+[[package]]
+name = "aws-smithy-query"
+version = "0.60.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2fbd61ceb3fe8a1cb7352e42689cec5335833cd9f94103a61e98f9bb61c64bb"
+dependencies = [
+ "aws-smithy-types",
+ "urlencoding",
+]
+
+[[package]]
+name = "aws-smithy-runtime"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14302f06d1d5b7d333fd819943075b13d27c7700b414f574c3c35859bfb55d5e"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-observability",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.3.1",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "pin-project-lite",
+ "pin-utils",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-runtime-api"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd8531b6d8882fd8f48f82a9754e682e29dd44cff27154af51fa3eb730f59efb"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-types",
+ "bytes",
+ "http 0.2.12",
+ "http 1.3.1",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-smithy-types"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d498595448e43de7f4296b7b7a18a8a02c61ec9349128c80a368f7c3b4ab11a8"
+dependencies = [
+ "base64-simd",
+ "bytes",
+ "bytes-utils",
+ "http 0.2.12",
+ "http 1.3.1",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "http-body-util",
+ "itoa",
+ "num-integer",
+ "pin-project-lite",
+ "pin-utils",
+ "ryu",
+ "serde",
+ "time",
+]
+
+[[package]]
+name = "aws-smithy-xml"
+version = "0.60.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3db87b96cb1b16c024980f133968d52882ca0daaee3a086c6decc500f6c99728"
+dependencies = [
+ "xmlparser",
+]
+
+[[package]]
+name = "aws-types"
+version = "1.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a322fec39e4df22777ed3ad8ea868ac2f94cd15e1a55f6ee8d8d6305057689a"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "rustc_version",
+ "tracing",
+]
+
+[[package]]
 name = "axum"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -421,8 +741,8 @@ dependencies = [
  "bytes",
  "form_urlencoded",
  "futures-util",
- "http",
- "http-body",
+ "http 1.3.1",
+ "http-body 1.0.1",
  "http-body-util",
  "hyper",
  "hyper-util",
@@ -453,8 +773,8 @@ checksum = "68464cd0412f486726fb3373129ef5d2993f90c34bc2bc1c1e9943b2f4fc7ca6"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
- "http-body",
+ "http 1.3.1",
+ "http-body 1.0.1",
  "http-body-util",
  "mime",
  "pin-project-lite",
@@ -497,6 +817,16 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339abbe78e73178762e23bea9dfd08e697eb3f3301cd4be981c0f78ba5859195"
+dependencies = [
+ "outref",
+ "vsimd",
+]
 
 [[package]]
 name = "base64ct"
@@ -677,6 +1007,16 @@ name = "bytes"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+
+[[package]]
+name = "bytes-utils"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dafe3a8757b027e2be6e4e5601ed563c55989fcf1546e933c66c8eb3a058d35"
+dependencies = [
+ "bytes",
+ "either",
+]
 
 [[package]]
 name = "cast"
@@ -976,6 +1316,19 @@ name = "crc-catalog"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+
+[[package]]
+name = "crc-fast"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bf62af4cc77d8fe1c22dde4e721d87f2f54056139d8c412e1366b740305f56f"
+dependencies = [
+ "crc",
+ "digest",
+ "libc",
+ "rand 0.9.1",
+ "regex",
+]
 
 [[package]]
 name = "crc32fast"
@@ -1983,7 +2336,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http",
+ "http 1.3.1",
  "indexmap",
  "slab",
  "tokio",
@@ -2138,6 +2491,17 @@ dependencies = [
 
 [[package]]
 name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
@@ -2149,12 +2513,23 @@ dependencies = [
 
 [[package]]
 name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http",
+ "http 1.3.1",
 ]
 
 [[package]]
@@ -2165,8 +2540,8 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
- "http-body",
+ "http 1.3.1",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -2192,8 +2567,8 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "h2",
- "http",
- "http-body",
+ "http 1.3.1",
+ "http-body 1.0.1",
  "httparse",
  "httpdate",
  "itoa",
@@ -2209,7 +2584,7 @@ version = "0.27.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03a01595e11bdcec50946522c32dde3fc6914743000a68b93000965f2f02406d"
 dependencies = [
- "http",
+ "http 1.3.1",
  "hyper",
  "hyper-util",
  "rustls",
@@ -2244,8 +2619,8 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "http",
- "http-body",
+ "http 1.3.1",
+ "http-body 1.0.1",
  "hyper",
  "ipnet",
  "libc",
@@ -2721,6 +3096,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fae87c125b03c1d2c0150c90365d7d6bcc53fb73a9acaef207d2d065860f062"
 dependencies = [
  "imgref",
+]
+
+[[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.3",
 ]
 
 [[package]]
@@ -3241,6 +3625,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
+
+[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3474,6 +3864,8 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "aws-config",
+ "aws-sdk-s3",
  "base64 0.22.1",
  "chrono",
  "displaydoc",
@@ -3904,7 +4296,7 @@ dependencies = [
  "base64 0.22.1",
  "blind-rsa-signatures",
  "generic-array",
- "http",
+ "http 1.3.1",
  "nom 8.0.0",
  "p384",
  "rand 0.8.5",
@@ -4394,6 +4786,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-lite"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53a49587ad06b26609c52e423de037e7f57f20d53535d66e08c695f347df952a"
+
+[[package]]
 name = "regex-syntax"
 version = "0.6.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4418,8 +4816,8 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http",
- "http-body",
+ "http 1.3.1",
+ "http-body 1.0.1",
  "http-body-util",
  "hyper",
  "hyper-rustls",
@@ -5535,8 +5933,8 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "h2",
- "http",
- "http-body",
+ "http 1.3.1",
+ "http-body 1.0.1",
  "http-body-util",
  "hyper",
  "hyper-timeout",
@@ -5609,8 +6007,8 @@ dependencies = [
  "bitflags 2.9.1",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 1.3.1",
+ "http-body 1.0.1",
  "iri-string",
  "pin-project-lite",
  "tower",
@@ -5639,7 +6037,7 @@ dependencies = [
  "axum",
  "forwarded-header-value",
  "governor",
- "http",
+ "http 1.3.1",
  "pin-project",
  "thiserror 2.0.12",
  "tonic",
@@ -5875,6 +6273,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5944,6 +6348,12 @@ dependencies = [
  "subtle",
  "zeroize",
 ]
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "walkdir"
@@ -6520,6 +6930,12 @@ dependencies = [
  "libc",
  "rustix",
 ]
+
+[[package]]
+name = "xmlparser"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
 name = "yaml-rust2"

--- a/apiclient/src/ds_api/grpc.rs
+++ b/apiclient/src/ds_api/grpc.rs
@@ -13,7 +13,7 @@ use mls_assist::{
 use phnxcommon::{
     credentials::keys::ClientSigningKey,
     crypto::{ear::keys::GroupStateEarKey, signatures::signable::Signable},
-    identifiers::{QsReference, QualifiedGroupId},
+    identifiers::{AttachmentId, QsReference, QualifiedGroupId},
     messages::{
         client_ds::UserProfileKeyUpdateParams,
         client_ds_out::{
@@ -27,7 +27,8 @@ use phnxprotos::{
     convert::{RefInto, TryRefInto},
     delivery_service::v1::{
         AddUsersInfo, ConnectionGroupInfoRequest, CreateGroupPayload, DeleteGroupPayload,
-        ExternalCommitInfoRequest, GroupOperationPayload, JoinConnectionGroupRequest,
+        ExternalCommitInfoRequest, GetAttachmentUrlPayload, GroupOperationPayload,
+        JoinConnectionGroupRequest, ProvisionAttachmentPayload, ProvisionAttachmentResponse,
         RequestGroupIdRequest, ResyncPayload, SelfRemovePayload, SendMessagePayload, UpdatePayload,
         UpdateProfileKeyPayload, WelcomeInfoPayload,
         delivery_service_client::DeliveryServiceClient,
@@ -399,5 +400,53 @@ impl DsGrpcClient {
         let request = payload.sign(signing_key)?;
         self.client.clone().update_profile_key(request).await?;
         Ok(())
+    }
+
+    pub(crate) async fn provision_attachment(
+        &self,
+        signing_key: &ClientSigningKey,
+        group_state_ear_key: &GroupStateEarKey,
+        group_id: &GroupId,
+        sender_index: LeafNodeIndex,
+    ) -> Result<ProvisionAttachmentResponse, DsRequestError> {
+        let qgid: QualifiedGroupId = group_id.try_into()?;
+        let payload = ProvisionAttachmentPayload {
+            group_state_ear_key: Some(group_state_ear_key.ref_into()),
+            group_id: Some(qgid.ref_into()),
+            sender: Some(sender_index.into()),
+        };
+        let request = payload.sign(signing_key)?;
+        let response = self
+            .client
+            .clone()
+            .provision_attachment(request)
+            .await?
+            .into_inner();
+        Ok(response)
+    }
+
+    pub(crate) async fn get_attachment_url(
+        &self,
+        signing_key: &ClientSigningKey,
+        group_state_ear_key: &GroupStateEarKey,
+        group_id: &GroupId,
+        sender_index: LeafNodeIndex,
+        attachment_id: AttachmentId,
+    ) -> Result<String, DsRequestError> {
+        let qgid: QualifiedGroupId = group_id.try_into()?;
+        let payload = GetAttachmentUrlPayload {
+            group_state_ear_key: Some(group_state_ear_key.ref_into()),
+            group_id: Some(qgid.ref_into()),
+            sender: Some(sender_index.into()),
+            attachment_id: Some(attachment_id.uuid().into()),
+        };
+        let request = payload.sign(signing_key)?;
+        let response = self
+            .client
+            .clone()
+            .get_attachment_url(request)
+            .await?
+            .into_inner();
+        Ok(response.download_url)
     }
 }

--- a/apiclient/src/ds_api/mod.rs
+++ b/apiclient/src/ds_api/mod.rs
@@ -12,7 +12,7 @@ use phnxcommon::{
     LibraryError,
     credentials::keys::ClientSigningKey,
     crypto::ear::keys::GroupStateEarKey,
-    identifiers::QsReference,
+    identifiers::{AttachmentId, QsReference},
     messages::{
         client_ds::UserProfileKeyUpdateParams,
         client_ds_out::{
@@ -23,6 +23,7 @@ use phnxcommon::{
     },
     time::TimeStamp,
 };
+pub use phnxprotos::delivery_service::v1::ProvisionAttachmentResponse;
 
 use crate::ApiClient;
 
@@ -202,5 +203,40 @@ impl ApiClient {
     /// Request a group ID.
     pub async fn ds_request_group_id(&self) -> Result<GroupId, DsRequestError> {
         self.ds_grpc_client.request_group_id().await
+    }
+
+    /// Provision an attachment for a group.
+    ///
+    /// The result is used to upload the attachment to the server.
+    pub async fn ds_provision_attachment(
+        &self,
+        signing_key: &ClientSigningKey,
+        group_state_ear_key: &GroupStateEarKey,
+        group_id: &GroupId,
+        sender_index: LeafNodeIndex,
+    ) -> Result<ProvisionAttachmentResponse, DsRequestError> {
+        self.ds_grpc_client
+            .provision_attachment(signing_key, group_state_ear_key, group_id, sender_index)
+            .await
+    }
+
+    /// Get the download URL for an attachment.
+    pub async fn ds_get_attachment_url(
+        &self,
+        signing_key: &ClientSigningKey,
+        group_state_ear_key: &GroupStateEarKey,
+        group_id: &GroupId,
+        sender_index: LeafNodeIndex,
+        attachment_id: AttachmentId,
+    ) -> Result<String, DsRequestError> {
+        self.ds_grpc_client
+            .get_attachment_url(
+                signing_key,
+                group_state_ear_key,
+                group_id,
+                sender_index,
+                attachment_id,
+            )
+            .await
     }
 }

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -19,8 +19,8 @@ thiserror = { workspace = true }
 serde = { version = "1", features = ["derive"] }
 async-trait = "0.1.53"
 uuid = { version = "1.0.0", features = ["v4", "serde"] }
-# Rust crypto dependencies
 tracing = { version = "0.1.35", features = ["log"] }
+# Rust crypto dependencies
 sqlx = { workspace = true, features = ["postgres", "tls-rustls"] }
 mimi-room-policy = { workspace = true }
 tokio = "1"
@@ -37,6 +37,13 @@ sha2 = "0.10"
 displaydoc = "0.2.5"
 prost.workspace = true
 base64 = "0.22.1"
+aws-sdk-s3 = { version = "1.92.0", default-features = false, features = [
+    "behavior-version-latest",
+    "http-1x",
+] }
+aws-config = { version = "1.8.0", default-features = false, features = [
+    "behavior-version-latest",
+] }
 
 [dev-dependencies]
 phnxcommon = { path = "../common", features = ["test_utils"] }

--- a/backend/src/ds/attachments.rs
+++ b/backend/src/ds/attachments.rs
@@ -1,0 +1,198 @@
+// SPDX-FileCopyrightText: 2025 Phoenix R&D GmbH <hello@phnx.im>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+use aws_sdk_s3::{
+    config::http,
+    error::{BuildError, SdkError},
+    operation::{get_object, put_object},
+    presigning::{PresigningConfig, PresigningConfigError},
+};
+use chrono::{DateTime, Duration, Utc};
+use displaydoc::Display;
+use phnxcommon::{identifiers::AttachmentId, time::ExpirationData};
+use phnxprotos::delivery_service::v1::{
+    GetAttachmentUrlResponse, HeaderEntry, ProvisionAttachmentPayload, ProvisionAttachmentResponse,
+};
+use tonic::{Response, Status};
+use tracing::error;
+use uuid::Uuid;
+
+use super::Ds;
+
+impl Ds {
+    pub(super) async fn provision_attachment(
+        &self,
+        _payload: ProvisionAttachmentPayload,
+    ) -> Result<Response<ProvisionAttachmentResponse>, ProvisionAttachmentError> {
+        let client = self
+            .storage
+            .as_ref()
+            .map(|s| s.client())
+            .ok_or(ProvisionAttachmentError::NoStorageConfigured)?;
+
+        let attachment_id = Uuid::new_v4();
+
+        let expiration = ExpirationData::now(Duration::minutes(5));
+        let not_before: DateTime<Utc> = expiration.not_before().into();
+        let not_after: DateTime<Utc> = expiration.not_after().into();
+        let duration = not_after - not_before;
+
+        let mut presigning_config = PresigningConfig::builder();
+        presigning_config.set_start_time(Some(not_before.into()));
+        presigning_config.set_expires_in(Some(duration.to_std()?));
+        let presigning_config = presigning_config.build()?;
+
+        let request = client
+            .put_object()
+            .bucket("data")
+            .key(attachment_id.as_simple().to_string())
+            .presigned(presigning_config)
+            .await
+            .map_err(Box::new)?;
+
+        let url = request.uri().to_owned();
+        let header: Vec<HeaderEntry> = request
+            .headers()
+            .map(|(k, v)| HeaderEntry {
+                key: k.to_owned(),
+                value: v.to_owned(),
+            })
+            .collect();
+
+        Ok(Response::new(ProvisionAttachmentResponse {
+            attachment_id: Some(attachment_id.into()),
+            upload_url_expiration: Some(expiration.into()),
+            upload_url: url,
+            upload_headers: header,
+        }))
+    }
+
+    pub(super) async fn get_attachment_url(
+        &self,
+        attachment_id: AttachmentId,
+    ) -> Result<Response<GetAttachmentUrlResponse>, GetAttachmentUrlError> {
+        let client = self
+            .storage
+            .as_ref()
+            .map(|s| s.client())
+            .ok_or(GetAttachmentUrlError::NoStorageConfigured)?;
+
+        let expiration = ExpirationData::now(Duration::minutes(5));
+        let not_before: DateTime<Utc> = expiration.not_before().into();
+        let not_after: DateTime<Utc> = expiration.not_after().into();
+        let duration = not_after - not_before;
+
+        let mut presigning_config = PresigningConfig::builder();
+        presigning_config.set_start_time(Some(not_before.into()));
+        presigning_config.set_expires_in(Some(duration.to_std()?));
+        let presigning_config = presigning_config.build()?;
+
+        let request = client
+            .get_object()
+            .bucket("data")
+            .key(attachment_id.uuid().as_simple().to_string())
+            .presigned(presigning_config)
+            .await
+            .map_err(Box::new)?;
+
+        let url = request.uri().to_owned();
+        let headers: Vec<HeaderEntry> = request
+            .headers()
+            .map(|(k, v)| HeaderEntry {
+                key: k.to_owned(),
+                value: v.to_owned(),
+            })
+            .collect();
+
+        Ok(Response::new(GetAttachmentUrlResponse {
+            download_url_expiration: Some(expiration.into()),
+            download_url: url,
+            download_headers: headers,
+        }))
+    }
+}
+
+#[derive(Debug, thiserror::Error, Display)]
+pub(super) enum ProvisionAttachmentError {
+    /// Attachments are not supported
+    NoStorageConfigured,
+    /// Internal error
+    Build(#[from] BuildError),
+    /// Internal error
+    Duration(#[from] chrono::OutOfRangeError),
+    /// Internal error
+    Presigning(#[from] PresigningConfigError),
+    /// Internal error
+    Sdk(#[from] Box<SdkError<put_object::PutObjectError, http::HttpResponse>>),
+}
+
+impl From<ProvisionAttachmentError> for Status {
+    fn from(error: ProvisionAttachmentError) -> Self {
+        let msg = error.to_string();
+        match error {
+            ProvisionAttachmentError::NoStorageConfigured => {
+                error!("Storage is not configured");
+                Status::internal(msg)
+            }
+            ProvisionAttachmentError::Build(error) => {
+                error!(%error, "Failed to build S3 config");
+                Status::internal(msg)
+            }
+            ProvisionAttachmentError::Duration(error) => {
+                error!(%error, "Failed to convert chrono to std duration");
+                Status::internal(msg)
+            }
+            ProvisionAttachmentError::Presigning(error) => {
+                error!(%error, "Failed to create presigning config");
+                Status::internal(msg)
+            }
+            ProvisionAttachmentError::Sdk(error) => {
+                error!(%error, "Failed to build S3 request");
+                Status::internal(msg)
+            }
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error, Display)]
+pub(super) enum GetAttachmentUrlError {
+    /// Attachments are not supported
+    NoStorageConfigured,
+    /// Internal error
+    Build(#[from] BuildError),
+    /// Internal error
+    Duration(#[from] chrono::OutOfRangeError),
+    /// Internal error
+    Presigning(#[from] PresigningConfigError),
+    /// Internal error
+    Sdk(#[from] Box<SdkError<get_object::GetObjectError, http::HttpResponse>>),
+}
+
+impl From<GetAttachmentUrlError> for Status {
+    fn from(error: GetAttachmentUrlError) -> Self {
+        let msg = error.to_string();
+        match error {
+            GetAttachmentUrlError::NoStorageConfigured => {
+                error!("Storage is not configured");
+                Status::internal(msg)
+            }
+            GetAttachmentUrlError::Build(error) => {
+                error!(%error, "Failed to build S3 config");
+                Status::internal(msg)
+            }
+            GetAttachmentUrlError::Duration(error) => {
+                error!(%error, "Failed to convert chrono to std duration");
+                Status::internal(msg)
+            }
+            GetAttachmentUrlError::Presigning(error) => {
+                error!(%error, "Failed to create presigning config");
+                Status::internal(msg)
+            }
+            GetAttachmentUrlError::Sdk(error) => {
+                error!(%error, "Failed to build S3 request");
+                Status::internal(msg)
+            }
+        }
+    }
+}

--- a/backend/src/ds/storage.rs
+++ b/backend/src/ds/storage.rs
@@ -4,12 +4,15 @@
 
 use aws_config::Region;
 use aws_sdk_s3::{Client, Config, config::Credentials};
+use chrono::Duration;
 
 use crate::settings::StorageSettings;
 
 #[derive(Debug, Clone)]
 pub struct Storage {
-    pub(crate) config: Config,
+    client: Client,
+    upload_expiration: Duration,
+    download_expiration: Duration,
 }
 
 impl Storage {
@@ -28,10 +31,24 @@ impl Storage {
             .force_path_style(settings.force_path_style)
             .behavior_version_latest()
             .build();
-        Self { config }
+        let client = Client::from_conf(config.clone());
+
+        Self {
+            client,
+            upload_expiration: settings.upload_expiration,
+            download_expiration: settings.download_expiration,
+        }
     }
 
     pub(crate) fn client(&self) -> Client {
-        Client::from_conf(self.config.clone())
+        self.client.clone()
+    }
+
+    pub(crate) fn upload_expiration(&self) -> Duration {
+        self.upload_expiration
+    }
+
+    pub(crate) fn download_expiration(&self) -> Duration {
+        self.download_expiration
     }
 }

--- a/backend/src/ds/storage.rs
+++ b/backend/src/ds/storage.rs
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: 2025 Phoenix R&D GmbH <hello@phnx.im>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+use aws_config::Region;
+use aws_sdk_s3::{Client, Config, config::Credentials};
+
+use crate::settings::StorageSettings;
+
+#[derive(Debug, Clone)]
+pub struct Storage {
+    pub(crate) config: Config,
+}
+
+impl Storage {
+    pub fn new(settings: StorageSettings) -> Self {
+        let credentials = Credentials::new(
+            settings.access_key_id,
+            settings.secret_access_key,
+            None,
+            None,
+            "storage",
+        );
+        let config = Config::builder()
+            .endpoint_url(settings.endpoint)
+            .region(Region::new(settings.region))
+            .credentials_provider(credentials)
+            .force_path_style(settings.force_path_style)
+            .behavior_version_latest()
+            .build();
+        Self { config }
+    }
+
+    pub(crate) fn client(&self) -> Client {
+        Client::from_conf(self.config.clone())
+    }
+}

--- a/backend/src/settings.rs
+++ b/backend/src/settings.rs
@@ -10,12 +10,14 @@ use serde::Deserialize;
 pub struct Settings {
     pub database: DatabaseSettings,
     pub application: ApplicationSettings,
-    // If this isn't present, the provider will not send push notifications to
-    // apple devices.
+    /// If this isn't present, the provider will not send push notifications to
+    /// apple devices.
     pub apns: Option<ApnsSettings>,
-    // If this isn't present, the provider will not send push notifications to
-    // android devices.
+    /// If this isn't present, the provider will not send push notifications to
+    /// android devices.
     pub fcm: Option<FcmSettings>,
+    /// If this isn't present, the support for attachments is disabled.
+    pub storage: Option<StorageSettings>,
 }
 
 /// Configuration for the application.
@@ -54,6 +56,21 @@ pub struct ApnsSettings {
     pub keyid: String,
     pub teamid: String,
     pub privatekeypath: String,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct StorageSettings {
+    /// Endpoint for the storage provider
+    pub endpoint: String,
+    /// Region for the storage provider
+    pub region: String,
+    /// Access key ID for the storage provider
+    pub access_key_id: String,
+    /// Secret access key for the storage provider
+    pub secret_access_key: String,
+    /// Force path style for the storage provider
+    #[serde(default)]
+    pub force_path_style: bool,
 }
 
 impl DatabaseSettings {

--- a/common/src/identifiers/attachment.rs
+++ b/common/src/identifiers/attachment.rs
@@ -1,0 +1,78 @@
+// SPDX-FileCopyrightText: 2025 Phoenix R&D GmbH <hello@phnx.im>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+use url::Url;
+use uuid::Uuid;
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, PartialOrd, Ord, Hash)]
+pub struct AttachmentId {
+    pub uuid: Uuid,
+}
+
+impl AttachmentId {
+    pub fn new(uuid: Uuid) -> Self {
+        Self { uuid }
+    }
+
+    pub fn url(&self) -> String {
+        format!("phnx:///attachment/{}", self.uuid)
+    }
+
+    pub fn from_url(url: &str) -> Option<Self> {
+        let url = Url::parse(url).ok()?;
+        if url.scheme() != "phnx" {
+            return None;
+        }
+        let suffix = url.path().strip_prefix("/attachment/")?;
+        let uuid = suffix.parse().ok()?;
+        Some(Self { uuid })
+    }
+
+    pub fn uuid(&self) -> Uuid {
+        self.uuid
+    }
+}
+
+mod sqlx_impls {
+    use sqlx::{Database, Decode, Encode, Sqlite, Type, encode::IsNull, error::BoxDynError};
+
+    use super::*;
+
+    impl Type<Sqlite> for AttachmentId {
+        fn type_info() -> <Sqlite as Database>::TypeInfo {
+            <Uuid as Type<Sqlite>>::type_info()
+        }
+    }
+
+    impl<'q> Encode<'q, Sqlite> for AttachmentId {
+        fn encode_by_ref(
+            &self,
+            buf: &mut <Sqlite as Database>::ArgumentBuffer<'q>,
+        ) -> Result<IsNull, BoxDynError> {
+            Encode::<Sqlite>::encode_by_ref(&self.uuid, buf)
+        }
+    }
+
+    impl<'r> Decode<'r, Sqlite> for AttachmentId {
+        fn decode(value: <Sqlite as Database>::ValueRef<'r>) -> Result<Self, BoxDynError> {
+            let id: Uuid = Decode::<Sqlite>::decode(value)?;
+            Ok(Self::new(id))
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use uuid::Uuid;
+
+    #[test]
+    fn from_url() {
+        let url = "phnx:///attachment/b6a42a7a-62fa-4c10-acfb-6124d80aae09?width=1920&height=1080";
+        let attachment_id = super::AttachmentId::from_url(url).unwrap();
+        assert_eq!(
+            attachment_id.uuid,
+            Uuid::parse_str("b6a42a7a-62fa-4c10-acfb-6124d80aae09").unwrap()
+        );
+    }
+}

--- a/common/src/identifiers/mod.rs
+++ b/common/src/identifiers/mod.rs
@@ -21,12 +21,14 @@ use super::*;
 
 mod tls_codec_impls;
 
+pub use attachment::AttachmentId;
 pub use user_handle::{
     USER_HANDLE_VALIDITY_PERIOD, UserHandle, UserHandleHash, UserHandleHashError,
     UserHandleValidationError,
 };
 
 pub use tls_codec_impls::{TlsStr, TlsString};
+mod attachment;
 mod user_handle;
 
 pub const QS_CLIENT_REFERENCE_EXTENSION_TYPE: u16 = 0xff00;

--- a/common/src/time.rs
+++ b/common/src/time.rs
@@ -160,10 +160,20 @@ impl ExpirationData {
     }
 
     /// Create a new instance of [`ExpirationData`] that expires in `lifetime`
-    /// days and the validity of which starts now.
+    /// days and the validity of which starts 15 minutes before the current time.
     pub fn new(lifetime: Duration) -> Self {
         // Note: databases only support microsecond precision.
         let not_before = Utc::now().round_subsecs(6) - Duration::minutes(15);
+        Self {
+            not_before: TimeStamp::from(not_before),
+            not_after: TimeStamp::from(not_before + lifetime),
+        }
+    }
+
+    /// Create a new instance of [`ExpirationData`] that expires in `lifetime`
+    /// days and the validity of which starts now.
+    pub fn now(lifetime: Duration) -> Self {
+        let not_before = Utc::now().round_subsecs(6);
         Self {
             not_before: TimeStamp::from(not_before),
             not_after: TimeStamp::from(not_before + lifetime),

--- a/common/src/time.rs
+++ b/common/src/time.rs
@@ -10,6 +10,11 @@ use super::*;
 
 pub use chrono::Duration;
 
+/// Number of digits to round when constructing a [`TimeStamp`].
+///
+/// Note: Databases only support microsecond precision.
+const ROUND_SUBSECS_DIGITS: u16 = 6;
+
 /// A time stamp that can be used to represent a point in time.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Eq, Hash, Copy, sqlx::Type)]
 #[sqlx(transparent)]
@@ -101,7 +106,7 @@ impl TimeStamp {
     /// Same as [`Utc::now`], but rounded to microsecond precision.
     pub fn now() -> Self {
         // Note: databases only support microsecond precision.
-        Utc::now().round_subsecs(6).into()
+        Utc::now().round_subsecs(ROUND_SUBSECS_DIGITS).into()
     }
 
     /// Checks if this time stamp is more than `expiration` in the past.
@@ -162,8 +167,7 @@ impl ExpirationData {
     /// Create a new instance of [`ExpirationData`] that expires in `lifetime`
     /// days and the validity of which starts 15 minutes before the current time.
     pub fn new(lifetime: Duration) -> Self {
-        // Note: databases only support microsecond precision.
-        let not_before = Utc::now().round_subsecs(6) - Duration::minutes(15);
+        let not_before = Utc::now().round_subsecs(ROUND_SUBSECS_DIGITS) - Duration::minutes(15);
         Self {
             not_before: TimeStamp::from(not_before),
             not_after: TimeStamp::from(not_before + lifetime),
@@ -173,7 +177,7 @@ impl ExpirationData {
     /// Create a new instance of [`ExpirationData`] that expires in `lifetime`
     /// days and the validity of which starts now.
     pub fn now(lifetime: Duration) -> Self {
-        let not_before = Utc::now().round_subsecs(6);
+        let not_before = Utc::now().round_subsecs(ROUND_SUBSECS_DIGITS);
         Self {
             not_before: TimeStamp::from(not_before),
             not_after: TimeStamp::from(not_before + lifetime),

--- a/compose.yaml
+++ b/compose.yaml
@@ -19,9 +19,9 @@ services:
       -c ssl_key_file=/etc/postgresql/certs/server.key
       -c ssl_ca_file=/etc/postgresql/certs/root.crt
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U postgres -h 127.0.0.1"]
+      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB"]
       start_period: 1s
-      interval: 1s
+      interval: 2s
       timeout: 5s
       retries: 10
     ports:
@@ -32,8 +32,40 @@ services:
       - ./backend/test_certs/server.key:/etc/postgresql/certs/server.key:ro,z
       - ./backend/test_certs/root.crt:/etc/postgresql/certs/root.crt:ro,z
 
+  minio:
+    image: minio/minio:latest
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    volumes:
+      - minio_data:/data
+    environment:
+      MINIO_ROOT_USER: minioadmin
+      MINIO_ROOT_PASSWORD: minioadmin
+    command: server /data --console-address ":9001"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      start_period: 1s
+      interval: 2s
+      timeout: 5s
+      retries: 10
+
+  minio-setup:
+    image: minio/mc
+    depends_on:
+      minio:
+        condition: service_healthy
+    restart: "no"
+    entrypoint: >
+      sh -exc "
+      mc alias set local http://minio:9000 minioadmin minioadmin;
+      mc admin user add local minioaccesskey miniosecretkey;
+      mc admin policy attach local readwrite --user=minioaccesskey;
+      mc mb local/data"
+
 x-podman:
   in_pod: false
 
 volumes:
   postgres_data:
+  minio_data:

--- a/protos/api/auth_service/v1/auth_service.proto
+++ b/protos/api/auth_service/v1/auth_service.proto
@@ -86,11 +86,6 @@ message MlsInfraVersion {
   uint32 version = 1;
 }
 
-message ExpirationData {
-  common.v1.Timestamp not_before = 1;
-  common.v1.Timestamp not_after = 2;
-}
-
 message EncryptedUserProfile {
   common.v1.IndexedCiphertext ciphertext = 1;
 }
@@ -103,7 +98,7 @@ message ConnectionPackage {
 message ConnectionPackagePayload {
   MlsInfraVersion protocol_version = 1;
   ConnectionEncryptionKey encryption_key = 2;
-  ExpirationData lifetime = 3;
+  common.v1.ExpirationData lifetime = 3;
   ClientCredential client_credential = 4;
 }
 
@@ -118,7 +113,7 @@ message ClientCredential {
 
 message ClientCredentialPayload {
   ClientCredentialCsr csr = 1;
-  ExpirationData expiration_data = 2;
+  common.v1.ExpirationData expiration_data = 2;
   CredentialFingerprint credential_fingerprint = 3;
 }
 
@@ -274,7 +269,7 @@ message AsCredential {
 message AsCredentialBody {
   MlsInfraVersion version = 1;
   common.v1.Fqdn user_domain = 2;
-  ExpirationData expiration_data = 3;
+  common.v1.ExpirationData expiration_data = 3;
   SignatureScheme signature_scheme = 4;
   AsVerifyingKey verifying_key = 5;
 }
@@ -295,7 +290,7 @@ message AsIntermediateCredentialBody {
 
 message AsIntermediateCredentialPayload {
   AsIntermediateCredentialCsr csr = 1;
-  ExpirationData expiration_data = 2;
+  common.v1.ExpirationData expiration_data = 2;
   CredentialFingerprint signer_fingerprint = 3;
 }
 

--- a/protos/api/common/v1/common.proto
+++ b/protos/api/common/v1/common.proto
@@ -55,3 +55,8 @@ message HpkeCiphertext {
   bytes kem_output = 1;
   bytes ciphertext = 2;
 }
+
+message ExpirationData {
+  Timestamp not_before = 1;
+  Timestamp not_after = 2;
+}

--- a/protos/api/delivery_service/v1/delivery_service.proto
+++ b/protos/api/delivery_service/v1/delivery_service.proto
@@ -35,6 +35,20 @@ service DeliveryService {
   rpc GroupOperation(GroupOperationRequest) returns (GroupOperationResponse);
 
   rpc UpdateProfileKey(UpdateProfileKeyRequest) returns (UpdateProfileKeyResponse);
+
+  // Generates an attachment ID and returns a pre-signed URL for uploading an attachment.
+  //
+  // The actual upload is done by the client.
+  //
+  // Note: An attachment is always provisioned relative to a specific group.
+  rpc ProvisionAttachment(ProvisionAttachmentRequest) returns (ProvisionAttachmentResponse);
+
+  // Returns a URL for downloading attachment.
+  //
+  // The actual download is done by the client.
+  //
+  // Note: An attachment is always retrieved relative to a specific group.
+  rpc GetAttachmentUrl(GetAttachmentUrlRequest) returns (GetAttachmentUrlResponse);
 }
 
 // common messages
@@ -298,3 +312,48 @@ message UpdateProfileKeyPayload {
 }
 
 message UpdateProfileKeyResponse {}
+
+// provision attachment
+
+message ProvisionAttachmentRequest {
+  ProvisionAttachmentPayload payload = 1;
+  common.v1.Signature signature = 2;
+}
+
+message ProvisionAttachmentPayload {
+  GroupStateEarKey group_state_ear_key = 1;
+  common.v1.QualifiedGroupId group_id = 2;
+  LeafNodeIndex sender = 3;
+}
+
+message ProvisionAttachmentResponse {
+  common.v1.Uuid attachment_id = 1;
+  common.v1.ExpirationData upload_url_expiration = 2;
+  string upload_url = 4; // non-empty
+  repeated HeaderEntry upload_headers = 5; // can be empty
+}
+
+message HeaderEntry {
+  string key = 1;
+  string value = 2;
+}
+
+// get attachment url
+
+message GetAttachmentUrlRequest {
+  GetAttachmentUrlPayload payload = 1;
+  common.v1.Signature signature = 2;
+}
+
+message GetAttachmentUrlPayload {
+  GroupStateEarKey group_state_ear_key = 1;
+  common.v1.QualifiedGroupId group_id = 2;
+  LeafNodeIndex sender = 3;
+  common.v1.Uuid attachment_id = 4;
+}
+
+message GetAttachmentUrlResponse {
+  common.v1.ExpirationData download_url_expiration = 1;
+  string download_url = 2;
+  repeated HeaderEntry download_headers = 3;
+}

--- a/protos/src/auth_service/convert.rs
+++ b/protos/src/auth_service/convert.rs
@@ -11,13 +11,15 @@ use phnxcommon::{
         self,
         client_as::{self, ConnectionPackageHashError},
     },
-    time,
 };
 use thiserror::Error;
 use tonic::Status;
 
 use crate::{
-    common::{convert::InvalidIndexedCiphertext, v1::Signature},
+    common::{
+        convert::{ExpirationDataError, InvalidIndexedCiphertext},
+        v1::Signature,
+    },
     convert::TryRefInto,
     validation::{MissingFieldError, MissingFieldExt},
 };
@@ -27,8 +29,8 @@ use super::v1::{
     AsIntermediateCredentialCsr, AsIntermediateCredentialPayload, AsIntermediateVerifyingKey,
     AsVerifyingKey, ClientCredential, ClientCredentialCsr, ClientCredentialPayload,
     ClientVerifyingKey, ConnectionEncryptionKey, ConnectionOfferMessage, ConnectionPackage,
-    ConnectionPackagePayload, CredentialFingerprint, EncryptedUserProfile, ExpirationData,
-    HandleSignature, HandleVerifyingKey, MlsInfraVersion, SignatureScheme, UserHandleHash, UserId,
+    ConnectionPackagePayload, CredentialFingerprint, EncryptedUserProfile, HandleSignature,
+    HandleVerifyingKey, MlsInfraVersion, SignatureScheme, UserHandleHash, UserId,
 };
 
 impl From<identifiers::UserId> for UserId {
@@ -179,32 +181,6 @@ impl TryFrom<MlsInfraVersion> for messages::MlsInfraVersion {
         match value.version {
             0 => Ok(messages::MlsInfraVersion::Alpha),
             _ => Err(UnsupportedMlsVersion(value.version)),
-        }
-    }
-}
-
-impl TryFrom<ExpirationData> for time::ExpirationData {
-    type Error = ExpirationDataError;
-
-    fn try_from(value: ExpirationData) -> Result<Self, Self::Error> {
-        Ok(Self::from_parts(
-            value.not_before.ok_or_missing_field("not_before")?.into(),
-            value.not_after.ok_or_missing_field("not_after")?.into(),
-        ))
-    }
-}
-
-#[derive(Debug, thiserror::Error)]
-pub enum ExpirationDataError {
-    #[error(transparent)]
-    MissingField(#[from] MissingFieldError<&'static str>),
-}
-
-impl From<time::ExpirationData> for ExpirationData {
-    fn from(value: time::ExpirationData) -> Self {
-        Self {
-            not_before: Some(value.not_before().into()),
-            not_after: Some(value.not_after().into()),
         }
     }
 }

--- a/protos/src/common/convert.rs
+++ b/protos/src/common/convert.rs
@@ -18,6 +18,7 @@ use phnxcommon::{
 use tonic::Status;
 
 use crate::{
+    common::v1::ExpirationData,
     convert::{FromRef, TryFromRef, TryRefInto},
     validation::{MissingFieldError, MissingFieldExt},
 };
@@ -349,6 +350,32 @@ impl From<HpkeCiphertext> for openmls::prelude::HpkeCiphertext {
         Self {
             kem_output: proto.kem_output.into(),
             ciphertext: proto.ciphertext.into(),
+        }
+    }
+}
+
+impl TryFrom<ExpirationData> for time::ExpirationData {
+    type Error = ExpirationDataError;
+
+    fn try_from(value: ExpirationData) -> Result<Self, Self::Error> {
+        Ok(Self::from_parts(
+            value.not_before.ok_or_missing_field("not_before")?.into(),
+            value.not_after.ok_or_missing_field("not_after")?.into(),
+        ))
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ExpirationDataError {
+    #[error(transparent)]
+    MissingField(#[from] MissingFieldError<&'static str>),
+}
+
+impl From<time::ExpirationData> for ExpirationData {
+    fn from(value: time::ExpirationData) -> Self {
+        Self {
+            not_before: Some(value.not_before().into()),
+            not_after: Some(value.not_after().into()),
         }
     }
 }

--- a/protos/src/delivery_service/sign.rs
+++ b/protos/src/delivery_service/sign.rs
@@ -4,6 +4,11 @@
 
 use prost::Message;
 
+use crate::delivery_service::v1::{
+    GetAttachmentUrlPayload, GetAttachmentUrlRequest, ProvisionAttachmentPayload,
+    ProvisionAttachmentRequest,
+};
+
 use super::v1::{
     CreateGroupPayload, CreateGroupRequest, DeleteGroupPayload, DeleteGroupRequest,
     GroupOperationPayload, GroupOperationRequest, ResyncPayload, ResyncRequest, SelfRemovePayload,
@@ -482,6 +487,110 @@ impl Verifiable for UpdateProfileKeyRequest {
 
     fn label(&self) -> &str {
         UPDATE_PROFILE_KEY_PAYLOAD_LABEL
+    }
+}
+
+const PROVISION_ATTACHMENT_PAYLOAD_LABEL: &str = "ProvisionAttachmentPayload";
+
+impl SignedStruct<ProvisionAttachmentPayload, ClientKeyType> for ProvisionAttachmentRequest {
+    fn from_payload(payload: ProvisionAttachmentPayload, signature: ClientSignature) -> Self {
+        Self {
+            payload: Some(payload),
+            signature: Some(signature.into()),
+        }
+    }
+}
+
+impl Signable for ProvisionAttachmentPayload {
+    type SignedOutput = ProvisionAttachmentRequest;
+
+    fn unsigned_payload(&self) -> Result<Vec<u8>, tls_codec::Error> {
+        Ok(self.encode_to_vec())
+    }
+
+    fn label(&self) -> &str {
+        PROVISION_ATTACHMENT_PAYLOAD_LABEL
+    }
+}
+
+impl VerifiedStruct<ProvisionAttachmentRequest> for ProvisionAttachmentPayload {
+    type SealingType = private_mod::Seal;
+
+    fn from_verifiable(verifiable: ProvisionAttachmentRequest, _seal: Self::SealingType) -> Self {
+        verifiable.payload.unwrap()
+    }
+}
+
+impl Verifiable for ProvisionAttachmentRequest {
+    fn unsigned_payload(&self) -> Result<Vec<u8>, tls_codec::Error> {
+        Ok(self
+            .payload
+            .as_ref()
+            .ok_or(MissingPayloadError)?
+            .encode_to_vec())
+    }
+
+    fn signature(&self) -> impl AsRef<[u8]> {
+        self.signature
+            .as_ref()
+            .map(|s| s.value.as_slice())
+            .unwrap_or_default()
+    }
+
+    fn label(&self) -> &str {
+        PROVISION_ATTACHMENT_PAYLOAD_LABEL
+    }
+}
+
+const GET_ATTACHMENT_PAYLOAD_LABEL: &str = "GetAttachmentPayload";
+
+impl SignedStruct<GetAttachmentUrlPayload, ClientKeyType> for GetAttachmentUrlRequest {
+    fn from_payload(payload: GetAttachmentUrlPayload, signature: ClientSignature) -> Self {
+        Self {
+            payload: Some(payload),
+            signature: Some(signature.into()),
+        }
+    }
+}
+
+impl Signable for GetAttachmentUrlPayload {
+    type SignedOutput = GetAttachmentUrlRequest;
+
+    fn unsigned_payload(&self) -> Result<Vec<u8>, tls_codec::Error> {
+        Ok(self.encode_to_vec())
+    }
+
+    fn label(&self) -> &str {
+        GET_ATTACHMENT_PAYLOAD_LABEL
+    }
+}
+
+impl VerifiedStruct<GetAttachmentUrlRequest> for GetAttachmentUrlPayload {
+    type SealingType = private_mod::Seal;
+
+    fn from_verifiable(verifiable: GetAttachmentUrlRequest, _seal: Self::SealingType) -> Self {
+        verifiable.payload.unwrap()
+    }
+}
+
+impl Verifiable for GetAttachmentUrlRequest {
+    fn unsigned_payload(&self) -> Result<Vec<u8>, tls_codec::Error> {
+        Ok(self
+            .payload
+            .as_ref()
+            .ok_or(MissingPayloadError)?
+            .encode_to_vec())
+    }
+
+    fn signature(&self) -> impl AsRef<[u8]> {
+        self.signature
+            .as_ref()
+            .map(|s| s.value.as_slice())
+            .unwrap_or_default()
+    }
+
+    fn label(&self) -> &str {
+        GET_ATTACHMENT_PAYLOAD_LABEL
     }
 }
 

--- a/server/configuration/local.yaml
+++ b/server/configuration/local.yaml
@@ -5,3 +5,10 @@
 application:
   domain: localhost
   host: 127.0.0.1
+
+storage:
+  endpoint: http://localhost:9000
+  region: eu-west-1
+  access_key_id: minioaccesskey
+  secret_access_key: miniosecretkey
+  force_path_style: true

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -4,7 +4,12 @@
 
 use std::time::Duration;
 
-use phnxbackend::{auth_service::AuthService, ds::Ds, infra_service::InfraService, qs::Qs};
+use phnxbackend::{
+    auth_service::AuthService,
+    ds::{Ds, storage::Storage},
+    infra_service::InfraService,
+    qs::Qs,
+};
 use phnxcommon::identifiers::Fqdn;
 use phnxserver::{
     RateLimitsConfig, ServerRunParams,
@@ -69,7 +74,11 @@ async fn main() -> anyhow::Result<()> {
         }
         ds_result = Ds::new(&configuration.database, domain.clone()).await;
     }
-    let ds = ds_result.unwrap();
+    let mut ds = ds_result.unwrap();
+    if let Some(storage_settings) = &configuration.storage {
+        let storage = Storage::new(storage_settings.clone());
+        ds.set_storage(storage);
+    }
 
     // New database name for the QS provider
     configuration.database.name = format!("{}_qs", base_db_name);


### PR DESCRIPTION
This commit adds support for attachments to the delivery service.

Attachments are provisioned using a new `ProvisionAttachment` gRPC
method. This method returns a pre-signed URL for uploading the
attachment, along with the necessary headers. A new `GetAttachmentUrl`
method retrieves a pre-signed URL for downloading attachments.

Minio is added to docker compose as a development storage backend.