### PR TITLE
fix(app): set unencrypted group title to support clients <= 0.14.0

### DIFF
--- a/coreclient/src/clients/add_contact.rs
+++ b/coreclient/src/clients/add_contact.rs
@@ -222,7 +222,7 @@ impl<Payload> VerifiedConnectionPackagesWithGroupId<Payload> {
             // No group profile is uploaded, because there is no additational data except for the
             // title.
             external_group_profile: None,
-            legacy_title: None,
+            legacy_title: Some(title),
         }
         .encode()?;
 

--- a/coreclient/src/job/chat_operation.rs
+++ b/coreclient/src/job/chat_operation.rs
@@ -318,7 +318,7 @@ impl ChatOperation {
             let group_data = GroupData {
                 encrypted_title: Some(encrypted_title),
                 external_group_profile: Some(external),
-                legacy_title: None,
+                legacy_title: Some(group_profile.title),
             };
             (Some(group_data), attributes.picture)
         } else {

--- a/coreclient/src/job/create_chat.rs
+++ b/coreclient/src/job/create_chat.rs
@@ -118,7 +118,7 @@ impl CreateChat {
         let group_data_bytes = GroupData {
             encrypted_title: Some(encrypted_title),
             external_group_profile,
-            legacy_title: None,
+            legacy_title: Some(chat_attributes.title.clone()),
         }
         .encode()?;
 

--- a/protos/src/client/group.rs
+++ b/protos/src/client/group.rs
@@ -27,7 +27,9 @@ use uuid::Uuid;
 /// from `serde`.
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct GroupData {
-    /// Only set by older clients and deserialized as a fallback
+    /// Set for the clients with version <= 0.14.0
+    ///
+    /// Can be removed once all such clients have been updated.
     #[serde(rename = "title", skip_serializing_if = "Option::is_none")]
     pub legacy_title: Option<String>,
     /// Encrypted group title


### PR DESCRIPTION
When the last 0.14 is phased out, it can be removed again.