### PR TITLE
build: add dev flavor

### DIFF
--- a/app/android/app/build.gradle.kts
+++ b/app/android/app/build.gradle.kts
@@ -45,6 +45,22 @@ android {
             signingConfig = signingConfigs.getByName("debug")
         }
     }
+
+    flavorDimensions += "environment"
+
+    productFlavors {
+        create("dev") {
+            dimension = "environment"
+            applicationIdSuffix = ".dev"
+            resValue("string", "app_name", "prototype (dev)")
+            isDefault = true
+        }
+        create("prod") {
+            dimension = "environment"
+            // manifestPlaceholders["applicationName"] = "Prototype"
+            isDefault = false
+        }
+    }
 }
 
 flutter {

--- a/app/android/app/src/dev/google-services.json
+++ b/app/android/app/src/dev/google-services.json
@@ -1,0 +1,29 @@
+{
+  "project_info": {
+    "project_number": "348991441140",
+    "project_id": "prototype-6eb85",
+    "storage_bucket": "prototype-6eb85.firebasestorage.app"
+  },
+  "client": [
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:348991441140:android:cec4524c6f2b8c3bb5b6a1",
+        "android_client_info": {
+          "package_name": "im.phnx.prototype.dev"
+        }
+      },
+      "oauth_client": [],
+      "api_key": [
+        {
+          "current_key": "AIzaSyB5hRrUrS__JvCTCh0-pD1RNc7en5fz1mY"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": []
+        }
+      }
+    }
+  ],
+  "configuration_version": "1"
+}

--- a/app/android/app/src/main/AndroidManifest.xml
+++ b/app/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <application
-        android:label="prototype"
+        android:label="@string/app_name"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher">
         <activity

--- a/app/android/app/src/main/res/values/strings.xml
+++ b/app/android/app/src/main/res/values/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="app_name">prototype</string>
+</resources>

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -76,6 +76,8 @@ flutter:
   # the material Icons class.
   uses-material-design: true
 
+  default-flavor: dev
+
   # To add assets to your application, add an assets section, like this:
   assets:
     - assets/images/logo.png


### PR DESCRIPTION
The "dev" flavor is used by default.

TODO:
- Add the flavor in iOS
- Configure google service for the dev flavor properly. Currently, it won't work because it has a wrong package name.