### PR TITLE
build: support 16 KB page size on Android

### DIFF
--- a/app/rust_builder/cargokit/build_tool/lib/src/android_environment.dart
+++ b/app/rust_builder/cargokit/build_tool/lib/src/android_environment.dart
@@ -189,7 +189,24 @@ class AndroidEnvironment {
     if (rustFlags.isNotEmpty) {
       rustFlags = '$rustFlags\x1f';
     }
-    rustFlags = '$rustFlags-L\x1f$workaroundDir';
+
+    // Source: <https://github.com/irondash/cargokit/pull/107>
+    if (["arm64-v8a", "x86_64"].contains(target.android)) {
+      rustFlags = '$rustFlags-L\x1f$workaroundDir\x1f';
+
+      const pageSizeArgs = [
+        "-C",
+        "link-arg=-Wl,--hash-style=both",
+        "-C",
+        "link-arg=-Wl,-z,max-page-size=16384"
+      ];
+      final pageSizeArgsString = pageSizeArgs.join("\x1f");
+
+      rustFlags = '$rustFlags$pageSizeArgsString';
+    } else {
+      rustFlags = '$rustFlags-L\x1f$workaroundDir';
+    }
+
     return rustFlags;
   }
 }


### PR DESCRIPTION
Tested in Android Emulator with 16 KB pages support enabled.

Also see <https://android-developers.googleblog.com/2025/05/prepare-play-apps-for-devices-with-16kb-page-size.html>