### PR TITLE
feat(server): add RUST_LOG_FORMAT config env var

### DIFF
--- a/server/src/logging.rs
+++ b/server/src/logging.rs
@@ -2,20 +2,35 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-use tracing::{metadata::LevelFilter, subscriber::set_global_default};
+use tracing::{metadata::LevelFilter, subscriber::set_global_default, warn};
 use tracing_bunyan_formatter::{BunyanFormattingLayer, JsonStorageLayer};
 use tracing_log::LogTracer;
-use tracing_subscriber::{EnvFilter, Registry, layer::SubscriberExt};
+use tracing_subscriber::{EnvFilter, Registry, fmt, layer::SubscriberExt};
 
 pub fn init_logging() {
     let env_filter = EnvFilter::builder()
         .with_default_directive(LevelFilter::INFO.into())
         .from_env_lossy();
-    let formatting_layer = BunyanFormattingLayer::new("airserver".into(), std::io::stdout);
-    let registry = Registry::default()
-        .with(env_filter)
-        .with(JsonStorageLayer)
-        .with(formatting_layer);
-    LogTracer::init().expect("logging already initialized");
-    set_global_default(registry).expect("logging already initialized");
+
+    match std::env::var("RUST_LOG_FORMAT").as_deref() {
+        // log to stdout in JSON
+        Err(_) | Ok("json") => {
+            let formatting_layer = BunyanFormattingLayer::new("airserver".into(), std::io::stdout);
+            let registry = Registry::default()
+                .with(JsonStorageLayer)
+                .with(formatting_layer)
+                .with(env_filter);
+            LogTracer::init().expect("logging already initialized");
+            set_global_default(registry).expect("logging already initialized");
+        }
+        // log to stdout as text
+        Ok(format) => {
+            let registry = Registry::default().with(fmt::layer()).with(env_filter);
+            LogTracer::init().expect("logging already initialized");
+            set_global_default(registry).expect("logging already initialized");
+            if format != "text" {
+                warn!("RUST_LOG_FORMAT has unsupported value, defaulting to text.");
+            }
+        }
+    };
 }


### PR DESCRIPTION
Extracted from #1143

Defaults to `json` to avoid breaking backwards compatibility, and can be set to `text` (or any other value).