### PR TITLE
chore: increase out-of-order tolerance

### DIFF
--- a/common/src/mls_group_config.rs
+++ b/common/src/mls_group_config.rs
@@ -4,13 +4,35 @@
 
 //! Configuration for MLS groups.
 
-use mls_assist::openmls::prelude::{
-    Capabilities, Ciphersuite, CredentialType, ExtensionType, ProposalType, ProtocolVersion,
-    RequiredCapabilitiesExtension,
+use mls_assist::openmls::{
+    group::{MlsGroupJoinConfig, PURE_PLAINTEXT_WIRE_FORMAT_POLICY},
+    prelude::{
+        Capabilities, Ciphersuite, CredentialType, ExtensionType, ProposalType, ProtocolVersion,
+        RequiredCapabilitiesExtension, SenderRatchetConfiguration,
+    },
 };
 
 /// Dictates for how many past epochs we want to keep around message secrets.
 pub const MAX_PAST_EPOCHS: usize = 5;
+
+/// Determines the out-of-order tolerance for the sender ratchet. See
+/// [`SenderRatchetConfiguration`].
+pub const OUT_OF_ORDER_TOLERANCE: u32 = 20;
+/// Determines the maximum forward distance for the sender ratchet. See
+/// [`SenderRatchetConfiguration`].
+pub const MAXIMUM_FORWARD_DISTANCE: u32 = 1000;
+
+pub fn default_sender_ratchet_configuration() -> SenderRatchetConfiguration {
+    SenderRatchetConfiguration::new(OUT_OF_ORDER_TOLERANCE, MAXIMUM_FORWARD_DISTANCE)
+}
+
+pub fn default_mls_group_join_config() -> MlsGroupJoinConfig {
+    MlsGroupJoinConfig::builder()
+        .max_past_epochs(MAX_PAST_EPOCHS)
+        .sender_ratchet_configuration(default_sender_ratchet_configuration())
+        .wire_format_policy(PURE_PLAINTEXT_WIRE_FORMAT_POLICY)
+        .build()
+}
 
 /// Proposal type of the friendship package proposal.
 pub const FRIENDSHIP_PACKAGE_PROPOSAL_TYPE: u16 = 0xff00;

--- a/coreclient/src/groups/mod.rs
+++ b/coreclient/src/groups/mod.rs
@@ -46,7 +46,8 @@ use aircommon::{
     },
     mls_group_config::{
         GROUP_DATA_EXTENSION_TYPE, MAX_PAST_EPOCHS, default_capabilities,
-        default_required_capabilities,
+        default_mls_group_join_config, default_required_capabilities,
+        default_sender_ratchet_configuration,
     },
     time::TimeStamp,
 };
@@ -77,10 +78,10 @@ use openmls::{
     key_packages::KeyPackageBundle,
     prelude::{
         BasicCredentialError, CredentialWithKey, Extension, Extensions, GroupId, KeyPackage,
-        LeafNodeIndex, LeafNodeParameters, MlsGroup, MlsGroupJoinConfig, MlsMessageOut,
-        OpenMlsProvider, PURE_PLAINTEXT_WIRE_FORMAT_POLICY, PreSharedKeyProposal, Proposal,
-        ProtocolVersion, QueuedProposal, Sender, SignaturePublicKey, StagedCommit,
-        UnknownExtension, tls_codec::Serialize as TlsSerializeTrait,
+        LeafNodeIndex, LeafNodeParameters, MlsGroup, MlsMessageOut, OpenMlsProvider,
+        PURE_PLAINTEXT_WIRE_FORMAT_POLICY, PreSharedKeyProposal, Proposal, ProtocolVersion,
+        QueuedProposal, Sender, SignaturePublicKey, StagedCommit, UnknownExtension,
+        tls_codec::Serialize as TlsSerializeTrait,
     },
     schedule::{ExternalPsk, PreSharedKeyId, Psk},
     treesync::RatchetTree,
@@ -161,12 +162,6 @@ impl Group {
         &self.mls_group
     }
 
-    fn default_mls_group_join_config() -> MlsGroupJoinConfig {
-        MlsGroupJoinConfig::builder()
-            .wire_format_policy(PURE_PLAINTEXT_WIRE_FORMAT_POLICY)
-            .build()
-    }
-
     /// Create a group.
     pub(super) fn create_group(
         provider: &impl OpenMlsProvider,
@@ -197,6 +192,7 @@ impl Group {
             .with_group_id(group_id.clone())
             .with_capabilities(leaf_node_capabilities)
             .with_group_context_extensions(gc_extensions)?
+            .sender_ratchet_configuration(default_sender_ratchet_configuration())
             .max_past_epochs(MAX_PAST_EPOCHS)
             .with_wire_format_policy(PURE_PLAINTEXT_WIRE_FORMAT_POLICY)
             .build(provider, signer, credential_with_key)
@@ -250,7 +246,7 @@ impl Group {
     ) -> Result<(Self, Vec<ProfileInfo>)> {
         let serialized_welcome = welcome_bundle.welcome.tls_serialize_detached()?;
 
-        let mls_group_config = Self::default_mls_group_join_config();
+        let mls_group_config = default_mls_group_join_config();
 
         let (processed_welcome, joiner_info) = {
             // Phase 1: Fetch the right KeyPackageBundle from storage
@@ -426,7 +422,7 @@ impl Group {
         own_client_credential: &ClientCredential,
         connection_offer_hash: ConnectionOfferHash,
     ) -> Result<(Self, MlsMessageOut, MlsMessageOut, Vec<ProfileInfo>)> {
-        let mls_group_config = Self::default_mls_group_join_config();
+        let mls_group_config = default_mls_group_join_config();
         let credential_with_key = CredentialWithKey {
             credential: signer.credential().try_into()?,
             signature_key: signer.credential().verifying_key().clone().into(),


### PR DESCRIPTION
This PR increases OpenMLS' tolerance for messages reveived out-of-order from the default 5 to 20 for newly created groups/chats.

This PR also includes a fix, where MAX_PAST_EPOCHs only affect the group's creator, but none of the joiners. The fix is only for newly created groups.