### PR TITLE
perf(app): replace ciborium by minicbor-serde

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -196,7 +196,6 @@ dependencies = [
  "argon2",
  "cbor-diag",
  "chrono",
- "ciborium",
  "criterion",
  "displaydoc",
  "ed25519",
@@ -205,6 +204,9 @@ dependencies = [
  "insta",
  "mimi-room-policy",
  "mimi_content",
+ "minicbor",
+ "minicbor-derive",
+ "minicbor-serde",
  "mls-assist",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
@@ -276,7 +278,8 @@ dependencies = [
 name = "airmacros"
 version = "0.15.0"
 dependencies = [
- "ciborium",
+ "minicbor",
+ "minicbor-serde",
  "proc-macro2",
  "quote",
  "serde",
@@ -4430,15 +4433,44 @@ dependencies = [
 [[package]]
 name = "mimi_content"
 version = "0.1.0"
-source = "git+https://github.com/phnx-im/mimi-content?rev=9189ef0b350576e6edd130e43d281c8eb9bfe452#9189ef0b350576e6edd130e43d281c8eb9bfe452"
 dependencies = [
- "ciborium",
- "hex",
+ "minicbor",
+ "minicbor-derive",
+ "num_enum",
  "serde",
  "serde_bytes",
- "serde_list",
  "sha2",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "minicbor"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e70eae6d4f18f7d76877fe7b13f0bc21f7c2b7239d2041c338335f7b388d0dd7"
+dependencies = [
+ "minicbor-derive",
+]
+
+[[package]]
+name = "minicbor-derive"
+version = "0.19.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "294f0a0c161c510e9746adf546b8b044fbb0b00677d7dfc9a2452f9fdf63439b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "minicbor-serde"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80047f75e28e3b38f6ab2ec3c2c7669f6b411fa6f8424e1a90a3fd784b19a3f4"
+dependencies = [
+ "minicbor",
+ "serde",
 ]
 
 [[package]]
@@ -4717,6 +4749,28 @@ checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
 dependencies = [
  "hermit-abi",
  "libc",
+]
+
+[[package]]
+name = "num_enum"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
+dependencies = [
+ "num_enum_derive",
+ "rustversion",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -6335,24 +6389,6 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
-]
-
-[[package]]
-name = "serde_list"
-version = "1.1.0"
-source = "git+https://github.com/phnx-im/mimi-content?rev=9189ef0b350576e6edd130e43d281c8eb9bfe452#9189ef0b350576e6edd130e43d281c8eb9bfe452"
-dependencies = [
- "serde",
- "serde_list_macros",
-]
-
-[[package]]
-name = "serde_list_macros"
-version = "0.1.0"
-source = "git+https://github.com/phnx-im/mimi-content?rev=9189ef0b350576e6edd130e43d281c8eb9bfe452#9189ef0b350576e6edd130e43d281c8eb9bfe452"
-dependencies = [
- "quote",
- "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -205,7 +205,6 @@ dependencies = [
  "mimi-room-policy",
  "mimi_content",
  "minicbor",
- "minicbor-derive",
  "minicbor-serde",
  "mls-assist",
  "rand 0.8.5",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4433,6 +4433,7 @@ dependencies = [
 [[package]]
 name = "mimi_content"
 version = "0.1.0"
+source = "git+https://github.com/phnx-im/mimi-content?rev=c6e5ab7a7ede126906961332551c5e67c1081d3a#c6e5ab7a7ede126906961332551c5e67c1081d3a"
 dependencies = [
  "minicbor",
  "minicbor-derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,6 @@ metrics = "0.24.2"
 metrics-exporter-prometheus = { version = "0.17.2", default-features = false }
 mimi-room-policy = { git = "https://github.com/phnx-im/mimi-room-policy", rev = "6406e6d84c1219da3afcccb91007f2fdaaf61193" }
 minicbor = { version = "2.2.1", features = ["std"] }
-minicbor-derive = "0.19.3"
 minicbor-serde = { version = "0.6", features = ["std"] }
 mimi_content = { git = "https://github.com/phnx-im/mimi-content", rev = "c6e5ab7a7ede126906961332551c5e67c1081d3a", features = ["serde"] }
 mockall = "0.13.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,6 @@ camino = "1.1"
 cargo_metadata = "0.23"
 cbor-diag = "0.1.12"
 chrono = { version = "0.4.38", features = ["serde"] }
-ciborium = "0.2"
 clap = { version = "4.5", features = ["derive"] }
 config = { version = "0.15", default-features = false, features = ["yaml"] }
 criterion = { version = "0.6.0", features = ["html_reports", "async", "async_tokio"] }
@@ -75,7 +74,11 @@ memmap2 = "0.9.5"
 metrics = "0.24.2"
 metrics-exporter-prometheus = { version = "0.17.2", default-features = false }
 mimi-room-policy = { git = "https://github.com/phnx-im/mimi-room-policy", rev = "6406e6d84c1219da3afcccb91007f2fdaaf61193" }
-mimi_content = { git = "https://github.com/phnx-im/mimi-content", rev = "9189ef0b350576e6edd130e43d281c8eb9bfe452" }
+minicbor = { version = "2.2.1", features = ["std"] }
+minicbor-derive = "0.19.3"
+minicbor-serde = { version = "0.6", features = ["std"] }
+#mimi_content = { git = "https://github.com/phnx-im/mimi-content", rev = "4fb6ce006d81c7b73d7b95bb489659a39e224321" }
+mimi_content = { path = "../mimi-content", features = ["serde"] }
 mockall = "0.13.1"
 mockito = "1.7.0"
 openmls = { version = "0.8.1", features = ["extensions-draft-08"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,8 +77,7 @@ mimi-room-policy = { git = "https://github.com/phnx-im/mimi-room-policy", rev = 
 minicbor = { version = "2.2.1", features = ["std"] }
 minicbor-derive = "0.19.3"
 minicbor-serde = { version = "0.6", features = ["std"] }
-#mimi_content = { git = "https://github.com/phnx-im/mimi-content", rev = "4fb6ce006d81c7b73d7b95bb489659a39e224321" }
-mimi_content = { path = "../mimi-content", features = ["serde"] }
+mimi_content = { git = "https://github.com/phnx-im/mimi-content", rev = "c6e5ab7a7ede126906961332551c5e67c1081d3a", features = ["serde"] }
 mockall = "0.13.1"
 mockito = "1.7.0"
 openmls = { version = "0.8.1", features = ["extensions-draft-08"] }

--- a/applogic/src/api/message_content.rs
+++ b/applogic/src/api/message_content.rs
@@ -5,7 +5,6 @@
 pub use aircommon::identifiers::AttachmentId;
 use aircommon::identifiers::MimiId;
 use flutter_rust_bridge::frb;
-use mimi_content::ByteBuf;
 use uuid::Uuid;
 
 use crate::api::markdown::MessageContent;
@@ -27,9 +26,9 @@ impl From<UiMimiId> for MimiId {
     }
 }
 
-impl From<UiMimiId> for ByteBuf {
+impl From<UiMimiId> for Vec<u8> {
     fn from(id: UiMimiId) -> Self {
-        ByteBuf::from(id.0)
+        Vec::from(id.0)
     }
 }
 

--- a/applogic/src/message_content.rs
+++ b/applogic/src/message_content.rs
@@ -5,7 +5,7 @@
 use aircoreclient::AttachmentUrl;
 use mimi_content::{
     MimiContent,
-    content_container::{Disposition, NestedPart, NestedPartContent, PartSemantics},
+    content_container::{Disposition, NestedPart, PartSemantics},
 };
 use tracing::warn;
 
@@ -21,11 +21,12 @@ pub(crate) trait MimiContentExt {
 impl MimiContentExt for MimiContent {
     // Message editing relies on this function returning the original input again. When we add processing to the input or the plain_body function, we need to adjust message editing.
     fn plain_body(&self) -> Option<&str> {
-        match &self.nested_part.part {
+        match &self.nested_part {
             // single part message
-            NestedPartContent::SinglePart {
+            NestedPart::SinglePart {
                 content,
                 content_type,
+                ..
             } if content_type == "text/markdown" => str::from_utf8(content).ok(),
             _ => None,
         }
@@ -45,25 +46,21 @@ impl From<MimiContent> for UiMimiContent {
     fn from(mut mimi_content: MimiContent) -> Self {
         let mut res = Self {
             plain_body: None,
-            replaces: mimi_content.replaces.map(|v| v.into_vec()),
-            topic_id: mimi_content.topic_id.into_vec(),
-            in_reply_to: mimi_content.in_reply_to.map(|v| v.into_vec()),
+            replaces: mimi_content.replaces,
+            topic_id: mimi_content.topic_id,
+            in_reply_to: mimi_content.in_reply_to,
             content: None,
             attachments: Default::default(),
         };
 
-        match (
-            mimi_content.nested_part.disposition,
-            std::mem::take(&mut mimi_content.nested_part.part),
-        ) {
+        match std::mem::take(&mut mimi_content.nested_part) {
             // multipart attachment message with ProcessAll semantics
-            (
-                Disposition::Attachment,
-                NestedPartContent::MultiPart {
-                    part_semantics: PartSemantics::ProcessAll,
-                    parts,
-                },
-            ) => {
+            NestedPart::MultiPart {
+                disposition: Disposition::Attachment,
+                part_semantics: PartSemantics::ProcessAll,
+                parts,
+                ..
+            } => {
                 let Some(attachment) = convert_attachment(parts) else {
                     return res.error_message("Unsupported attachment message");
                 };
@@ -71,25 +68,23 @@ impl From<MimiContent> for UiMimiContent {
             }
 
             // single part message
-            (
-                _,
-                NestedPartContent::SinglePart {
-                    content,
-                    content_type,
-                },
-            ) if content_type == "text/markdown" => {
-                let plain_body = String::from_utf8(content.into_vec())
+            NestedPart::SinglePart {
+                content,
+                content_type,
+                ..
+            } if content_type == "text/markdown" => {
+                let plain_body = String::from_utf8(content)
                     .unwrap_or_else(|_| "Invalid non-UTF8 message".to_owned());
                 res.content = Some(MessageContent::parse_markdown(&plain_body));
                 res.plain_body = Some(plain_body);
             }
-            (_, NestedPartContent::NullPart) => {
+            NestedPart::NullPart { .. } => {
                 res.content = None;
             }
 
             // any other message
-            (disposition, _) => {
-                return res.error_message(format!("Unsupported message: {disposition:?}"));
+            part => {
+                return res.error_message(format!("Unsupported message: {:?}", part.disposition()));
             }
         }
 
@@ -103,19 +98,17 @@ fn convert_attachment(parts: Vec<NestedPart>) -> Option<UiAttachment> {
     let mut dimensions: Option<(u32, u32)> = None;
 
     for part in parts {
-        match (part.disposition, part.part) {
+        match part {
             // actual attachment
-            (
-                Disposition::Attachment,
-                NestedPartContent::ExternalPart {
-                    content_type,
-                    url,
-                    description,
-                    filename,
-                    size,
-                    ..
-                },
-            ) => {
+            NestedPart::ExternalPart {
+                disposition: Disposition::Attachment,
+                content_type,
+                url,
+                description,
+                filename,
+                size,
+                ..
+            } => {
                 if attachment.is_some() {
                     warn!("Skipping duplicate attachment part");
                     continue;
@@ -142,13 +135,12 @@ fn convert_attachment(parts: Vec<NestedPart>) -> Option<UiAttachment> {
             }
 
             // blurhash preview
-            (
-                Disposition::Preview,
-                NestedPartContent::SinglePart {
-                    content,
-                    content_type,
-                },
-            ) if content_type == "text/blurhash" => {
+            NestedPart::SinglePart {
+                disposition: Disposition::Preview,
+                content,
+                content_type,
+                ..
+            } if content_type == "text/blurhash" => {
                 if blurhash.is_some() {
                     warn!("Skipping duplicate blurhash preview part");
                     continue;
@@ -161,8 +153,11 @@ fn convert_attachment(parts: Vec<NestedPart>) -> Option<UiAttachment> {
             }
 
             // other parts
-            (disposition, _) => {
-                warn!("Skipping unsupported attachment part: {disposition:?}");
+            part => {
+                warn!(
+                    "Skipping unsupported attachment part: {:?}",
+                    part.disposition()
+                );
             }
         }
     }

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -16,13 +16,15 @@ aes-gcm.workspace = true
 airmacros.workspace = true
 argon2 = { workspace = true, features = ["std"] }
 chrono = { workspace = true, features = ["serde"] }
-ciborium.workspace = true
 displaydoc.workspace = true
 ed25519 = { workspace = true, features = ["serde"] }
 hex.workspace = true
 hkdf.workspace = true
 mimi-room-policy.workspace = true
 mimi_content.workspace = true
+minicbor.workspace = true
+minicbor-derive.workspace = true
+minicbor-serde.workspace = true
 mls-assist.workspace = true
 rand.workspace = true
 rand_chacha.workspace = true

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -23,7 +23,6 @@ hkdf.workspace = true
 mimi-room-policy.workspace = true
 mimi_content.workspace = true
 minicbor.workspace = true
-minicbor-derive.workspace = true
 minicbor-serde.workspace = true
 mls-assist.workspace = true
 rand.workspace = true

--- a/common/src/codec/cbor.rs
+++ b/common/src/codec/cbor.rs
@@ -11,20 +11,23 @@ use super::Codec;
 pub(super) struct Cbor;
 
 impl Cbor {
-    pub(crate) fn to_writer(
-        value: &impl Serialize,
-        writer: &mut impl std::io::Write,
-    ) -> Result<(), ciborium::ser::Error<std::io::Error>> {
-        ciborium::into_writer(value, writer)
+    pub(crate) fn to_writer<T: Serialize, W: std::io::Write>(
+        value: T,
+        writer: W,
+    ) -> Result<(), minicbor_serde::error::EncodeError<std::io::Error>> {
+        let writer = minicbor::encode::write::Writer::new(writer);
+        let mut serializer = minicbor_serde::Serializer::new(writer);
+        value.serialize(&mut serializer)?;
+        Ok(())
     }
 }
 
 #[derive(Debug, Error)]
 pub enum CborError {
     #[error(transparent)]
-    Serialization(#[from] ciborium::ser::Error<std::io::Error>),
+    Serialization(#[from] minicbor_serde::error::EncodeError<std::convert::Infallible>),
     #[error(transparent)]
-    Deserialization(#[from] ciborium::de::Error<std::io::Error>),
+    Deserialization(#[from] minicbor_serde::error::DecodeError),
 }
 
 impl Codec for Cbor {
@@ -34,15 +37,13 @@ impl Codec for Cbor {
     where
         T: Sized + Serialize,
     {
-        let mut buf = Vec::new();
-        ciborium::into_writer(value, &mut buf)?;
-        Ok(buf)
+        Ok(minicbor_serde::to_vec(value)?)
     }
 
     fn from_slice<T>(bytes: &[u8]) -> Result<T, Self::Error>
     where
         T: DeserializeOwned,
     {
-        Ok(ciborium::de::from_reader(bytes)?)
+        Ok(minicbor_serde::from_slice(bytes)?)
     }
 }

--- a/common/src/codec/cbor.rs
+++ b/common/src/codec/cbor.rs
@@ -12,7 +12,7 @@ pub(super) struct Cbor;
 
 impl Cbor {
     pub(crate) fn to_writer<T: Serialize, W: std::io::Write>(
-        value: T,
+        value: &T,
         writer: W,
     ) -> Result<(), minicbor_serde::error::EncodeError<std::io::Error>> {
         let writer = minicbor::encode::write::Writer::new(writer);

--- a/coreclient/src/chats/messages/mod.rs
+++ b/coreclient/src/chats/messages/mod.rs
@@ -187,10 +187,7 @@ impl ChatMessage {
         let salt: [u8; 16] = RustCrypto::default().random_array()?;
         Ok(MimiContent {
             salt: salt.to_vec(),
-            replaces: self
-                .message()
-                .mimi_id()
-                .map(|id| id.as_slice().to_vec().into()),
+            replaces: self.message().mimi_id().map(|id| id.as_slice().to_vec()),
             topic_id: Default::default(),
             expires: None,
             in_reply_to: None,

--- a/coreclient/src/chats/messages/mod.rs
+++ b/coreclient/src/chats/messages/mod.rs
@@ -4,7 +4,8 @@
 
 use aircommon::{OpenMlsRand, RustCrypto, identifiers::MimiId, time::TimeStamp};
 use mimi_content::{
-    Disposition, MessageStatus, MimiContent, NestedPartContent, content_container::PartSemantics,
+    MessageStatus, MimiContent,
+    content_container::{Disposition, NestedPart, PartSemantics},
 };
 use tracing::{error, warn};
 
@@ -185,7 +186,7 @@ impl ChatMessage {
     pub(crate) fn null_part_content(&self) -> anyhow::Result<MimiContent> {
         let salt: [u8; 16] = RustCrypto::default().random_array()?;
         Ok(MimiContent {
-            salt: mimi_content::ByteBuf::from(salt.to_vec()),
+            salt: salt.to_vec(),
             replaces: self
                 .message()
                 .mimi_id()
@@ -194,10 +195,9 @@ impl ChatMessage {
             expires: None,
             in_reply_to: None,
             extensions: Default::default(),
-            nested_part: mimi_content::NestedPart {
-                disposition: mimi_content::Disposition::Render,
+            nested_part: NestedPart::NullPart {
+                disposition: Disposition::Render,
                 language: String::new(),
-                part: NestedPartContent::NullPart,
             },
         })
     }
@@ -291,7 +291,7 @@ pub struct InReplyToMessage {
 
 // WARNING: If this type is changed, a new `VersionedMessage` variant must be
 // introduced and the storage logic changed accordingly.
-#[derive(PartialEq, Debug, Clone, Serialize, Deserialize)]
+#[derive(PartialEq, Debug, Clone)]
 pub enum Message {
     Content(Box<ContentMessage>),
     Event(EventMessage),
@@ -398,25 +398,26 @@ impl Message {
             return None;
         };
 
-        match &content_message.content().nested_part.part {
+        match &content_message.content().nested_part {
             // Attachment
-            NestedPartContent::MultiPart {
+            NestedPart::MultiPart {
                 part_semantics: PartSemantics::ProcessAll,
                 parts,
+                ..
             } if parts
                 .iter()
-                .any(|part| part.disposition == Disposition::Attachment) =>
+                .any(|part| part.disposition() == Disposition::Attachment) =>
             {
                 // Blurhash preview indicates an image
                 let is_image = parts.iter().any(|part| {
-                    part.disposition == Disposition::Preview
-                        && matches!(
-                            &part.part,
-                            NestedPartContent::SinglePart {
-                                content_type,
-                                ..
-                            } if content_type == "text/blurhash"
-                        )
+                    matches!(
+                        &part,
+                        NestedPart::SinglePart {
+                            content_type,
+                            disposition: Disposition::Preview,
+                            ..
+                        } if content_type == "text/blurhash"
+                    )
                 });
                 Some(if is_image {
                     AttachmentType::Image
@@ -430,8 +431,13 @@ impl Message {
 
     pub fn is_deleted(&self) -> bool {
         self.mimi_content().is_some_and(|c| {
-            c.nested_part.disposition == mimi_content::Disposition::Render
-                && c.nested_part.part == NestedPartContent::NullPart
+            matches!(
+                c.nested_part,
+                NestedPart::NullPart {
+                    disposition: Disposition::Render,
+                    ..
+                }
+            )
         })
     }
 }

--- a/coreclient/src/chats/messages/mod.rs
+++ b/coreclient/src/chats/messages/mod.rs
@@ -288,7 +288,7 @@ pub struct InReplyToMessage {
 
 // WARNING: If this type is changed, a new `VersionedMessage` variant must be
 // introduced and the storage logic changed accordingly.
-#[derive(PartialEq, Debug, Clone)]
+#[derive(PartialEq, Debug, Clone, Serialize, Deserialize)]
 pub enum Message {
     Content(Box<ContentMessage>),
     Event(EventMessage),

--- a/coreclient/src/chats/messages/persistence.rs
+++ b/coreclient/src/chats/messages/persistence.rs
@@ -160,7 +160,7 @@ impl From<SqlChatMessage> for ChatMessage {
             MessageStatus::Hidden
         } else {
             u8::try_from(status)
-                .map(MessageStatus::from_repr)
+                .map(MessageStatus::from)
                 .unwrap_or(MessageStatus::Unread)
         };
 
@@ -680,7 +680,7 @@ impl ChatMessage {
             Message::Event(_) => true,
         };
         let edited_at = self.edited_at();
-        let status = self.status().repr();
+        let status: u8 = self.status().into();
         let message_id = self.id();
 
         query!(

--- a/coreclient/src/chats/messages/persistence.rs
+++ b/coreclient/src/chats/messages/persistence.rs
@@ -1419,7 +1419,7 @@ pub(crate) mod tests {
         let sender = UserId::random("localhost".parse().unwrap());
         let report = MessageStatusReport {
             statuses: vec![PerMessageStatus {
-                mimi_id: mimi_id.as_ref().to_vec().into(),
+                mimi_id: mimi_id.as_ref().to_vec(),
                 status: mimi_content::MessageStatus::Delivered,
             }],
         };

--- a/coreclient/src/chats/persistence.rs
+++ b/coreclient/src/chats/persistence.rs
@@ -555,8 +555,8 @@ impl Chat {
             mimi_id: MimiId,
         }
 
-        let unread_status = MessageStatus::Unread.repr();
-        let delivered_status = MessageStatus::Delivered.repr();
+        let unread_status: u8 = MessageStatus::Unread.into();
+        let delivered_status: u8 = MessageStatus::Delivered.into();
         let new_marked_as_read: Vec<(MessageId, MimiId)> = query_as!(
             Record,
             r#"SELECT
@@ -605,7 +605,7 @@ impl Chat {
         executor: impl SqliteExecutor<'_>,
     ) -> sqlx::Result<usize> {
         // We exclude deleted messages from the unread count.
-        let excluded_status = MessageStatus::Deleted.repr();
+        let excluded_status: u8 = MessageStatus::Deleted.into();
         query_scalar!(
             r#"SELECT
                 COUNT(m.chat_id) AS "count: _"
@@ -651,7 +651,7 @@ impl Chat {
         chat_id: ChatId,
     ) -> sqlx::Result<usize> {
         // We exclude deleted messages from the unread count.
-        let excluded_status = MessageStatus::Deleted.repr();
+        let excluded_status: u8 = MessageStatus::Deleted.into();
         query_scalar!(
             r#"SELECT
                 COUNT(*) AS "count: _"

--- a/coreclient/src/chats/status.rs
+++ b/coreclient/src/chats/status.rs
@@ -163,15 +163,15 @@ mod persistence {
             };
 
             report.statuses.push(PerMessageStatus {
-                mimi_id: mimi_id_a.as_ref().to_vec().into(),
+                mimi_id: mimi_id_a.as_ref().to_vec(),
                 status: MessageStatus::Delivered,
             });
             report.statuses.push(PerMessageStatus {
-                mimi_id: mimi_id_a.as_ref().to_vec().into(),
+                mimi_id: mimi_id_a.as_ref().to_vec(),
                 status: MessageStatus::Read,
             });
             report.statuses.push(PerMessageStatus {
-                mimi_id: mimi_id_b.as_ref().to_vec().into(),
+                mimi_id: mimi_id_b.as_ref().to_vec(),
                 status: MessageStatus::Deleted,
             });
 
@@ -181,20 +181,20 @@ mod persistence {
                 .await?;
             txn.commit().await?;
 
-            let status_a: i64 =
+            let status_a: u8 =
                 query_scalar("SELECT status FROM message_status WHERE message_id = ?")
                     .bind(message_a.id())
                     .fetch_one(&mut *pool.acquire().await?)
                     .await?;
 
-            let status_b: i64 =
+            let status_b: u8 =
                 query_scalar("SELECT status FROM message_status WHERE message_id = ?")
                     .bind(message_b.id())
                     .fetch_one(&mut *pool.acquire().await?)
                     .await?;
 
-            assert_eq!(status_a, i64::from(MessageStatus::Read));
-            assert_eq!(status_b, i64::from(MessageStatus::Deleted));
+            assert_eq!(status_a, u8::from(MessageStatus::Read));
+            assert_eq!(status_b, u8::from(MessageStatus::Deleted));
 
             Ok(())
         }
@@ -219,13 +219,13 @@ mod persistence {
             // Create status records from multiple users
             let report_alice = MessageStatusReport {
                 statuses: vec![PerMessageStatus {
-                    mimi_id: mimi_id.as_ref().to_vec().into(),
+                    mimi_id: mimi_id.as_ref().to_vec(),
                     status: MessageStatus::Delivered,
                 }],
             };
             let report_bob = MessageStatusReport {
                 statuses: vec![PerMessageStatus {
-                    mimi_id: mimi_id.as_ref().to_vec().into(),
+                    mimi_id: mimi_id.as_ref().to_vec(),
                     status: MessageStatus::Read,
                 }],
             };

--- a/coreclient/src/chats/status.rs
+++ b/coreclient/src/chats/status.rs
@@ -56,7 +56,7 @@ mod persistence {
 
                 // Load the message id
                 let mimi_id = mimi_id.as_slice();
-                let status = status.repr();
+                let status: u8 = (*status).into();
                 let Some(message_id) = query_scalar!(
                     r#"SELECT message_id AS "message_id: MessageId"
                         FROM message
@@ -193,8 +193,8 @@ mod persistence {
                     .fetch_one(&mut *pool.acquire().await?)
                     .await?;
 
-            assert_eq!(status_a, i64::from(MessageStatus::Read.repr()));
-            assert_eq!(status_b, i64::from(MessageStatus::Deleted.repr()));
+            assert_eq!(status_a, i64::from(MessageStatus::Read));
+            assert_eq!(status_b, i64::from(MessageStatus::Deleted));
 
             Ok(())
         }

--- a/coreclient/src/clients/attachment/content.rs
+++ b/coreclient/src/clients/attachment/content.rs
@@ -6,19 +6,19 @@ use aircommon::identifiers::UserId;
 use anyhow::ensure;
 use mimi_content::{
     MimiContent,
-    content_container::{NestedPart, NestedPartContent, PartSemantics},
+    content_container::{NestedPart, PartSemantics},
 };
 use openmls::group::GroupId;
 
 pub trait MimiContentExt {
     fn visit_attachments(
         &self,
-        visitor: impl FnMut(&NestedPartContent) -> anyhow::Result<()>,
+        visitor: impl FnMut(&NestedPart) -> anyhow::Result<()>,
     ) -> anyhow::Result<()>;
 
     fn visit_attachments_mut(
         &mut self,
-        visitor: impl FnMut(&mut NestedPartContent) -> anyhow::Result<()>,
+        visitor: impl FnMut(&mut NestedPart) -> anyhow::Result<()>,
     ) -> anyhow::Result<()>;
 
     fn mimi_id(&self, sender: &UserId, group_id: &GroupId) -> anyhow::Result<Vec<u8>>;
@@ -27,14 +27,14 @@ pub trait MimiContentExt {
 impl MimiContentExt for MimiContent {
     fn visit_attachments(
         &self,
-        mut visitor: impl FnMut(&NestedPartContent) -> anyhow::Result<()>,
+        mut visitor: impl FnMut(&NestedPart) -> anyhow::Result<()>,
     ) -> anyhow::Result<()> {
         visit_attachments_impl(&self.nested_part, &mut visitor, 0)
     }
 
     fn visit_attachments_mut(
         &mut self,
-        mut visitor: impl FnMut(&mut NestedPartContent) -> anyhow::Result<()>,
+        mut visitor: impl FnMut(&mut NestedPart) -> anyhow::Result<()>,
     ) -> anyhow::Result<()> {
         visit_attachments_mut_impl(&mut self.nested_part, &mut visitor, 0)
     }
@@ -48,7 +48,7 @@ const MAX_RECURSION_DEPTH: usize = 3;
 
 fn visit_attachments_impl(
     part: &NestedPart,
-    visitor: &mut impl FnMut(&NestedPartContent) -> anyhow::Result<()>,
+    visitor: &mut impl FnMut(&NestedPart) -> anyhow::Result<()>,
     recursion_depth: usize,
 ) -> anyhow::Result<()> {
     ensure!(
@@ -56,13 +56,14 @@ fn visit_attachments_impl(
         "Failed to handle attachment due to maximum recursion depth reached"
     );
 
-    match &part.part {
-        external_part @ NestedPartContent::ExternalPart { .. } => {
+    match &part {
+        external_part @ NestedPart::ExternalPart { .. } => {
             visitor(external_part)?;
         }
-        NestedPartContent::MultiPart {
+        NestedPart::MultiPart {
             part_semantics: PartSemantics::ProcessAll,
             parts,
+            ..
         } => {
             for part in parts {
                 visit_attachments_impl(part, visitor, recursion_depth + 1)?;
@@ -76,7 +77,7 @@ fn visit_attachments_impl(
 
 fn visit_attachments_mut_impl(
     part: &mut NestedPart,
-    visitor: &mut impl FnMut(&mut NestedPartContent) -> anyhow::Result<()>,
+    visitor: &mut impl FnMut(&mut NestedPart) -> anyhow::Result<()>,
     recursion_depth: usize,
 ) -> anyhow::Result<()> {
     ensure!(
@@ -84,13 +85,14 @@ fn visit_attachments_mut_impl(
         "Failed to handle attachment due to maximum recursion depth reached"
     );
 
-    match &mut part.part {
-        external_part @ NestedPartContent::ExternalPart { .. } => {
+    match part {
+        external_part @ NestedPart::ExternalPart { .. } => {
             visitor(external_part)?;
         }
-        NestedPartContent::MultiPart {
+        NestedPart::MultiPart {
             part_semantics: PartSemantics::ProcessAll,
             parts,
+            ..
         } => {
             for part in parts {
                 visit_attachments_mut_impl(part, visitor, recursion_depth + 1)?;

--- a/coreclient/src/clients/attachment/persistence.rs
+++ b/coreclient/src/clients/attachment/persistence.rs
@@ -377,8 +377,8 @@ impl PendingAttachmentRecord {
         notifier: &mut StoreNotifier,
     ) -> sqlx::Result<()> {
         let size = self.size as i64;
-        let enc_alg: i64 = self.enc_alg.repr().into();
-        let hash_alg: i64 = self.hash_alg.repr().into();
+        let enc_alg: u16 = self.enc_alg.into();
+        let hash_alg: u8 = self.hash_alg.into();
         query!(
             "INSERT INTO pending_attachment (
                 attachment_id,
@@ -451,11 +451,11 @@ impl PendingAttachmentRecord {
                 PendingAttachmentRecord {
                     attachment_id,
                     size,
-                    enc_alg: EncryptionAlgorithm::from_repr(enc_alg),
+                    enc_alg: EncryptionAlgorithm::from(enc_alg),
                     enc_key,
                     nonce,
                     aad,
-                    hash_alg: HashAlgorithm::from_repr(hash_alg),
+                    hash_alg: HashAlgorithm::from(hash_alg),
                     hash,
                 }
             },

--- a/coreclient/src/clients/attachment/process.rs
+++ b/coreclient/src/clients/attachment/process.rs
@@ -7,7 +7,7 @@
 use std::mem;
 
 use aircommon::identifiers::AttachmentId;
-use mimi_content::content_container::NestedPartContent;
+use mimi_content::content_container::NestedPart;
 use tracing::error;
 
 use super::{content::MimiContentExt, persistence::PendingAttachmentRecord};
@@ -40,7 +40,7 @@ impl CoreUser {
         };
 
         let visit_res = mimi_content.visit_attachments_mut(|part| {
-            let NestedPartContent::ExternalPart {
+            let NestedPart::ExternalPart {
                 url,
                 content_type,
                 size,
@@ -61,7 +61,13 @@ impl CoreUser {
                 Ok(id) => id,
                 Err(error) => {
                     error!(%url, %error, "invalid attachment url; dropping attachment");
-                    let _ = mem::replace(part, NestedPartContent::NullPart);
+                    let _ = mem::replace(
+                        part,
+                        NestedPart::NullPart {
+                            disposition: Disposition::Unspecified,
+                            language: Default::default(),
+                        },
+                    );
                     return Ok(());
                 }
             };
@@ -80,11 +86,11 @@ impl CoreUser {
                 attachment_id,
                 size: *size,
                 enc_alg: *enc_alg,
-                enc_key: mem::take(key).into_vec(),
-                nonce: mem::take(nonce).into_vec(),
-                aad: mem::take(aad).into_vec(),
+                enc_key: mem::take(key),
+                nonce: mem::take(nonce),
+                aad: mem::take(aad),
                 hash_alg: *hash_alg,
-                hash: mem::take(content_hash).into_vec(),
+                hash: mem::take(content_hash),
             };
             records.push((record, pending_record));
 

--- a/coreclient/src/clients/attachment/process.rs
+++ b/coreclient/src/clients/attachment/process.rs
@@ -7,7 +7,7 @@
 use std::mem;
 
 use aircommon::identifiers::AttachmentId;
-use mimi_content::content_container::NestedPart;
+use mimi_content::{Disposition, content_container::NestedPart};
 use tracing::error;
 
 use super::{content::MimiContentExt, persistence::PendingAttachmentRecord};

--- a/coreclient/src/clients/attachment/upload.rs
+++ b/coreclient/src/clients/attachment/upload.rs
@@ -24,7 +24,7 @@ use base64::{Engine, prelude::BASE64_STANDARD};
 use chrono::{DateTime, Local, Utc};
 use mimi_content::{
     MimiContent,
-    content_container::{Disposition, NestedPart, NestedPartContent, PartSemantics},
+    content_container::{Disposition, NestedPart, PartSemantics},
 };
 use reqwest::{Body, multipart};
 use serde::Deserialize;
@@ -94,13 +94,11 @@ impl CoreUser {
         let content_type = attachment.content_type;
 
         let content = MimiContent {
-            nested_part: NestedPart {
+            nested_part: NestedPart::MultiPart {
                 disposition: Disposition::Attachment,
-                part: NestedPartContent::MultiPart {
-                    part_semantics: PartSemantics::ProcessAll,
-                    parts: attachment.into_nested_parts(attachment_metadata)?,
-                },
-                ..Default::default()
+                part_semantics: PartSemantics::ProcessAll,
+                parts: attachment.into_nested_parts(attachment_metadata)?,
+                language: Default::default(),
             },
             ..Default::default()
         };
@@ -201,13 +199,13 @@ impl CoreUser {
         // attachment record and this message is broken. We must copy the attachment record with
         // the new attachment id.
         if let Some(mimi_content) = message.message_mut().mimi_content_mut()
-            && let NestedPartContent::MultiPart { parts, .. } = &mut mimi_content.nested_part.part
+            && let NestedPart::MultiPart { parts, .. } = &mut mimi_content.nested_part
             && let Some(attachment_part) = parts
                 .iter_mut()
-                .find(|part| part.disposition == Disposition::Attachment)
-            && let NestedPartContent::ExternalPart {
+                .find(|part| part.disposition() == Disposition::Attachment)
+            && let NestedPart::ExternalPart {
                 url, key, nonce, ..
-            } = &mut attachment_part.part
+            } = attachment_part
             && let Ok(attachment_url) = AttachmentUrl::from_url(&url.parse()?)
         {
             *url = AttachmentUrl::new(attachment_metadata.attachment_id, attachment_url.dimensions)
@@ -391,32 +389,28 @@ impl ProcessedAttachment {
                 .map(|data| (data.width, data.height)),
         );
 
-        let attachment = NestedPart {
+        let attachment = NestedPart::ExternalPart {
             disposition: Disposition::Attachment,
             language: String::new(),
-            part: NestedPartContent::ExternalPart {
-                content_type: self.content_type.to_owned(),
-                url: url.to_string(),
-                expires: 0,
-                size: self.size,
-                enc_alg: AIR_ATTACHMENT_ENCRYPTION_ALG,
-                key: metadata.key.into_bytes().to_vec().into(),
-                nonce: metadata.nonce.to_vec().into(),
-                aad: Default::default(),
-                hash_alg: AIR_ATTACHMENT_HASH_ALG,
-                content_hash: self.content_hash.into(),
-                description: Default::default(),
-                filename: self.filename,
-            },
+            content_type: self.content_type.to_owned(),
+            url: url.to_string(),
+            expires: 0,
+            size: self.size,
+            enc_alg: AIR_ATTACHMENT_ENCRYPTION_ALG,
+            key: metadata.key.into_bytes().to_vec().into(),
+            nonce: metadata.nonce.to_vec().into(),
+            aad: Default::default(),
+            hash_alg: AIR_ATTACHMENT_HASH_ALG,
+            content_hash: self.content_hash.into(),
+            description: Default::default(),
+            filename: self.filename,
         };
 
-        let blurhash = self.image_data.map(|data| NestedPart {
+        let blurhash = self.image_data.map(|data| NestedPart::SinglePart {
             disposition: Disposition::Preview,
             language: String::new(),
-            part: NestedPartContent::SinglePart {
-                content_type: "text/blurhash".to_owned(),
-                content: data.blurhash.into_bytes().into(),
-            },
+            content_type: "text/blurhash".to_owned(),
+            content: data.blurhash.into_bytes().into(),
         });
 
         Ok([Some(attachment), blurhash].into_iter().flatten().collect())

--- a/coreclient/src/clients/attachment/upload.rs
+++ b/coreclient/src/clients/attachment/upload.rs
@@ -210,8 +210,8 @@ impl CoreUser {
         {
             *url = AttachmentUrl::new(attachment_metadata.attachment_id, attachment_url.dimensions)
                 .to_string();
-            *key = attachment_metadata.key.into_bytes().to_vec().into();
-            *nonce = attachment_metadata.nonce.to_vec().into();
+            *key = attachment_metadata.key.into_bytes().to_vec();
+            *nonce = attachment_metadata.nonce.to_vec();
 
             self.with_transaction_and_notifier(async |txn, notifier| {
                 message.update(txn.as_mut(), notifier).await?;
@@ -397,11 +397,11 @@ impl ProcessedAttachment {
             expires: 0,
             size: self.size,
             enc_alg: AIR_ATTACHMENT_ENCRYPTION_ALG,
-            key: metadata.key.into_bytes().to_vec().into(),
-            nonce: metadata.nonce.to_vec().into(),
+            key: metadata.key.into_bytes().to_vec(),
+            nonce: metadata.nonce.to_vec(),
             aad: Default::default(),
             hash_alg: AIR_ATTACHMENT_HASH_ALG,
-            content_hash: self.content_hash.into(),
+            content_hash: self.content_hash,
             description: Default::default(),
             filename: self.filename,
         };
@@ -410,7 +410,7 @@ impl ProcessedAttachment {
             disposition: Disposition::Preview,
             language: String::new(),
             content_type: "text/blurhash".to_owned(),
-            content: data.blurhash.into_bytes().into(),
+            content: data.blurhash.into_bytes(),
         });
 
         Ok([Some(attachment), blurhash].into_iter().flatten().collect())

--- a/coreclient/src/clients/message.rs
+++ b/coreclient/src/clients/message.rs
@@ -4,7 +4,7 @@
 
 use aircommon::{identifiers::UserId, time::TimeStamp};
 use anyhow::{Context, bail};
-use mimi_content::{MessageStatus, MimiContent, NestedPart};
+use mimi_content::{MessageStatus, MimiContent};
 use sqlx::SqliteTransaction;
 
 use crate::{
@@ -258,7 +258,7 @@ impl UnsentContent {
                 .message()
                 .mimi_id()
                 .context("Replaced message does not have mimi id")?;
-            content.replaces = Some(original_mimi_id.as_slice().to_vec().into());
+            content.replaces = Some(original_mimi_id.as_slice().to_vec());
             let edit_created_at = TimeStamp::now();
 
             if !is_deletion {

--- a/coreclient/src/clients/message.rs
+++ b/coreclient/src/clients/message.rs
@@ -4,7 +4,7 @@
 
 use aircommon::{identifiers::UserId, time::TimeStamp};
 use anyhow::{Context, bail};
-use mimi_content::{MessageStatus, MimiContent, NestedPartContent};
+use mimi_content::{MessageStatus, MimiContent, NestedPart};
 use sqlx::SqliteTransaction;
 
 use crate::{
@@ -247,7 +247,7 @@ impl UnsentContent {
             .await?
             .with_context(|| format!("Can't find chat with id {chat_id}"))?;
 
-        let is_deletion = content.nested_part.part == NestedPartContent::NullPart;
+        let is_deletion = content.nested_part.is_null_part();
 
         let message = if let Some(replaces) = replaces {
             let original_mimi_content = replaces

--- a/coreclient/src/clients/process/process_qs.rs
+++ b/coreclient/src/clients/process/process_qs.rs
@@ -1381,7 +1381,7 @@ mod tests {
         bob_mimi_content.in_reply_to = alice_message
             .message()
             .mimi_id()
-            .map(|mimi_id| ByteBuf::from(mimi_id.as_slice()));
+            .map(|mimi_id| mimi_id.as_slice().to_vec());
         let bob_message = ChatMessage::new_for_test(
             chat.id(),
             MessageId::random(),
@@ -1504,7 +1504,7 @@ mod tests {
         bob_mimi_content.in_reply_to = alice_message
             .message()
             .mimi_id()
-            .map(|mimi_id| ByteBuf::from(mimi_id.as_slice()));
+            .map(|mimi_id| mimi_id.as_slice().to_vec());
         let bob_message = ChatMessage::new_for_test(
             chat.id(),
             MessageId::random(),
@@ -1519,7 +1519,7 @@ mod tests {
         carol_mimi_content.in_reply_to = alice_message
             .message()
             .mimi_id()
-            .map(|mimi_id| ByteBuf::from(mimi_id.as_slice()));
+            .map(|mimi_id| mimi_id.as_slice().to_vec());
         let carol_message = ChatMessage::new_for_test(
             chat.id(),
             MessageId::random(),

--- a/coreclient/src/clients/process/process_qs.rs
+++ b/coreclient/src/clients/process/process_qs.rs
@@ -25,9 +25,7 @@ use airprotos::{
 };
 use anyhow::{Context, Result, bail, ensure};
 use chrono::Utc;
-use mimi_content::{
-    Disposition, MessageStatus, MessageStatusReport, MimiContent, NestedPartContent,
-};
+use mimi_content::{Disposition, MessageStatus, MessageStatusReport, MimiContent, NestedPart};
 use mimi_room_policy::RoleIndex;
 use openmls::{
     group::{GroupId, QueuedProposal},
@@ -563,7 +561,7 @@ impl CoreUser {
         let delivery_receipts = messages.iter().filter_map(|message| {
             if let Message::Content(content_message) = message.message()
                 && let Disposition::Render | Disposition::Attachment =
-                    content_message.content().nested_part.disposition
+                    content_message.content().nested_part.disposition()
                 && let Some(mimi_id) = content_message.mimi_id()
             {
                 Some((message.id(), mimi_id, MessageStatus::Delivered))
@@ -607,10 +605,11 @@ impl CoreUser {
 
         // Delivery receipt
         if let Ok(content) = &content
-            && let NestedPartContent::SinglePart {
+            && let NestedPart::SinglePart {
                 content_type,
                 content: report_content,
-            } = &content.nested_part.part
+                ..
+            } = &content.nested_part
             && content_type == "application/mimi-message-status"
         {
             let mut report = MessageStatusReport::deserialize(report_content)?;
@@ -1103,7 +1102,7 @@ async fn handle_message_edit(
     replaces: MimiId,
     content: MimiContent,
 ) -> anyhow::Result<ChatMessage> {
-    let is_delete = content.nested_part.part == NestedPartContent::NullPart;
+    let is_delete = content.nested_part.is_null_part();
 
     // First try to directly load the original message by mimi id (non-edited message) and fallback
     // to the history of edits otherwise.
@@ -1337,7 +1336,7 @@ impl QsProcessEventResult {
 #[cfg(test)]
 mod tests {
     use aircommon::{identifiers::UserId, time::TimeStamp};
-    use mimi_content::{ByteBuf, MimiContent};
+    use mimi_content::MimiContent;
     use sqlx::SqlitePool;
 
     use crate::{
@@ -1611,8 +1610,7 @@ mod tests {
         let edited_alice_mimi_id = *alice_message.message().mimi_id().unwrap();
         let mut bob_mimi_content =
             MimiContent::simple_markdown_message("Reply to edited message!".to_string(), [1; 16]);
-        bob_mimi_content.in_reply_to =
-            Some(ByteBuf::from(edited_alice_mimi_id.as_slice().to_vec()));
+        bob_mimi_content.in_reply_to = Some(edited_alice_mimi_id.as_slice().to_vec());
         let bob_message = ChatMessage::new_for_test(
             chat.id(),
             MessageId::random(),

--- a/coreclient/src/outbound_service/chat_message_queue.rs
+++ b/coreclient/src/outbound_service/chat_message_queue.rs
@@ -135,7 +135,7 @@ mod persistence {
             txn: &mut SqliteTransaction<'_>,
             notifier: &mut StoreNotifier,
         ) -> sqlx::Result<()> {
-            let failed_status = MessageStatus::Error.repr();
+            let failed_status: u8 = MessageStatus::Error.into();
             query!(
                 "UPDATE message SET status = ? WHERE message_id = ?",
                 failed_status,
@@ -171,7 +171,7 @@ mod persistence {
             txn: &mut SqliteTransaction<'_>,
             notifier: &mut StoreNotifier,
         ) -> sqlx::Result<()> {
-            let failed_status = MessageStatus::Error.repr();
+            let failed_status: u8 = MessageStatus::Error.into();
             let marked_messages: Vec<MessageId> = query_scalar!(
                 r#"UPDATE message
                 SET status = ?1

--- a/coreclient/src/outbound_service/receipt_queue.rs
+++ b/coreclient/src/outbound_service/receipt_queue.rs
@@ -45,7 +45,7 @@ mod persistence {
                 ?self.message_id, ?mimi_id, ?self.message_status, "Enqueueing receipt"
             );
 
-            let status = self.message_status.repr();
+            let status: u8 = self.message_status.into();
             let now = TimeStamp::now();
 
             query!(
@@ -108,9 +108,7 @@ mod persistence {
                 locked_before,
             )
             .fetch(txn.as_mut())
-            .map(|record| {
-                record.map(|record| (record.mimi_id, MessageStatus::from_repr(record.status)))
-            })
+            .map(|record| record.map(|record| (record.mimi_id, MessageStatus::from(record.status))))
             .collect::<Result<Vec<_>, _>>()
             .await?;
 

--- a/coreclient/src/outbound_service/receipts.rs
+++ b/coreclient/src/outbound_service/receipts.rs
@@ -8,8 +8,7 @@ use aircommon::{
 };
 use anyhow::Context;
 use mimi_content::{
-    ByteBuf, Disposition, MessageStatus, MessageStatusReport, MimiContent, NestedPart,
-    NestedPartContent, PerMessageStatus,
+    Disposition, MessageStatus, MessageStatusReport, MimiContent, NestedPart, PerMessageStatus,
 };
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error};
@@ -242,14 +241,14 @@ impl UnsentReceipt {
         }
 
         let content = MimiContent {
-            salt: ByteBuf::from(aircommon::crypto::secrets::Secret::<16>::random()?.secret()),
-            nested_part: NestedPart {
+            salt: aircommon::crypto::secrets::Secret::<16>::random()?
+                .secret()
+                .to_vec(),
+            nested_part: NestedPart::SinglePart {
                 disposition: Disposition::Unspecified,
-                part: NestedPartContent::SinglePart {
-                    content_type: "application/mimi-message-status".to_owned(),
-                    content: report.serialize()?.into(),
-                },
-                ..Default::default()
+                content_type: "application/mimi-message-status".to_owned(),
+                content: report.serialize()?.into(),
+                language: Default::default(),
             },
             ..Default::default()
         };

--- a/coreclient/src/outbound_service/receipts.rs
+++ b/coreclient/src/outbound_service/receipts.rs
@@ -230,7 +230,7 @@ impl UnsentReceipt {
             statuses: statuses
                 .into_iter()
                 .map(|(id, status)| PerMessageStatus {
-                    mimi_id: id.as_ref().to_vec().into(),
+                    mimi_id: id.as_ref().to_vec(),
                     status,
                 })
                 .collect(),
@@ -247,7 +247,7 @@ impl UnsentReceipt {
             nested_part: NestedPart::SinglePart {
                 disposition: Disposition::Unspecified,
                 content_type: "application/mimi-message-status".to_owned(),
-                content: report.serialize()?.into(),
+                content: report.serialize()?,
                 language: Default::default(),
             },
             ..Default::default()

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -20,6 +20,7 @@ quote = "1"
 syn = { version = "2", features = ["full"] }
 
 [dev-dependencies]
-ciborium.workspace = true
+minicbor.workspace = true
+minicbor-serde.workspace = true
 serde.workspace = true
 serde_bytes.workspace = true

--- a/macros/tests/tagged_map.rs
+++ b/macros/tests/tagged_map.rs
@@ -5,7 +5,7 @@
 use std::borrow::Cow;
 
 use airmacros::{DeserializeTaggedMap, SerializeTaggedMap};
-use ciborium::{from_reader, into_writer};
+use minicbor_serde::{from_slice, to_vec};
 
 // Helpers
 
@@ -13,20 +13,21 @@ fn cbor_roundtrip<T>(value: &T) -> T
 where
     T: serde::Serialize + for<'de> serde::Deserialize<'de>,
 {
-    let mut buf = Vec::new();
-    into_writer(value, &mut buf).expect("serialize");
-    from_reader(buf.as_slice()).expect("deserialize")
+    let buf = to_vec(value).expect("serialize");
+    from_slice(&buf).expect("deserialize")
 }
 
 /// Returns the number of entries in the top-level CBOR map.
-fn cbor_map_len(value: &impl serde::Serialize) -> usize {
+fn cbor_map_len(value: &impl serde::Serialize) -> u64 {
     let mut buf = Vec::new();
-    into_writer(value, &mut buf).expect("serialize");
-    let v: ciborium::value::Value = from_reader(buf.as_slice()).expect("parse");
-    match v {
-        ciborium::value::Value::Map(m) => m.len(),
-        other => panic!("expected CBOR map, got {other:?}"),
-    }
+    let mut serializer = minicbor_serde::Serializer::new(&mut buf);
+    value.serialize(&mut serializer).expect("serialize");
+
+    let mut decoder = minicbor::Decoder::new(&buf);
+    decoder
+        .map()
+        .expect("expected CBOR map")
+        .unwrap_or_default()
 }
 
 // Basic roundtrip
@@ -201,10 +202,8 @@ fn unknown_keys_are_ignored() {
         known: 5,
         unknown: 999,
     };
-    let mut buf = Vec::new();
-    into_writer(&super_val, &mut buf).expect("serialize");
-
-    let sub_val: Subset = from_reader(buf.as_slice()).expect("deserialize");
+    let buf = to_vec(&super_val).expect("serialize");
+    let sub_val: Subset = from_slice(&buf).expect("deserialize");
     assert_eq!(sub_val, Subset { known: 5 });
 }
 
@@ -217,9 +216,7 @@ fn missing_keys_default_to_zero() {
         known: 0, // default -> omitted
         unknown: 1,
     };
-    let mut buf = Vec::new();
-    into_writer(&super_val, &mut buf).expect("serialize");
-
-    let sub_val: Subset = from_reader(buf.as_slice()).expect("deserialize");
+    let buf = to_vec(&super_val).expect("serialize");
+    let sub_val: Subset = from_slice(&buf).expect("deserialize");
     assert_eq!(sub_val, Subset { known: 0 });
 }

--- a/server/tests/tests/attachment.rs
+++ b/server/tests/tests/attachment.rs
@@ -9,7 +9,7 @@ use aircoreclient::{AttachmentProgressEvent, ProvisionAttachmentError, store::St
 use airserver_test_harness::utils::setup::{TestBackend, TestBackendParams};
 use base64::{Engine, prelude::BASE64_STANDARD};
 use image::{ImageBuffer, Rgba};
-use mimi_content::content_container::NestedPartContent;
+use mimi_content::content_container::NestedPart;
 use png::Encoder;
 use sha2::{Digest, Sha256};
 use tokio_stream::StreamExt;
@@ -54,7 +54,7 @@ async fn send_attachment() {
         .unwrap();
 
     let attachment_id = match &external_part {
-        NestedPartContent::ExternalPart {
+        NestedPart::ExternalPart {
             content_type,
             url,
             filename,
@@ -104,7 +104,7 @@ async fn send_attachment() {
         .into_bytes()
         .unwrap();
     match external_part {
-        NestedPartContent::ExternalPart {
+        NestedPart::ExternalPart {
             size, content_hash, ..
         } => {
             assert_eq!(content.len() as u64, size);
@@ -144,7 +144,7 @@ async fn send_image_attachment() {
     alice.user.outbound_service().run_once().await;
 
     let attachment_id = match &external_part {
-        NestedPartContent::ExternalPart {
+        NestedPart::ExternalPart {
             content_type,
             url,
             filename,
@@ -196,7 +196,7 @@ async fn send_image_attachment() {
         .into_bytes()
         .unwrap();
     match external_part {
-        NestedPartContent::ExternalPart {
+        NestedPart::ExternalPart {
             size, content_hash, ..
         } => {
             assert_eq!(content.len() as u64, size);

--- a/server/tests/tests/message.rs
+++ b/server/tests/tests/message.rs
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-use mimi_content::{MessageStatus, MimiContent, NestedPartContent};
+use mimi_content::{MessageStatus, MimiContent};
 use rand::{Rng, distributions::Alphanumeric, rngs::OsRng};
 
 use aircoreclient::{
@@ -158,15 +158,14 @@ async fn delete_messages_and_check_replies() -> anyhow::Result<()> {
         "Bob's reply to Alice should point to the updated empty MIMI content"
     );
 
-    assert_eq!(
+    assert!(
         bob_reply_to_alice_irt
             .unwrap()
             .mimi_content
             .as_ref()
             .unwrap()
             .nested_part
-            .part,
-        NestedPartContent::NullPart,
+            .is_null_part(),
         "Bob's reply to Alice should have a loaded empty MIMI content"
     );
 
@@ -193,14 +192,13 @@ async fn delete_messages_and_check_replies() -> anyhow::Result<()> {
         "Bob's reply to Alice should point to "
     );
 
-    assert_eq!(
+    assert!(
         bob_replies_to_alice_irt
             .unwrap()
             .mimi_content
             .unwrap()
             .nested_part
-            .part,
-        NestedPartContent::NullPart,
+            .is_null_part(),
         "Bob's reply to Alice should have a loaded empty MIMI content"
     );
 
@@ -604,7 +602,7 @@ async fn delete_message_preserves_other_messages() {
                 text.contains("First")
                     || text.contains("Second")
                     || text.contains("Third")
-                    || c.nested_part.part == mimi_content::NestedPartContent::NullPart
+                    || c.nested_part.is_null_part()
             })
             .unwrap_or(false)
     };

--- a/test_harness/src/utils/setup.rs
+++ b/test_harness/src/utils/setup.rs
@@ -18,8 +18,8 @@ use aircoreclient::{ChatId, ChatStatus, ChatType, clients::CoreUser, store::Stor
 use airserver::network_provider::MockNetworkProvider;
 use anyhow::Context;
 use mimi_content::{
-    ByteBuf, MimiContent,
-    content_container::{EncryptionAlgorithm, HashAlgorithm, NestedPartContent},
+    MimiContent, NestedPart,
+    content_container::{EncryptionAlgorithm, HashAlgorithm},
 };
 use rand::{Rng, RngCore, distributions::Alphanumeric, seq::IteratorRandom};
 use rand_chacha::rand_core::OsRng;
@@ -713,7 +713,7 @@ impl TestBackend {
             .collect();
         let salt: [u8; 16] = RustCrypto::default().random_array().unwrap();
         let mut orig_message = MimiContent::simple_markdown_message(message, salt);
-        orig_message.in_reply_to = in_reply_to.map(|id| ByteBuf::from(id.as_slice()));
+        orig_message.in_reply_to = in_reply_to.map(|id| id.as_slice().to_vec());
         let test_sender = self.users.get_mut(sender_id).unwrap();
         let sender = &mut test_sender.user;
 
@@ -808,9 +808,14 @@ impl TestBackend {
 
         let salt: [u8; 16] = RustCrypto::default().random_array().unwrap();
         let mut orig_message = MimiContent::simple_markdown_message("edited".to_owned(), salt);
-        orig_message.replaces = Some(ByteBuf::from(
-            last_message.message().mimi_id().unwrap().as_slice(),
-        ));
+        orig_message.replaces = Some(
+            last_message
+                .message()
+                .mimi_id()
+                .unwrap()
+                .as_slice()
+                .to_vec(),
+        );
 
         // Before sending a message, the sender must first fetch and process its QS messages.
 
@@ -922,7 +927,7 @@ impl TestBackend {
         recipients: Vec<&UserId>,
         attachment: &[u8],
         filename: &str,
-    ) -> Result<(MessageId, NestedPartContent), ProvisionAttachmentError> {
+    ) -> Result<(MessageId, NestedPart), ProvisionAttachmentError> {
         let recipient_strings = recipients
             .iter()
             .map(|n| format!("{n:?}"))
@@ -968,7 +973,7 @@ impl TestBackend {
             .unwrap();
         let external_part = external_part.unwrap();
         match &external_part {
-            NestedPartContent::ExternalPart {
+            NestedPart::ExternalPart {
                 enc_alg,
                 key,
                 nonce,
@@ -1005,7 +1010,7 @@ impl TestBackend {
 
                     // Removed cleared fields from the expected attachment.
                     let mut expected = external_part.clone();
-                    if let NestedPartContent::ExternalPart {
+                    if let NestedPart::ExternalPart {
                         key,
                         nonce,
                         aad,


### PR DESCRIPTION
While looking into contention with @boxdot we realised that CBOR en/de-coding was rather slow (10x slower than `serde_json`). After looking at https://github.com/djkoloski/rust_serialization_benchmark we decided to give a shot to `minicbor` which seems to kinda work out of the box with our codebase.

This provides (at least) a meaningful ~5x speedup in OpenMLS storage `serde` deserialize operations as well as en/decoding keys and MIMI content in our database.

Technically, we could switch to `minicbor::Encode` and `minicbor::Decode` directly, but I would first like to make those changes which are easier to review and integrate (read: less risky IMO).

For more performance comparison, see https://github.com/phnx-im/mimi-content and run `cargo bench`.

<img width="1483" height="316" alt="Screenshot From 2026-04-29 16-57-37" src="https://github.com/user-attachments/assets/09859764-41e5-4b2c-a6d4-630615e51b68" />