### PR TITLE
feat: flutter licenses screen

### DIFF
--- a/app/lib/user/help_screen.dart
+++ b/app/lib/user/help_screen.dart
@@ -11,7 +11,6 @@ import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 
 import 'contact_us_screen.dart';
-import 'licenses_screen.dart';
 import 'user_settings_screen.dart';
 
 class HelpScreen extends StatelessWidget {


### PR DESCRIPTION
For now, we replace the licenses screen with the flutter licenses screen. Including Rust licenses is TBD.