### PR TITLE
feat(server): add invitation code metrics

### DIFF
--- a/backend/src/auth_service/client_api/user.rs
+++ b/backend/src/auth_service/client_api/user.rs
@@ -9,6 +9,7 @@ use aircommon::{
     messages::{client_as::RegisterUserResponse, client_as_out::RegisterUserParamsIn},
     time::TimeStamp,
 };
+use metrics::counter;
 use tracing::error;
 
 use crate::{
@@ -99,6 +100,7 @@ impl AuthService {
                 error!(%error, "Failed to save invitation code");
                 RegisterUserError::StorageError
             })?;
+            counter!("air_invitation_codes_redeemed_total").increment(1);
         }
 
         txn.commit().await.map_err(|error| {

--- a/backend/src/auth_service/grpc.rs
+++ b/backend/src/auth_service/grpc.rs
@@ -11,6 +11,7 @@ use airprotos::{
 };
 use displaydoc::Display;
 use futures_util::stream::BoxStream;
+use metrics::counter;
 
 use aircommon::{
     credentials::keys,
@@ -195,6 +196,7 @@ impl auth_service_server::AuthService for GrpcAs {
         }
 
         if self.inner.unredeemable_code.as_deref() == Some(&code.code) {
+            counter!("air_invitation_codes_checked_total", "is_valid" => "true").increment(1);
             return Ok(Response::new(CheckInvitationCodeResponse {
                 is_valid: true,
             }));
@@ -207,9 +209,15 @@ impl auth_service_server::AuthService for GrpcAs {
                 Status::internal("database error")
             })?;
 
-        Ok(Response::new(CheckInvitationCodeResponse {
-            is_valid: record.filter(|r| !r.redeemed).is_some(),
-        }))
+        let is_valid = record.filter(|r| !r.redeemed).is_some();
+
+        counter!(
+            "air_invitation_codes_checked_total",
+            "is_valid" => if is_valid { "true" } else { "false" },
+        )
+        .increment(1);
+
+        Ok(Response::new(CheckInvitationCodeResponse { is_valid }))
     }
 
     async fn get_invitation_codes(
@@ -272,6 +280,7 @@ impl auth_service_server::AuthService for GrpcAs {
                 })?;
 
             invitation_codes.push(InvitationCode { code });
+            counter!("air_invitation_codes_issued_total").increment(1);
         }
 
         txn.commit().await.map_err(|error| {


### PR DESCRIPTION
Added 3 metrics:

* `air_invitation_codes_checked_total` with label `is_valid =
  true|false`: total number of checked invitation codes
* `air_invitation_codes_issued_total`: total number of issued invitation
  codes
* `air_invitation_codes_redeemed_total`: total number of redeemed
  invitation codes