### PR TITLE
CI: fix dart being formatted differently in CI

### DIFF
--- a/.github/workflows/flutter_test.yml
+++ b/.github/workflows/flutter_test.yml
@@ -16,17 +16,6 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  flutter-check-localizations:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: extractions/setup-just@v2
-      - name: Set up Flutter FVM
-        uses: kuhnroyal/flutter-fvm-config-action/setup@v3
-        with:
-          path: 'app/.fvmrc'
-      - run: just check-l10n
-
   flutter-test:
     runs-on: ubuntu-latest
 
@@ -44,8 +33,16 @@ jobs:
         with:
           path: 'app/.fvmrc'
 
-      - name: Set up Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+      - name: Check Flutter lockfile
+        run: just check-flutter-lockfile
+
+      # Note: for formatting to use the correct style, we need to run `flutter
+      # pub get` first. This is done in the `check-dart-format` step.
+      - name: Check dart format
+        run: just check-dart-format
+
+      - name: Check localization
+        run: just check-l10n
 
       - name: Analyze dart code
         run: just analyze-dart

--- a/justfile
+++ b/justfile
@@ -67,18 +67,41 @@ frb-generate $CARGO_TARGET_DIR=(justfile_directory() + "/target/frb_codegen"):
 # `flutter_rust_bridge_codegen` runs the `dart run build_runner build` command,
 # which updates the generated files.
 check-frb: frb-generate
-    #!/usr/bin/env -S bash -eu
-    if [ -n "$(git status --porcelain)" ]; then
-        git add -N .
-        git --no-pager diff
-        echo -e "\x1b[1;31mFound uncommitted changes. Did you forget to run 'just frb-generate'?"
-        exit 1
-    fi
+    just check-clean-repo "just frb-generate"
 
 # same as check-generated-frb (with all prerequisite steps for running in CI)
 check-frb-ci: install-cargo-binstall
     cargo binstall flutter_rust_bridge_codegen@2.10.0 cargo-expand
     just check-frb
+
+check-clean-repo command:
+    #!/usr/bin/env -S bash -eu
+    if [ -n "$(git status --porcelain)" ]; then
+        git add -N .
+        git --no-pager diff
+        echo -e "\x1b[1;31mFound uncommitted changes. Did you forget to run '{{command}}'?"
+        exit 1
+    fi
+
+# update the Flutter dependencies
+[working-directory: 'app']
+flutter-pub-get:
+    flutter pub get
+
+# check that the Flutter lockfile is up to date
+[working-directory: 'app']
+check-flutter-lockfile: flutter-pub-get
+    just check-clean-repo "just flutter-pub-get"
+
+# format dart code
+[working-directory: 'app']
+dart-format:
+    dart format .
+
+# check that dart code is formatted
+[working-directory: 'app']
+check-dart-format: dart-format
+    just check-clean-repo "just dart-format"
 
 # generate localization files
 [working-directory: 'app']
@@ -88,14 +111,7 @@ gen-l10n:
 # check that the localization files are up to date
 [working-directory: 'app']
 check-l10n: gen-l10n
-    #!/usr/bin/env -S bash -eu
-    if [ -n "$(git status --porcelain)" ]; then
-        git add -N .
-        git --no-pager diff
-        echo -e "\x1b[1;31mFound uncommitted changes. Did you forget to check in generated localization?"
-        echo -e "\x1b[1;31mConsider to run 'just gen-l10n' manually."
-        exit 1
-    fi
+    just check-clean-repo "just gen-l10n"
 
 # set up the CI environment for the app
 install-cargo-binstall:


### PR DESCRIPTION
Also merge `flutter-test` and `flutter-check-localizations` in CI into a
single job to avoid installing Flutter SDK twice in CI. Additionally,
add a step to check that the Flutter lockfile is up to date. Also 
remove unneeded Rust toolchain setup because it is not used.