### PR TITLE
fix: set message input action to newline on mobile

### DIFF
--- a/app/lib/message_list/message_composer.dart
+++ b/app/lib/message_list/message_composer.dart
@@ -259,8 +259,7 @@ class _MessageInput extends StatelessWidget {
           context,
         ).textTheme.bodyMedium?.copyWith(color: colorDMB),
       ).copyWith(filled: false),
-      textInputAction:
-          smallScreen ? TextInputAction.send : TextInputAction.newline,
+      textInputAction: TextInputAction.newline,
       onEditingComplete: () => _focusNode.requestFocus(),
       keyboardType: TextInputType.multiline,
       textCapitalization: TextCapitalization.sentences,


### PR DESCRIPTION
Also on small screens, the virtual keyboard enter should not send the message but rather insert a newline. Otherwise, there is no way to input multi-line messages.