### PR TITLE
CI: test flutter on windows

### DIFF
--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -40,6 +40,9 @@ jobs:
         with:
           cache-directories: app/build/windows/x64/plugins/airapplogic/cargokit_build
 
+      - name: Test flutter
+        run: just test-flutter
+
       - name: Build Windows app
         run: just build-windows
 


### PR DESCRIPTION
Otherwise, there is no need to have windows snapshot tests.