### PR TITLE
fix: chat details navigation regression

### DIFF
--- a/app/lib/navigation/app_router.dart
+++ b/app/lib/navigation/app_router.dart
@@ -170,6 +170,8 @@ extension on IntroScreenType {
 
 /// Convert [HomeNavigation] state into a list of pages.
 extension on HomeNavigationState {
+  ChatId? get openChatId => chatOpen ? chatId : null;
+
   List<MaterialPage> pages(ResponsiveScreenType screenType) {
     const homeScreenPage = NoAnimationPage(
       key: ValueKey("home-screen"),
@@ -217,22 +219,22 @@ extension on HomeNavigationState {
           ),
         ],
       },
-      if (chatId != null &&
-          chatOpen &&
-          screenType == ResponsiveScreenType.mobile)
+      if (openChatId != null && screenType == ResponsiveScreenType.mobile)
         const MaterialPage(
           key: ValueKey("conversation-screen"),
           child: ConversationScreen(),
         ),
-      if (chatId != null &&
-          chatOpen &&
-          chatDetailsOpen &&
-          memberDetails != null)
+      if (openChatId != null && chatDetailsOpen)
+        const MaterialPage(
+          key: ValueKey("chat-details-screen"),
+          child: ConversationDetailsScreen(),
+        ),
+      if (openChatId != null && chatDetailsOpen && memberDetails != null)
         const MaterialPage(
           key: ValueKey("chat-member-details-screen"),
           child: MemberDetailsScreen(),
         ),
-      if (chatId != null && chatOpen && chatDetailsOpen && addMembersOpen)
+      if (openChatId != null && chatDetailsOpen && addMembersOpen)
         const MaterialPage(
           key: ValueKey("add-members-screen"),
           child: AddMembersScreen(),

--- a/applogic/src/api/navigation_cubit.rs
+++ b/applogic/src/api/navigation_cubit.rs
@@ -194,16 +194,7 @@ impl NavigationCubitBase {
     pub fn close_chat(&self) {
         self.core.state_tx().send_if_modified(|state| match state {
             NavigationState::Intro { .. } => false,
-            NavigationState::Home { home } => {
-                if home.chat_open {
-                    home.chat_open = false;
-                    home.chat_details_open = false;
-                    home.chat_id = None;
-                    true
-                } else {
-                    false
-                }
-            }
+            NavigationState::Home { home } => mem::replace(&mut home.chat_open, false),
         });
     }
 
@@ -225,10 +216,12 @@ impl NavigationCubitBase {
     }
 
     pub fn open_chat_details(&self) {
-        self.core.state_tx().send_if_modified(|state| match state {
-            NavigationState::Intro { .. } => false,
-            NavigationState::Home { home } => !mem::replace(&mut home.chat_details_open, true),
-        });
+        self.core
+            .state_tx()
+            .send_if_modified(|state| match dbg!(state) {
+                NavigationState::Intro { .. } => false,
+                NavigationState::Home { home } => !mem::replace(&mut home.chat_details_open, true),
+            });
     }
 
     pub fn open_add_members(&self) {


### PR DESCRIPTION
Fix two regressions in the chat details navigation:

1. The chat details screen is not opened when opening it (introduced in #676).
2. When closing a chat, empty chat was shown during the animation transition (introduced in #659).