### PR TITLE
fix: use Rust toolchain in cargokit as specified in rust-toolchain.toml

### DIFF
--- a/app/rust_builder/android/build.gradle
+++ b/app/rust_builder/android/build.gradle
@@ -52,5 +52,6 @@ android {
 apply from: "../cargokit/gradle/plugin.gradle"
 cargokit {
     manifestDir = "../../../applogic"
+    toolchainToml = "../../../rust-toolchain.toml"
     libname = "phnxapplogic"
 }

--- a/app/rust_builder/cargokit/build_pod.sh
+++ b/app/rust_builder/cargokit/build_pod.sh
@@ -25,6 +25,9 @@ export CARGOKIT_CONFIGURATION=$CONFIGURATION
 # Path to directory containing Cargo.toml.
 export CARGOKIT_MANIFEST_DIR=$PODS_TARGET_SRCROOT/$1
 
+# Path to rust-toolchain.toml file.
+export CARGOKIT_TOOLCHAIN_TOML=$PODS_TARGET_SRCROOT/$3
+
 # Temporary directory for build artifacts.
 export CARGOKIT_TARGET_TEMP_DIR=$TARGET_TEMP_DIR
 

--- a/app/rust_builder/cargokit/build_tool/lib/src/builder.dart
+++ b/app/rust_builder/cargokit/build_tool/lib/src/builder.dart
@@ -142,6 +142,11 @@ class RustBuilder {
   Future<String> build() async {
     final extraArgs = _buildOptions?.flags ?? [];
     final manifestPath = path.join(environment.manifestDir, 'Cargo.toml');
+
+    final version =
+        runCommand('rustup', ['run', _toolchain, 'cargo', '--version']);
+    print('Using cargo version from toolchain $_toolchain: ${version.stdout}');
+
     runCommand(
       'rustup',
       [

--- a/app/rust_builder/cargokit/build_tool/lib/src/builder.dart
+++ b/app/rust_builder/cargokit/build_tool/lib/src/builder.dart
@@ -88,8 +88,11 @@ class BuildEnvironment {
     final manifestDir = Environment.manifestDir;
     final crateOptions = CargokitCrateOptions.load(
       manifestDir: manifestDir,
+      buildConfiguration: buildConfiguration,
+      toolchainToml: Environment.toolchainToml,
     );
     final crateInfo = CrateInfo.load(manifestDir);
+
     return BuildEnvironment(
       configuration: buildConfiguration,
       crateOptions: crateOptions,

--- a/app/rust_builder/cargokit/build_tool/lib/src/environment.dart
+++ b/app/rust_builder/cargokit/build_tool/lib/src/environment.dart
@@ -28,6 +28,9 @@ class Environment {
   /// not resolved on purpose.
   static String get rootProjectDir => _getEnv('CARGOKIT_ROOT_PROJECT_DIR');
 
+  /// Path to the rust-toolchain.toml file.
+  static String get toolchainToml => _getEnvPath('CARGOKIT_TOOLCHAIN_TOML');
+
   // Pod
 
   /// Platform name (macosx, iphoneos, iphonesimulator).

--- a/app/rust_builder/cargokit/cmake/cargokit.cmake
+++ b/app/rust_builder/cargokit/cmake/cargokit.cmake
@@ -14,7 +14,7 @@ endif()
 # - lib_name: cargo package name
 # - any_symbol_name: name of any exported symbol from the library.
 #                    used on windows to force linking with library.
-function(apply_cargokit target manifest_dir lib_name any_symbol_name)
+function(apply_cargokit target manifest_dir toolchain_toml lib_name any_symbol_name)
 
     set(CARGOKIT_LIB_NAME "${lib_name}")
     set(CARGOKIT_LIB_FULL_NAME "${CMAKE_SHARED_MODULE_PREFIX}${CARGOKIT_LIB_NAME}${CMAKE_SHARED_MODULE_SUFFIX}")
@@ -37,6 +37,7 @@ function(apply_cargokit target manifest_dir lib_name any_symbol_name)
         "CARGOKIT_CMAKE=${CMAKE_COMMAND}"
         "CARGOKIT_CONFIGURATION=$<CONFIG>"
         "CARGOKIT_MANIFEST_DIR=${CMAKE_CURRENT_SOURCE_DIR}/${manifest_dir}"
+        "CARGOKIT_TOOLCHAIN_TOML=${CMAKE_CURRENT_SOURCE_DIR}/${toolchain_toml}"
         "CARGOKIT_TARGET_TEMP_DIR=${CARGOKIT_TEMP_DIR}"
         "CARGOKIT_OUTPUT_DIR=${CARGOKIT_OUTPUT_DIR}"
         "CARGOKIT_TARGET_PLATFORM=${CARGOKIT_TARGET_PLATFORM}"

--- a/app/rust_builder/cargokit/gradle/plugin.gradle
+++ b/app/rust_builder/cargokit/gradle/plugin.gradle
@@ -53,10 +53,16 @@ abstract class CargoKitBuildTask extends DefaultTask {
             throw new GradleException("Property 'libname' must be set on cargokit extension");
         }
 
+        if (project.cargokit.toolchainToml == null) {
+            throw new GradleException("Property 'toolchainToml' must be set on cargokit extension");
+        }
+
         def executableName = Os.isFamily(Os.FAMILY_WINDOWS) ? "run_build_tool.cmd" : "run_build_tool.sh"
         def path = Paths.get(new File(pluginFile).parent, "..", executableName);
 
         def manifestDir = Paths.get(project.buildscript.sourceFile.parent, project.cargokit.manifestDir)
+
+        def toolchainToml = Paths.get(project.buildscript.sourceFile.parent, project.cargokit.toolchainToml)
 
         def rootProjectDir = project.rootProject.projectDir
 

--- a/app/rust_builder/cargokit/gradle/plugin.gradle
+++ b/app/rust_builder/cargokit/gradle/plugin.gradle
@@ -11,6 +11,7 @@ apply plugin: CargoKitPlugin
 class CargoKitExtension {
     String manifestDir; // Relative path to folder containing Cargo.toml
     String libname; // Library name within Cargo.toml. Must be a cdylib
+    String toolchainToml; // Relative path to rust-toolchain.toml
 }
 
 abstract class CargoKitBuildTask extends DefaultTask {
@@ -72,6 +73,7 @@ abstract class CargoKitBuildTask extends DefaultTask {
             environment "CARGOKIT_TOOL_TEMP_DIR", "${buildDir}/build_tool"
             environment "CARGOKIT_MANIFEST_DIR", manifestDir
             environment "CARGOKIT_CONFIGURATION", buildMode
+            environment "CARGOKIT_TOOLCHAIN_TOML", toolchainToml
             environment "CARGOKIT_TARGET_TEMP_DIR", buildDir
             environment "CARGOKIT_OUTPUT_DIR", outputDir
             environment "CARGOKIT_NDK_VERSION", ndkVersion

--- a/app/rust_builder/ios/phnxapplogic.podspec
+++ b/app/rust_builder/ios/phnxapplogic.podspec
@@ -29,7 +29,7 @@ A new Flutter FFI plugin project.
   s.script_phase = {
     :name => 'Build Rust library',
     # First argument is relative path to the `rust` folder, second is name of rust library
-    :script => 'sh "$PODS_TARGET_SRCROOT/../cargokit/build_pod.sh" ../../../applogic phnxapplogic',
+    :script => 'sh "$PODS_TARGET_SRCROOT/../cargokit/build_pod.sh" ../../../applogic phnxapplogic ../../../rust-toolchain.toml',
     :execution_position => :before_compile,
     :input_files => ['${BUILT_PRODUCTS_DIR}/cargokit_phony'],
     # Let XCode know that the static library referenced in -force_load below is

--- a/app/rust_builder/linux/CMakeLists.txt
+++ b/app/rust_builder/linux/CMakeLists.txt
@@ -8,7 +8,7 @@ set(PROJECT_NAME "phnxapplogic")
 project(${PROJECT_NAME} LANGUAGES CXX)
 
 include("../cargokit/cmake/cargokit.cmake")
-apply_cargokit(${PROJECT_NAME} ../../../applogic phnxapplogic "")
+apply_cargokit(${PROJECT_NAME} ../../../applogic ../../../rust-toolchain.toml phnxapplogic "")
 
 # List of absolute paths to libraries that should be bundled with the plugin.
 # This list could contain prebuilt libraries, or libraries created by an

--- a/app/rust_builder/macos/phnxapplogic.podspec
+++ b/app/rust_builder/macos/phnxapplogic.podspec
@@ -28,7 +28,7 @@ A new Flutter FFI plugin project.
   s.script_phase = {
     :name => 'Build Rust library',
     # First argument is relative path to the `rust` folder, second is name of rust library
-    :script => 'sh "$PODS_TARGET_SRCROOT/../cargokit/build_pod.sh" ../../../applogic phnxapplogic',
+    :script => 'sh "$PODS_TARGET_SRCROOT/../cargokit/build_pod.sh" ../../../applogic phnxapplogic ../../../rust-toolchain.toml',
     :execution_position => :before_compile,
     :input_files => ['${BUILT_PRODUCTS_DIR}/cargokit_phony'],
     # Let XCode know that the static library referenced in -force_load below is

--- a/app/rust_builder/windows/CMakeLists.txt
+++ b/app/rust_builder/windows/CMakeLists.txt
@@ -9,7 +9,7 @@ set(PROJECT_NAME "phnxapplogic")
 project(${PROJECT_NAME} LANGUAGES CXX)
 
 include("../cargokit/cmake/cargokit.cmake")
-apply_cargokit(${PROJECT_NAME} ../../../../../../../applogic phnxapplogic "")
+apply_cargokit(${PROJECT_NAME} ../../../../../../../applogic ../../../../../../../toolchain.toml phnxapplogic "")
 
 # List of absolute paths to libraries that should be bundled with the plugin.
 # This list could contain prebuilt libraries, or libraries created by an

--- a/app/rust_builder/windows/CMakeLists.txt
+++ b/app/rust_builder/windows/CMakeLists.txt
@@ -9,7 +9,7 @@ set(PROJECT_NAME "phnxapplogic")
 project(${PROJECT_NAME} LANGUAGES CXX)
 
 include("../cargokit/cmake/cargokit.cmake")
-apply_cargokit(${PROJECT_NAME} ../../../../../../../applogic ../../../../../../../toolchain.toml phnxapplogic "")
+apply_cargokit(${PROJECT_NAME} ../../../../../../../applogic ../../../../../../../rust-toolchain.toml phnxapplogic "")
 
 # List of absolute paths to libraries that should be bundled with the plugin.
 # This list could contain prebuilt libraries, or libraries created by an

--- a/applogic/src/notifications.rs
+++ b/applogic/src/notifications.rs
@@ -72,19 +72,19 @@ impl User {
         notifications: &mut Vec<NotificationContent>,
     ) {
         for conversation_id in connection_conversations {
-            if let Some(conversation) = self.user.conversation(conversation_id).await {
-                if let ConversationType::Connection(client_id) = conversation.conversation_type() {
-                    let contact_name = self.user.user_profile(client_id).await.display_name;
-                    let title = format!("New connection with {contact_name}");
-                    let body = "Say hi".to_owned();
+            if let Some(conversation) = self.user.conversation(conversation_id).await
+                && let ConversationType::Connection(client_id) = conversation.conversation_type()
+            {
+                let contact_name = self.user.user_profile(client_id).await.display_name;
+                let title = format!("New connection with {contact_name}");
+                let body = "Say hi".to_owned();
 
-                    notifications.push(NotificationContent {
-                        identifier: NotificationId::random(),
-                        title,
-                        body,
-                        conversation_id: Some(*conversation_id),
-                    });
-                }
+                notifications.push(NotificationContent {
+                    identifier: NotificationId::random(),
+                    title,
+                    body,
+                    conversation_id: Some(*conversation_id),
+                });
             }
         }
     }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: 2025 Phoenix R&D GmbH <hello@phnx.im>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+[toolchain]
+channel = "1.88"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -3,5 +3,5 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
 [toolchain]
-channel = "1.88"
+channel = "1.88.0"
 components = ["rustfmt", "clippy"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -4,3 +4,4 @@
 
 [toolchain]
 channel = "1.88"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
CargoKit used stable toolchain by default ignoring installed toolchain
in CI.

Rust toolchain is now specified in rust-toolchain.toml file.
Additionally, cargokit has a new environment variable
CARGOKIT_TOOLCHAIN_TOML which is the path to the rust-toolchain.toml
file. It reads the toolchain from the file and uses it cargo build.

Caveat: the version specified in CI workflow files and rust-toolchain.toml
needs to be in sync.