### PR TITLE
fix(app): open notification navigation on android

### DIFF
--- a/app/android/app/src/main/kotlin/ms/air/MainActivity.kt
+++ b/app/android/app/src/main/kotlin/ms/air/MainActivity.kt
@@ -40,24 +40,33 @@ class MainActivity : FlutterActivity() {
 
     private var channel: MethodChannel? = null
 
+
+    private var pendingInitialNotification: Map<String, String?>? = null
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         requestNotificationPermissionIfNeeded()
+
+        // We store a potential notification tap event, so it can be delivered
+        // once the Flutter engine is ready.
+        readNotificationPayload(intent)?.let { pendingInitialNotification = it }
     }
 
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
 
-        if (intent.action == Notifications.SELECT_NOTIFICATION) {
-            val notificationId = intent.extras?.getString(Notifications.EXTRAS_NOTIFICATION_ID_KEY)
-            val chatId = intent.extras?.getString(Notifications.EXTRAS_CHAT_ID_KEY)
-            if (notificationId != null) {
-                val arguments = mapOf(
-                    "identifier" to notificationId, "chatId" to chatId
-                )
-                channel?.invokeMethod("openedNotification", arguments)
-            }
-        }
+        // Send the notification tap event to Dart directly
+        val payload = readNotificationPayload(intent) ?: return
+        channel?.invokeMethod("openedNotification", payload)
+    }
+
+    private fun readNotificationPayload(intent: Intent): Map<String, String?>? {
+        // We only care about intents that represent notification taps
+        if (intent.action != Notifications.SELECT_NOTIFICATION) return null
+        val notificationId =
+            intent.extras?.getString(Notifications.EXTRAS_NOTIFICATION_ID_KEY) ?: return null
+        val chatId = intent.extras?.getString(Notifications.EXTRAS_CHAT_ID_KEY)
+        return mapOf("identifier" to notificationId, "chatId" to chatId)
     }
 
     override fun detachFromFlutterEngine() {
@@ -86,6 +95,12 @@ class MainActivity : FlutterActivity() {
                             result.error("NoDeviceToken", "Device token not available", "")
                         }
                     }
+                }
+
+                "getInitialNotification" -> {
+                    val payload = pendingInitialNotification
+                    pendingInitialNotification = null
+                    result.success(payload)
                 }
 
                 "getDatabasesDirectory" -> {

--- a/app/android/app/src/main/kotlin/ms/air/Notifications.kt
+++ b/app/android/app/src/main/kotlin/ms/air/Notifications.kt
@@ -134,9 +134,12 @@ class Notifications {
                 putExtra(EXTRAS_CHAT_ID_KEY, content.chatId?.uuid)
             }
 
+
             val pendingIntent = PendingIntent.getActivity(
                 context,
-                1,
+                // Unique identifier per intent to ensure that multiple
+                // notifications don't overwrite each other's pending intent
+                content.identifier.hashCode(),
                 intent,
                 PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
             )

--- a/app/lib/app.dart
+++ b/app/lib/app.dart
@@ -15,6 +15,7 @@ import 'package:air/theme/theme.dart';
 import 'package:air/user/user.dart';
 import 'package:air/util/interface_scale.dart';
 import 'package:air/ui/components/context_menu/context_menu.dart';
+import 'package:air/util/notifications.dart';
 import 'package:air/util/platform.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -61,6 +62,10 @@ class _AppState extends State<App> with WidgetsBindingObserver {
           _appRouter.dismissOverlays();
           _navigationCubit.openChat(chatId);
         });
+
+    // Fetch potential initial notification that launched the app on Android
+    // cold start.
+    unawaited(consumeInitialNotification(_openedNotificationController.sink));
 
     _backgroundService.start(runImmediately: true);
   }

--- a/app/lib/util/notifications.dart
+++ b/app/lib/util/notifications.dart
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: 2026 Phoenix R&D GmbH <hello@phnx.im>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:air/core/core.dart';
+import 'package:air/util/platform.dart';
+import 'package:flutter/services.dart';
+import 'package:logging/logging.dart';
+import 'package:uuid/uuid.dart';
+
+final _log = Logger('NotificationTaps');
+
+/// Drain any notification tap that launched the app on Android cold start.
+Future<void> consumeInitialNotification(
+  StreamSink<ChatId> openedNotificationSink,
+) async {
+  // Only needed for Android, since iOS does not support launching the app from
+  // a notification tap
+  if (!Platform.isAndroid) return;
+  try {
+    final payload = await platform.invokeMapMethod<String, Object?>(
+      'getInitialNotification',
+    );
+    if (payload == null) return;
+    dispatchOpenedNotification(payload, openedNotificationSink);
+  } on PlatformException catch (e, stacktrace) {
+    _log.severe(
+      "Failed to get initial notification: '${e.message}'",
+      e,
+      stacktrace,
+    );
+  }
+}
+
+/// Parses an `openedNotification` payload from the platform and forwards the
+/// resulting [ChatId] to [openedNotificationSink]. Invalid payloads are logged
+/// and dropped.
+void dispatchOpenedNotification(
+  Map<Object?, Object?> arguments,
+  StreamSink<ChatId> openedNotificationSink,
+) {
+  final identifier = arguments["identifier"] as String?;
+  final chatIdStr = arguments["chatId"] as String?;
+  _log.fine(
+    'Notification opened: identifier = $identifier, chatId = $chatIdStr',
+  );
+  if (identifier == null || chatIdStr == null) return;
+  try {
+    openedNotificationSink.add(
+      ChatId(uuid: UuidValue.withValidation(chatIdStr)),
+    );
+  } on FormatException catch (e, stacktrace) {
+    _log.warning(
+      "Invalid chatId in notification payload: '$chatIdStr'",
+      e,
+      stacktrace,
+    );
+  }
+}

--- a/app/lib/util/platform.dart
+++ b/app/lib/util/platform.dart
@@ -8,8 +8,8 @@ import 'package:flutter/services.dart';
 import 'package:logging/logging.dart';
 import 'package:air/core/core.dart';
 import 'package:air/core/api/utils.dart' as rust_utils;
+import 'package:air/util/notifications.dart';
 import 'package:path_provider/path_provider.dart';
-import 'package:uuid/uuid.dart';
 
 const platform = MethodChannel('ms.air/channel');
 
@@ -37,16 +37,10 @@ Future<void> _handleMethod(
       // Do something with the data
       break;
     case 'openedNotification':
-      // Handle notification opened
-      final String? identifier = call.arguments["identifier"];
-      final String? chatIdStr = call.arguments["chatId"];
-      _log.fine(
-        'Notification opened: identifier = $identifier, chatId = $chatIdStr',
+      dispatchOpenedNotification(
+        call.arguments as Map<Object?, Object?>,
+        openedNotificationSink,
       );
-      if (identifier != null && chatIdStr != null) {
-        final chatId = ChatId(uuid: UuidValue.withValidation(chatIdStr));
-        openedNotificationSink.add(chatId);
-      }
       break;
     case 'backgroundTaskExpired':
       final taskId = call.arguments['taskId'];


### PR DESCRIPTION
Fixes two bugs on Android that prevented taps on notifications from reliably navigating to the right chat inside the app:
 - Intents were overwriting each other, because they all used "1" as an identifier.
 - When the app was not yet started, intents were not registered.