### PR TITLE
fix(app): process all messages in store notification batch

### DIFF
--- a/applogic/src/api/message_list_cubit.rs
+++ b/applogic/src/api/message_list_cubit.rs
@@ -966,45 +966,45 @@ impl<S: Store + Send + Sync + 'static> MessageListContext<S> {
         &mut self,
         notification: &StoreNotification,
     ) -> anyhow::Result<()> {
+        let mut needs_load_newer = false;
+        let mut clear_unread_marker = false;
+
         for (id, op) in &notification.ops {
-            if let StoreEntityId::Message(message_id) = id {
-                if op.contains(StoreOperation::Remove) {
-                    let in_window = self.data.message_ids_index.contains_key(message_id);
-                    if in_window {
-                        self.remove_message_in_place(*message_id);
-                    }
-                    return Ok(());
-                }
+            let StoreEntityId::Message(message_id) = id else {
+                continue;
+            };
 
-                if op.contains(StoreOperation::Add) {
-                    if let Some(message) = self.store.message(*message_id).await?
-                        && message.chat_id() == self.chat_id
-                    {
-                        // Own message (not yet sent to server) clears the
-                        // unread divider — the user has engaged with the chat.
-                        if !message.is_sent() {
-                            self.clear_first_unread_index();
-                        }
-
-                        let is_at_bottom = self.state_tx.borrow().is_at_bottom;
-                        if is_at_bottom {
-                            self.handle_load_newer().await;
-                        }
-                    }
-                    return Ok(());
+            if op.contains(StoreOperation::Remove) {
+                if self.data.message_ids_index.contains_key(message_id) {
+                    self.remove_message_in_place(*message_id);
                 }
-
-                if op.contains(StoreOperation::Update) {
-                    let in_window = self.data.message_ids_index.contains_key(message_id);
-                    if in_window
-                        && let Some(message) = self.store.message(*message_id).await?
-                        && message.chat_id() == self.chat_id
-                    {
-                        self.update_message_in_place(message);
+            } else if op.contains(StoreOperation::Add) {
+                if let Some(message) = self.store.message(*message_id).await?
+                    && message.chat_id() == self.chat_id
+                {
+                    // Own message (not yet sent to server) clears the
+                    // unread divider — the user has engaged with the chat.
+                    if !message.is_sent() {
+                        clear_unread_marker = true;
                     }
-                    return Ok(());
+                    if self.state_tx.borrow().is_at_bottom {
+                        needs_load_newer = true;
+                    }
                 }
+            } else if op.contains(StoreOperation::Update)
+                && self.data.message_ids_index.contains_key(message_id)
+                && let Some(message) = self.store.message(*message_id).await?
+                && message.chat_id() == self.chat_id
+            {
+                self.update_message_in_place(message);
             }
+        }
+
+        if clear_unread_marker {
+            self.clear_first_unread_index();
+        }
+        if needs_load_newer {
+            self.handle_load_newer().await;
         }
         Ok(())
     }

--- a/applogic/src/api/message_list_cubit.rs
+++ b/applogic/src/api/message_list_cubit.rs
@@ -975,7 +975,10 @@ impl<S: Store + Send + Sync + 'static> MessageListContext<S> {
             };
 
             if op.contains(StoreOperation::Remove) {
-                if self.data.message_ids_index.contains_key(message_id) {
+                if self.data.message_ids_index.contains_key(message_id)
+                    && let Some(message) = self.store.message(*message_id).await?
+                    && message.chat_id() == self.chat_id
+                {
                     self.remove_message_in_place(*message_id);
                 }
             } else if op.contains(StoreOperation::Add) {

--- a/applogic/src/background_execution/java_api.rs
+++ b/applogic/src/background_execution/java_api.rs
@@ -55,7 +55,7 @@ pub extern "C" fn process_new_messages(
     // Convert Rust string back to Java string
     match env.new_string(response) {
         Ok(output) => output.into_raw(),
-        Err(error) => {
+        Err(_error) => {
             let _ = env.throw_new(
                 "java/lang/RuntimeException",
                 "Failed to create Java string from Rust",

--- a/coreclient/src/store/persistence.rs
+++ b/coreclient/src/store/persistence.rs
@@ -171,7 +171,8 @@ impl StoreNotification {
             let record = record?;
             match record.into_entity_id_and_op() {
                 Ok((entity_id, op)) => {
-                    ops.insert(entity_id, op);
+                    let entry = ops.entry(entity_id).or_default();
+                    *entry |= op;
                 }
                 Err(error) => {
                     error!(%error, "Error parsing store notification; skipping");


### PR DESCRIPTION
The open chat didn't update when new messages arrived via a push notification (when the app is backgrounded). Going back to the home (chats list) and into the chat showed them.

`try_process_store_notification` looped over `notification.ops` but returned after handling the first `Message` entry. This was fine on the websocket path (when the app is in foreground) but broke with the push path: the persistence function dequeues the persisted store notifications as a single merged notification spanning many messages and chats, and only the first entry was acted upon.

(What I think is) a good fix is to iterate through the whole batch, then call `handle_load_newer` and `clear_first_unread_index` at the end.

Note that because we were looping in a BTreeMap of UUIDs, the bug was also intermittent and gets easier to reproduce the bigger the chat (and activity) is when opening. With a group with 3 clients, the bug is relatively easy to reproduce.