### PR TITLE
fix(app): allow creation of empty groups

### DIFF
--- a/coreclient/src/job/chat_operation.rs
+++ b/coreclient/src/job/chat_operation.rs
@@ -136,18 +136,10 @@ impl ChatOperation {
             ChatOperationType::AddMembers(user_ids) => {
                 let members: HashSet<_> = group.members().collect();
                 user_ids.retain(|user_id| !members.contains(user_id));
-
-                if user_ids.is_empty() {
-                    bail!("All users to add are already members of the group");
-                }
             }
             ChatOperationType::RemoveMembers(user_ids) => {
                 let members: HashSet<_> = group.members().collect();
                 user_ids.retain(|user_id| members.contains(user_id));
-
-                if user_ids.is_empty() {
-                    bail!("None of the users to remove are members of the group");
-                }
             }
             // The following operations are always valid as long as the
             // group is active.
@@ -169,9 +161,15 @@ impl ChatOperation {
 
         match self.operation.clone() {
             ChatOperationType::AddMembers(user_ids) => {
+                if user_ids.is_empty() {
+                    return Ok(Vec::new());
+                }
                 self.execute_add_members(context, user_ids).await
             }
             ChatOperationType::RemoveMembers(user_ids) => {
+                if user_ids.is_empty() {
+                    return Ok(Vec::new());
+                }
                 self.execute_remove_members(context, user_ids).await
             }
             ChatOperationType::Leave => self.execute_leave_chat(context).await,

--- a/server/tests/tests/group.rs
+++ b/server/tests/tests/group.rs
@@ -29,6 +29,28 @@ async fn create_group() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[tracing::instrument(name = "Create empty group", skip_all)]
+async fn create_empty_group() {
+    let mut setup = TestBackend::single().await;
+    let alice = setup.add_user().await;
+    let chat_id = setup.create_group(&alice).await;
+
+    let alice_user = &setup.get_user(&alice).user;
+
+    // Inviting an empty user list should be a no-op
+    let messages = alice_user
+        .invite_users(chat_id, &[])
+        .await
+        .expect("inviting an empty user list should succeed")
+        .expect("inviting an empty user list should succeed");
+    assert!(messages.is_empty());
+
+    let participants = alice_user.chat_participants(chat_id).await.unwrap();
+    assert_eq!(participants.len(), 1);
+    assert!(participants.contains(&alice));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 #[tracing::instrument(name = "Invite to group test", skip_all)]
 async fn invite_to_group() {
     let mut setup = TestBackend::single().await;


### PR DESCRIPTION
Fixes a regression where creating empty groups was not possible.