### PR TITLE
feat: scale automatically on Linux/4k

### DIFF
--- a/app/lib/core/api/user_settings_cubit.dart
+++ b/app/lib/core/api/user_settings_cubit.dart
@@ -54,7 +54,7 @@ abstract class UserSettingsCubitBase implements RustOpaqueInterface {
 @freezed
 sealed class UserSettings with _$UserSettings {
   const factory UserSettings({
-    @Default(1.0) double interfaceScale,
+    double? interfaceScale,
     @Default(300.0) double sidebarWidth,
     @Default(false) bool sendOnEnter,
   }) = _UserSettings;

--- a/app/lib/core/api/user_settings_cubit.freezed.dart
+++ b/app/lib/core/api/user_settings_cubit.freezed.dart
@@ -14,7 +14,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$UserSettings {
 
- double get interfaceScale; double get sidebarWidth; bool get sendOnEnter;
+ double? get interfaceScale; double get sidebarWidth; bool get sendOnEnter;
 /// Create a copy of UserSettings
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -45,7 +45,7 @@ abstract mixin class $UserSettingsCopyWith<$Res>  {
   factory $UserSettingsCopyWith(UserSettings value, $Res Function(UserSettings) _then) = _$UserSettingsCopyWithImpl;
 @useResult
 $Res call({
- double interfaceScale, double sidebarWidth, bool sendOnEnter
+ double? interfaceScale, double sidebarWidth, bool sendOnEnter
 });
 
 
@@ -62,10 +62,10 @@ class _$UserSettingsCopyWithImpl<$Res>
 
 /// Create a copy of UserSettings
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? interfaceScale = null,Object? sidebarWidth = null,Object? sendOnEnter = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? interfaceScale = freezed,Object? sidebarWidth = null,Object? sendOnEnter = null,}) {
   return _then(_self.copyWith(
-interfaceScale: null == interfaceScale ? _self.interfaceScale : interfaceScale // ignore: cast_nullable_to_non_nullable
-as double,sidebarWidth: null == sidebarWidth ? _self.sidebarWidth : sidebarWidth // ignore: cast_nullable_to_non_nullable
+interfaceScale: freezed == interfaceScale ? _self.interfaceScale : interfaceScale // ignore: cast_nullable_to_non_nullable
+as double?,sidebarWidth: null == sidebarWidth ? _self.sidebarWidth : sidebarWidth // ignore: cast_nullable_to_non_nullable
 as double,sendOnEnter: null == sendOnEnter ? _self.sendOnEnter : sendOnEnter // ignore: cast_nullable_to_non_nullable
 as bool,
   ));
@@ -79,10 +79,10 @@ as bool,
 
 
 class _UserSettings implements UserSettings {
-  const _UserSettings({this.interfaceScale = 1.0, this.sidebarWidth = 300.0, this.sendOnEnter = false});
+  const _UserSettings({this.interfaceScale, this.sidebarWidth = 300.0, this.sendOnEnter = false});
   
 
-@override@JsonKey() final  double interfaceScale;
+@override final  double? interfaceScale;
 @override@JsonKey() final  double sidebarWidth;
 @override@JsonKey() final  bool sendOnEnter;
 
@@ -116,7 +116,7 @@ abstract mixin class _$UserSettingsCopyWith<$Res> implements $UserSettingsCopyWi
   factory _$UserSettingsCopyWith(_UserSettings value, $Res Function(_UserSettings) _then) = __$UserSettingsCopyWithImpl;
 @override @useResult
 $Res call({
- double interfaceScale, double sidebarWidth, bool sendOnEnter
+ double? interfaceScale, double sidebarWidth, bool sendOnEnter
 });
 
 
@@ -133,10 +133,10 @@ class __$UserSettingsCopyWithImpl<$Res>
 
 /// Create a copy of UserSettings
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? interfaceScale = null,Object? sidebarWidth = null,Object? sendOnEnter = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? interfaceScale = freezed,Object? sidebarWidth = null,Object? sendOnEnter = null,}) {
   return _then(_UserSettings(
-interfaceScale: null == interfaceScale ? _self.interfaceScale : interfaceScale // ignore: cast_nullable_to_non_nullable
-as double,sidebarWidth: null == sidebarWidth ? _self.sidebarWidth : sidebarWidth // ignore: cast_nullable_to_non_nullable
+interfaceScale: freezed == interfaceScale ? _self.interfaceScale : interfaceScale // ignore: cast_nullable_to_non_nullable
+as double?,sidebarWidth: null == sidebarWidth ? _self.sidebarWidth : sidebarWidth // ignore: cast_nullable_to_non_nullable
 as double,sendOnEnter: null == sendOnEnter ? _self.sendOnEnter : sendOnEnter // ignore: cast_nullable_to_non_nullable
 as bool,
   ));

--- a/app/lib/core/frb_generated.dart
+++ b/app/lib/core/frb_generated.dart
@@ -5823,6 +5823,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  double dco_decode_box_autoadd_f_64(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return raw as double;
+  }
+
+  @protected
   HomeNavigationState dco_decode_box_autoadd_home_navigation_state(
     dynamic raw,
   ) {
@@ -6361,6 +6367,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  double? dco_decode_opt_box_autoadd_f_64(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return raw == null ? null : dco_decode_box_autoadd_f_64(raw);
+  }
+
+  @protected
   ImageData? dco_decode_opt_box_autoadd_image_data(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return raw == null ? null : dco_decode_box_autoadd_image_data(raw);
@@ -6813,7 +6825,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     if (arr.length != 3)
       throw Exception('unexpected arr length: expect 3 but see ${arr.length}');
     return UserSettings(
-      interfaceScale: dco_decode_f_64(arr[0]),
+      interfaceScale: dco_decode_opt_box_autoadd_f_64(arr[0]),
       sidebarWidth: dco_decode_f_64(arr[1]),
       sendOnEnter: dco_decode_bool(arr[2]),
     );
@@ -7738,6 +7750,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  double sse_decode_box_autoadd_f_64(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    return (sse_decode_f_64(deserializer));
+  }
+
+  @protected
   HomeNavigationState sse_decode_box_autoadd_home_navigation_state(
     SseDeserializer deserializer,
   ) {
@@ -8431,6 +8449,17 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  double? sse_decode_opt_box_autoadd_f_64(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    if (sse_decode_bool(deserializer)) {
+      return (sse_decode_box_autoadd_f_64(deserializer));
+    } else {
+      return null;
+    }
+  }
+
+  @protected
   ImageData? sse_decode_opt_box_autoadd_image_data(
     SseDeserializer deserializer,
   ) {
@@ -8969,7 +8998,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   UserSettings sse_decode_user_settings(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
-    var var_interfaceScale = sse_decode_f_64(deserializer);
+    var var_interfaceScale = sse_decode_opt_box_autoadd_f_64(deserializer);
     var var_sidebarWidth = sse_decode_f_64(deserializer);
     var var_sendOnEnter = sse_decode_bool(deserializer);
     return UserSettings(
@@ -10099,6 +10128,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  void sse_encode_box_autoadd_f_64(double self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_f_64(self, serializer);
+  }
+
+  @protected
   void sse_encode_box_autoadd_home_navigation_state(
     HomeNavigationState self,
     SseSerializer serializer,
@@ -10782,6 +10817,16 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  void sse_encode_opt_box_autoadd_f_64(double? self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    sse_encode_bool(self != null, serializer);
+    if (self != null) {
+      sse_encode_box_autoadd_f_64(self, serializer);
+    }
+  }
+
+  @protected
   void sse_encode_opt_box_autoadd_image_data(
     ImageData? self,
     SseSerializer serializer,
@@ -11264,7 +11309,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   void sse_encode_user_settings(UserSettings self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
-    sse_encode_f_64(self.interfaceScale, serializer);
+    sse_encode_opt_box_autoadd_f_64(self.interfaceScale, serializer);
     sse_encode_f_64(self.sidebarWidth, serializer);
     sse_encode_bool(self.sendOnEnter, serializer);
   }

--- a/app/lib/core/frb_generated.io.dart
+++ b/app/lib/core/frb_generated.io.dart
@@ -558,6 +558,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   dco_decode_box_autoadd_developer_settings_screen_type(dynamic raw);
 
   @protected
+  double dco_decode_box_autoadd_f_64(dynamic raw);
+
+  @protected
   HomeNavigationState dco_decode_box_autoadd_home_navigation_state(dynamic raw);
 
   @protected
@@ -759,6 +762,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   DeveloperSettingsScreenType?
   dco_decode_opt_box_autoadd_developer_settings_screen_type(dynamic raw);
+
+  @protected
+  double? dco_decode_opt_box_autoadd_f_64(dynamic raw);
 
   @protected
   ImageData? dco_decode_opt_box_autoadd_image_data(dynamic raw);
@@ -1343,6 +1349,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  double sse_decode_box_autoadd_f_64(SseDeserializer deserializer);
+
+  @protected
   HomeNavigationState sse_decode_box_autoadd_home_navigation_state(
     SseDeserializer deserializer,
   );
@@ -1604,6 +1613,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   sse_decode_opt_box_autoadd_developer_settings_screen_type(
     SseDeserializer deserializer,
   );
+
+  @protected
+  double? sse_decode_opt_box_autoadd_f_64(SseDeserializer deserializer);
 
   @protected
   ImageData? sse_decode_opt_box_autoadd_image_data(
@@ -2310,6 +2322,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  void sse_encode_box_autoadd_f_64(double self, SseSerializer serializer);
+
+  @protected
   void sse_encode_box_autoadd_home_navigation_state(
     HomeNavigationState self,
     SseSerializer serializer,
@@ -2646,6 +2661,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     DeveloperSettingsScreenType? self,
     SseSerializer serializer,
   );
+
+  @protected
+  void sse_encode_opt_box_autoadd_f_64(double? self, SseSerializer serializer);
 
   @protected
   void sse_encode_opt_box_autoadd_image_data(

--- a/app/lib/core/frb_generated.web.dart
+++ b/app/lib/core/frb_generated.web.dart
@@ -560,6 +560,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   dco_decode_box_autoadd_developer_settings_screen_type(dynamic raw);
 
   @protected
+  double dco_decode_box_autoadd_f_64(dynamic raw);
+
+  @protected
   HomeNavigationState dco_decode_box_autoadd_home_navigation_state(dynamic raw);
 
   @protected
@@ -761,6 +764,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   DeveloperSettingsScreenType?
   dco_decode_opt_box_autoadd_developer_settings_screen_type(dynamic raw);
+
+  @protected
+  double? dco_decode_opt_box_autoadd_f_64(dynamic raw);
 
   @protected
   ImageData? dco_decode_opt_box_autoadd_image_data(dynamic raw);
@@ -1345,6 +1351,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  double sse_decode_box_autoadd_f_64(SseDeserializer deserializer);
+
+  @protected
   HomeNavigationState sse_decode_box_autoadd_home_navigation_state(
     SseDeserializer deserializer,
   );
@@ -1606,6 +1615,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   sse_decode_opt_box_autoadd_developer_settings_screen_type(
     SseDeserializer deserializer,
   );
+
+  @protected
+  double? sse_decode_opt_box_autoadd_f_64(SseDeserializer deserializer);
 
   @protected
   ImageData? sse_decode_opt_box_autoadd_image_data(
@@ -2312,6 +2324,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  void sse_encode_box_autoadd_f_64(double self, SseSerializer serializer);
+
+  @protected
   void sse_encode_box_autoadd_home_navigation_state(
     HomeNavigationState self,
     SseSerializer serializer,
@@ -2648,6 +2663,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     DeveloperSettingsScreenType? self,
     SseSerializer serializer,
   );
+
+  @protected
+  void sse_encode_opt_box_autoadd_f_64(double? self, SseSerializer serializer);
 
   @protected
   void sse_encode_opt_box_autoadd_image_data(

--- a/app/lib/user/user_settings_screen.dart
+++ b/app/lib/user/user_settings_screen.dart
@@ -4,8 +4,6 @@
 
 import 'dart:io';
 
-import 'package:air/util/interface_scale.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:air/core/core.dart';

--- a/app/lib/user/user_settings_screen.dart
+++ b/app/lib/user/user_settings_screen.dart
@@ -4,6 +4,8 @@
 
 import 'dart:io';
 
+import 'package:air/util/interface_scale.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:air/core/core.dart';
@@ -292,9 +294,15 @@ class _DesktopSettingsState extends State<_DesktopSettings> {
   @override
   void initState() {
     super.initState();
+
     setState(() {
+      final interfaceScale =
+          context.read<UserSettingsCubit>().state.interfaceScale;
+      var isLinuxAndScaled =
+          Platform.isLinux &&
+          WidgetsBinding.instance.platformDispatcher.textScaleFactor >= 1.5;
       _interfaceScaleSliderValue =
-          context.read<UserSettingsCubit>().state.interfaceScale * 100;
+          100 * (interfaceScale ?? (isLinuxAndScaled ? 1.5 : 1.0));
     });
   }
 

--- a/applogic/src/frb_generated.rs
+++ b/applogic/src/frb_generated.rs
@@ -7154,6 +7154,17 @@ impl SseDecode for Option<crate::api::navigation_cubit::DeveloperSettingsScreenT
     }
 }
 
+impl SseDecode for Option<f64> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        if (<bool>::sse_decode(deserializer)) {
+            return Some(<f64>::sse_decode(deserializer));
+        } else {
+            return None;
+        }
+    }
+}
+
 impl SseDecode for Option<crate::api::types::ImageData> {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -7754,7 +7765,7 @@ impl SseDecode for () {
 impl SseDecode for crate::api::user_settings_cubit::UserSettings {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
-        let mut var_interfaceScale = <f64>::sse_decode(deserializer);
+        let mut var_interfaceScale = <Option<f64>>::sse_decode(deserializer);
         let mut var_sidebarWidth = <f64>::sse_decode(deserializer);
         let mut var_sendOnEnter = <bool>::sse_decode(deserializer);
         return crate::api::user_settings_cubit::UserSettings {
@@ -10465,6 +10476,16 @@ impl SseEncode for Option<crate::api::navigation_cubit::DeveloperSettingsScreenT
     }
 }
 
+impl SseEncode for Option<f64> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <bool>::sse_encode(self.is_some(), serializer);
+        if let Some(value) = self {
+            <f64>::sse_encode(value, serializer);
+        }
+    }
+}
+
 impl SseEncode for Option<crate::api::types::ImageData> {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
@@ -10947,7 +10968,7 @@ impl SseEncode for () {
 impl SseEncode for crate::api::user_settings_cubit::UserSettings {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
-        <f64>::sse_encode(self.interface_scale, serializer);
+        <Option<f64>>::sse_encode(self.interface_scale, serializer);
         <f64>::sse_encode(self.sidebar_width, serializer);
         <bool>::sse_encode(self.send_on_enter, serializer);
     }

--- a/coreclient/src/store/mod.rs
+++ b/coreclient/src/store/mod.rs
@@ -47,9 +47,8 @@ pub trait Store {
 
     /// Loads a user setting
     ///
-    /// If the setting is not found, the default value is returned. If loading or decoding failed,
-    /// the default value is stored and returned.
-    async fn user_setting<T: UserSetting>(&self) -> T;
+    /// If the setting is not found, or loading or decoding failed, `None` is returned.
+    async fn user_setting<T: UserSetting>(&self) -> Option<T>;
 
     async fn set_user_setting<T: UserSetting>(&self, value: &T) -> StoreResult<()>;
 
@@ -240,8 +239,6 @@ pub trait Store {
 
 pub trait UserSetting: Send + Sync {
     const KEY: &'static str;
-
-    const DEFAULT: Self;
 
     fn encode(&self) -> StoreResult<Vec<u8>>;
     fn decode(bytes: Vec<u8>) -> StoreResult<Self>


### PR DESCRIPTION
When we are on Linux and there is no user setting for interface scale, we
automatically set the interface scale to 1.5 on 4k displays. Also, do
not scale linearly if there is no setting. This is important, since
other platforms (e.g. Android) might have non-linear scaling.