### PR TITLE
feat(app): improve jump-to-reply

### DIFF
--- a/app/lib/message_list/jump_highlight.dart
+++ b/app/lib/message_list/jump_highlight.dart
@@ -1,0 +1,156 @@
+// SPDX-FileCopyrightText: 2026 Phoenix R&D GmbH <hello@phnx.im>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import 'dart:async';
+
+import 'package:air/ds/foundations/spacing.dart';
+import 'package:air/ds/foundations/themes.dart';
+import 'package:flutter/widgets.dart';
+
+/// Provides the stream of jump target IDs to descendants.
+class JumpHighlightScope extends InheritedWidget {
+  const JumpHighlightScope({
+    super.key,
+    required this.jumpedToId,
+    required super.child,
+  });
+
+  final Stream<Object> jumpedToId;
+
+  static Stream<Object>? maybeOf(BuildContext context) {
+    return context
+        .dependOnInheritedWidgetOfExactType<JumpHighlightScope>()
+        ?.jumpedToId;
+  }
+
+  @override
+  bool updateShouldNotify(JumpHighlightScope oldWidget) =>
+      jumpedToId != oldWidget.jumpedToId;
+}
+
+/// Renders the bubble background and a highlight when its [id] matches the most
+/// recent jump target emitted by [JumpHighlightScope].
+class JumpHighlight extends StatefulWidget {
+  const JumpHighlight({
+    super.key,
+    required this.id,
+    required this.borderRadius,
+    required this.baseColor,
+    required this.child,
+  });
+
+  final Object id;
+  final BorderRadius borderRadius;
+  final Color baseColor;
+  final Widget child;
+
+  @override
+  State<JumpHighlight> createState() => _JumpHighlightState();
+}
+
+class _JumpHighlightState extends State<JumpHighlight>
+    with SingleTickerProviderStateMixin {
+  // Time to hold the highlight
+  static const _holdMillis = 1000;
+  // Time to fade back to the base color after the hold
+  static const _fadeMillis = 2000;
+  static const _totalDuration = Duration(
+    milliseconds: _holdMillis + _fadeMillis,
+  );
+
+  // Cap on how far we lerp toward the highlight color
+  static const double _peakStrength = 1;
+
+  late final AnimationController _controller;
+  late final Animation<double> _animation;
+  StreamSubscription<Object>? _subscription;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      vsync: this,
+      duration: _totalDuration,
+      value: 1.0,
+    );
+    _animation = TweenSequence<double>([
+      TweenSequenceItem(
+        tween: ConstantTween(_peakStrength),
+        weight: _holdMillis.toDouble(),
+      ),
+      TweenSequenceItem(
+        tween: Tween<double>(
+          begin: _peakStrength,
+          end: 0.0,
+        ).chain(CurveTween(curve: Curves.easeOutCubic)),
+        weight: _fadeMillis.toDouble(),
+      ),
+    ]).animate(_controller);
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    final stream = JumpHighlightScope.maybeOf(context);
+    _subscription?.cancel();
+    _subscription = stream?.where((id) => id == widget.id).listen((_) {
+      _controller.forward(from: 0.0);
+    });
+  }
+
+  @override
+  void didUpdateWidget(covariant JumpHighlight oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.id != widget.id) {
+      _controller.value = 1.0;
+    }
+  }
+
+  @override
+  void dispose() {
+    _subscription?.cancel();
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final highlightColor = CustomColorScheme.of(context).function.link;
+    return AnimatedBuilder(
+      animation: _animation,
+      builder: (context, child) {
+        final t = _animation.value;
+        final glowing = t > 0;
+        return Container(
+          decoration: BoxDecoration(
+            borderRadius: widget.borderRadius,
+            color: widget.baseColor,
+            boxShadow: glowing
+                ? [
+                    BoxShadow(
+                      color: highlightColor.withValues(alpha: t),
+                      spreadRadius: Spacing.px4,
+                      blurRadius: Spacing.px24,
+                    ),
+                  ]
+                : null,
+          ),
+          foregroundDecoration: glowing
+              ? BoxDecoration(
+                  borderRadius: widget.borderRadius,
+                  border: Border.all(
+                    color: highlightColor.withValues(
+                      alpha: (t / _peakStrength).clamp(0.0, 1.0),
+                    ),
+                    width: 5,
+                  ),
+                )
+              : null,
+          child: child,
+        );
+      },
+      child: widget.child,
+    );
+  }
+}

--- a/app/lib/message_list/jump_highlight.dart
+++ b/app/lib/message_list/jump_highlight.dart
@@ -6,9 +6,10 @@ import 'dart:async';
 
 import 'package:air/ds/foundations/spacing.dart';
 import 'package:air/ds/foundations/themes.dart';
+import 'package:air/widgets/anchored_list/controller.dart';
 import 'package:flutter/widgets.dart';
 
-/// Provides the stream of jump target IDs to descendants.
+/// Provides the stream of jump completion events to descendants.
 class JumpHighlightScope extends InheritedWidget {
   const JumpHighlightScope({
     super.key,
@@ -16,9 +17,9 @@ class JumpHighlightScope extends InheritedWidget {
     required super.child,
   });
 
-  final Stream<Object> jumpedToId;
+  final Stream<JumpedToEvent> jumpedToId;
 
-  static Stream<Object>? maybeOf(BuildContext context) {
+  static Stream<JumpedToEvent>? maybeOf(BuildContext context) {
     return context
         .dependOnInheritedWidgetOfExactType<JumpHighlightScope>()
         ?.jumpedToId;
@@ -64,7 +65,7 @@ class _JumpHighlightState extends State<JumpHighlight>
 
   late final AnimationController _controller;
   late final Animation<double> _animation;
-  StreamSubscription<Object>? _subscription;
+  StreamSubscription<JumpedToEvent>? _subscription;
 
   @override
   void initState() {
@@ -94,9 +95,16 @@ class _JumpHighlightState extends State<JumpHighlight>
     super.didChangeDependencies();
     final stream = JumpHighlightScope.maybeOf(context);
     _subscription?.cancel();
-    _subscription = stream?.where((id) => id == widget.id).listen((_) {
-      _controller.forward(from: 0.0);
-    });
+    // Only react to user-driven jumps to a quoted message. Initial
+    // first-unread positioning shouldn't trigger the highlight.
+    _subscription = stream
+        ?.where(
+          (event) =>
+              event.id == widget.id && event.intent == JumpIntent.quotedMessage,
+        )
+        .listen((_) {
+          _controller.forward(from: 0.0);
+        });
   }
 
   @override

--- a/app/lib/message_list/message_list_view.dart
+++ b/app/lib/message_list/message_list_view.dart
@@ -233,7 +233,7 @@ class _MessageListViewState extends State<MessageListView>
       case MessageListCommand_ScrollToBottom():
         _listController.scrollToBottom(duration: Duration.zero);
       case MessageListCommand_ScrollToId(:final messageId):
-        _listController.goToId(messageId);
+        _listController.goToId(messageId, intent: JumpIntent.quotedMessage);
     }
   }
 
@@ -247,7 +247,7 @@ class _MessageListViewState extends State<MessageListView>
     _initialUnreadScrollHandled = true;
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (mounted) {
-        _listController.goToId(message.id);
+        _listController.goToId(message.id, intent: JumpIntent.firstUnread);
       }
     });
   }

--- a/app/lib/message_list/message_list_view.dart
+++ b/app/lib/message_list/message_list_view.dart
@@ -281,8 +281,14 @@ class _MessageListViewState extends State<MessageListView>
     final mediaPadding = MediaQuery.paddingOf(context);
     // Height of the tail of the fade beyon the toolbar
     const fadeBleeding = Spacing.px48;
-    // How much the list should be inset
-    final topInset = mediaPadding.top + fadeBleeding;
+    // Height of the safe area above the toolbar
+    final statusBarHeight = max(mediaPadding.top - kToolbarHeight, 0.0);
+    // Total height of the fade
+    const fadeHeight = kToolbarHeight + fadeBleeding;
+    // Y-coordinate where the fade is fully transparent — content above this
+    // is obstructed by the status bar cover or the fade gradient. Used as
+    // the list's top inset so jumps and the unread divider land below it.
+    final topInset = statusBarHeight + fadeHeight;
     // Y-coordinate of the floating date pill's top edge. Sits just below
     // the safe area, in the toolbar zone — the inline divider is hidden
     // when its pill reaches this slot, making the swap visually in-place.
@@ -293,10 +299,6 @@ class _MessageListViewState extends State<MessageListView>
     // [pillTop]. Both the inline-pill hide and the floating-pill show gate on
     // this threshold so they stay in sync.
     final swapTopThreshold = pillTop - Spacing.px32;
-    // Height of the safe area above the toolbar
-    final statusBarHeight = max(mediaPadding.top - kToolbarHeight, 0.0);
-    // Total height of the fade
-    const fadeHeight = kToolbarHeight + fadeBleeding;
     // Solid color for the safe area
     final bgColor = CustomColorScheme.of(context).backgroundBase.primary;
 

--- a/app/lib/message_list/message_list_view.dart
+++ b/app/lib/message_list/message_list_view.dart
@@ -21,6 +21,7 @@ import 'package:air/widgets/widgets.dart';
 import 'chat_tile.dart';
 import 'date_divider.dart';
 import 'floating_date_header.dart';
+import 'jump_highlight.dart';
 import 'message_cubit.dart';
 import 'message_list_cubit.dart';
 import 'scroll_to_bottom_controller.dart';
@@ -265,7 +266,10 @@ class _MessageListViewState extends State<MessageListView>
     final composerHeightListenable =
         widget.scrollToBottomController?.composerHeight;
 
-    return _buildList(composerHeightListenable, state);
+    return JumpHighlightScope(
+      jumpedToId: _listController.jumpedToId,
+      child: _buildList(composerHeightListenable, state),
+    );
   }
 
   /// Builds the [AnchoredList], wiring pagination and jump-to-message

--- a/app/lib/message_list/text_message_tile.dart
+++ b/app/lib/message_list/text_message_tile.dart
@@ -39,6 +39,7 @@ import 'package:logging/logging.dart';
 import 'package:share_plus/share_plus.dart';
 
 import 'image_viewer.dart';
+import 'jump_highlight.dart';
 import 'message_renderer.dart';
 import 'swipe_to_reply.dart';
 
@@ -301,6 +302,7 @@ class _MessageView extends HookWidget {
 
     Widget buildMessageBubble({required bool enableSelection}) {
       return _MessageContent(
+        messageId: messageId,
         content: contentMessage.content,
         inReplyToMessage: inReplyToMessage,
         isSender: isSender,
@@ -752,6 +754,7 @@ class _MessageMetadataRowState extends State<_MessageMetadataRow> {
 
 class _MessageContent extends StatelessWidget {
   const _MessageContent({
+    required this.messageId,
     required this.content,
     required this.inReplyToMessage,
     required this.isSender,
@@ -763,6 +766,7 @@ class _MessageContent extends StatelessWidget {
     required this.enableSelection,
   });
 
+  final MessageId messageId;
   final UiMimiContent content;
   final UiInReplyToMessage? inReplyToMessage;
   final bool isSender;
@@ -921,44 +925,49 @@ class _MessageContent extends StatelessWidget {
       messageBubble = IntrinsicWidth(child: messageBubble);
     }
 
-    return Padding(
-      padding: const EdgeInsets.only(bottom: 1.5),
-      child: DecoratedBox(
-        decoration: BoxDecoration(
-          borderRadius: _messageBorderRadius(isSender, flightPosition),
-          color: nakedContent
-              ? Colors.transparent
-              : isSender
-              ? colors.message.selfBackground
-              : colors.message.otherBackground,
-        ),
-        child: DefaultTextStyle.merge(
-          child: Column(
-            crossAxisAlignment: .end,
-            children: [
-              messageBubble,
-              if (isEdited)
-                Padding(
-                  padding: const EdgeInsets.only(
-                    left: Spacing.px16,
-                    right: Spacing.px16,
-                    bottom: Spacing.px8,
-                  ),
-                  child: SelectionContainer.disabled(
-                    child: Text(
-                      loc.textMessage_edited,
-                      style: Theme.of(context).textTheme.bodySmall!.copyWith(
-                        color: isSender
-                            ? colors.message.selfEditedLabel
-                            : colors.message.otherEditedLabel,
-                      ),
-                    ),
+    final borderRadius = _messageBorderRadius(isSender, flightPosition);
+    final baseColor = isSender
+        ? colors.message.selfBackground
+        : colors.message.otherBackground;
+    final bubbleContent = DefaultTextStyle.merge(
+      child: Column(
+        crossAxisAlignment: .end,
+        children: [
+          messageBubble,
+          if (isEdited)
+            Padding(
+              padding: const EdgeInsets.only(
+                left: Spacing.px16,
+                right: Spacing.px16,
+                bottom: Spacing.px8,
+              ),
+              child: SelectionContainer.disabled(
+                child: Text(
+                  loc.textMessage_edited,
+                  style: Theme.of(context).textTheme.bodySmall!.copyWith(
+                    color: isSender
+                        ? colors.message.selfEditedLabel
+                        : colors.message.otherEditedLabel,
                   ),
                 ),
-            ],
-          ),
-        ),
+              ),
+            ),
+        ],
       ),
+    );
+
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 1.5),
+      // Jumbo emoji renders without a bubble background, we skip the jump
+      // highlight
+      child: nakedContent
+          ? bubbleContent
+          : JumpHighlight(
+              id: messageId,
+              borderRadius: borderRadius,
+              baseColor: baseColor,
+              child: bubbleContent,
+            ),
     );
   }
 }

--- a/app/lib/widgets/anchored_list/anchored_list.dart
+++ b/app/lib/widgets/anchored_list/anchored_list.dart
@@ -145,6 +145,9 @@ class _AnchoredListState<T> extends State<AnchoredList<T>> {
   /// height cache. 8 is generous — most jumps converge in 2–3 iterations.
   static const _maxOffscreenJumpAttempts = 8;
 
+  /// Maximum re-alignment attempts after the target is on screen.
+  static const _maxAlignmentAttempts = 4;
+
   @override
   void initState() {
     super.initState();
@@ -795,9 +798,10 @@ class _AnchoredListState<T> extends State<AnchoredList<T>> {
     }
   }
 
-  /// Estimates the scroll offset that would place item at [index] at the
-  /// top of the viewport. Because the list is reversed (offset 0 = bottom),
-  /// we need: item's cumulative offset − viewport height + item height.
+  /// Estimates the scroll offset that would place item at [index] just
+  /// below the top inset ([widget.topPadding]). Because the list is
+  /// reversed (offset 0 = bottom), we need: item's cumulative offset −
+  /// viewport height + item height + top inset.
   double _topAlignedOffset(int index) {
     final offset = _estimateOffsetAtIndex(index);
     final targetId = widget.idExtractor(widget.data[index]);
@@ -805,7 +809,7 @@ class _AnchoredListState<T> extends State<AnchoredList<T>> {
     final viewportBox = _viewportBox;
     if (viewportBox == null) return offset;
     final viewportHeight = viewportBox.size.height;
-    return offset - viewportHeight + itemHeight;
+    return offset - viewportHeight + itemHeight + widget.topPadding;
   }
 
   void _executeJumpScroll() {
@@ -824,20 +828,28 @@ class _AnchoredListState<T> extends State<AnchoredList<T>> {
     _jumpToOffscreenTarget(targetId, index, attempt: 0);
   }
 
-  /// Scrolls so that [targetId] sits at the top of the viewport.
-  /// Used when the item is already laid out and visible — the offset
-  /// needed is simply current pixels minus the item's current top.
-  void _alignVisibleTarget(Object targetId) {
+  /// Scrolls so that [targetId] sits just below the top inset
+  /// ([widget.topPadding]). Used when the item is already laid out and
+  /// visible — the offset needed is the current pixels minus the item's
+  /// distance from the inset.
+  void _alignVisibleTarget(Object targetId, {int attempt = 0}) {
     if (!_scrollController.hasClients || _jumpState.targetId != targetId) {
       return;
     }
 
     final currentTop = _itemTopInViewport(targetId);
-    if (currentTop == null) return;
+    if (currentTop == null) {
+      _jumpState.onScrollComplete();
+      return;
+    }
 
-    // Shift the scroll position by exactly how far the item is from
-    // the viewport's top edge.
-    final desiredOffset = _scrollController.position.pixels - currentTop;
+    final delta = currentTop - widget.topPadding;
+    if (delta.abs() < _jumpAlignmentTolerance) {
+      _jumpState.onScrollComplete();
+      return;
+    }
+
+    final desiredOffset = _scrollController.position.pixels - delta;
     final clampedOffset = desiredOffset
         .clamp(
           _scrollController.position.minScrollExtent,
@@ -852,7 +864,16 @@ class _AnchoredListState<T> extends State<AnchoredList<T>> {
     }
 
     _scrollController.jumpTo(clampedOffset);
-    _jumpState.onScrollComplete();
+
+    if (attempt >= _maxAlignmentAttempts) {
+      _jumpState.onScrollComplete();
+      return;
+    }
+
+    SchedulerBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      _alignVisibleTarget(targetId, attempt: attempt + 1);
+    });
   }
 
   /// Iteratively jumps toward an off-screen item.

--- a/app/lib/widgets/anchored_list/anchored_list.dart
+++ b/app/lib/widgets/anchored_list/anchored_list.dart
@@ -4,6 +4,7 @@
 
 import 'dart:math' as math;
 
+import 'package:air/ds/foundations/motion.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter/widgets.dart';
@@ -133,8 +134,8 @@ class _AnchoredListState<T> extends State<AnchoredList<T>> {
   bool _pendingJumpExecutionFrameCallbackScheduled = false;
   bool _pendingViewportStateFrameCallbackScheduled = false;
 
-  static const _animateDuration = Duration(milliseconds: 300);
-  static const _animateCurve = Curves.easeOut;
+  static const _animateDuration = motionRegular;
+  static const _animateCurve = motionEasing;
 
   /// Sub-pixel threshold: differences smaller than this are treated as
   /// equal to avoid infinite correction loops from floating-point drift.
@@ -495,6 +496,19 @@ class _AnchoredListState<T> extends State<AnchoredList<T>> {
     return top;
   }
 
+  /// True when [id]'s rendered box sits entirely within the unobscured region
+  /// of the viewport between [topPadding] and the bottom inset.
+  bool _isFullyVisibleInUnobscuredArea(Object id) {
+    final itemBox = _renderBoxForId(id);
+    final viewportBox = itemBox != null ? _viewportForItemBox(itemBox) : null;
+    if (viewportBox == null || itemBox == null) return false;
+    final top = _itemTopInViewportBox(itemBox, id);
+    if (top == null) return false;
+    final bottom = top + _estimatedHeight(id);
+    final usableBottom = viewportBox.size.height - widget.bottomPadding;
+    return top >= widget.topPadding && bottom <= usableBottom;
+  }
+
   /// Computes an item's top-edge position in viewport coordinates by
   /// combining the sliver's paint offset with the child's main-axis
   /// position within the sliver.
@@ -821,11 +835,66 @@ class _AnchoredListState<T> extends State<AnchoredList<T>> {
 
     final currentTop = _itemTopInViewport(targetId);
     if (currentTop != null) {
-      _alignVisibleTarget(targetId);
+      if (_isFullyVisibleInUnobscuredArea(targetId)) {
+        _completeJump(reachedTarget: true);
+        return;
+      }
+      _animateAlignVisibleTarget(targetId);
       return;
     }
 
     _jumpToOffscreenTarget(targetId, index, attempt: 0);
+  }
+
+  /// Scroll the list so that [targetId] is just below the top inset ([widget.topPadding]).
+  void _animateAlignVisibleTarget(Object targetId) {
+    // A second goToId can replace [targetId] mid-flight; bail so we
+    // don't animate against a stale target.
+    if (!_scrollController.hasClients || _jumpState.targetId != targetId) {
+      return;
+    }
+
+    // The item is off screen
+    final currentTop = _itemTopInViewport(targetId);
+    if (currentTop == null) {
+      _completeJump(reachedTarget: false);
+      return;
+    }
+
+    // We are already there
+    final delta = currentTop - widget.topPadding;
+    if (delta.abs() < _jumpAlignmentTolerance) {
+      _completeJump(reachedTarget: true);
+      return;
+    }
+
+    // Stay within the scroll extents
+    final desiredOffset = _scrollController.position.pixels - delta;
+    final clampedOffset = desiredOffset
+        .clamp(
+          _scrollController.position.minScrollExtent,
+          _scrollController.position.maxScrollExtent,
+        )
+        .toDouble();
+
+    // No animation is needed in that case
+    if ((clampedOffset - _scrollController.position.pixels).abs() <
+        _jumpAlignmentTolerance) {
+      _completeJump(reachedTarget: true);
+      return;
+    }
+
+    // Actual scroll with animation
+    _scrollController
+        .animateTo(
+          clampedOffset,
+          duration: _animateDuration,
+          curve: _animateCurve,
+        )
+        .then((_) {
+          if (!mounted || _jumpState.targetId != targetId) return;
+          _completeJump(reachedTarget: true);
+        });
   }
 
   /// Scrolls so that [targetId] sits just below the top inset
@@ -839,13 +908,13 @@ class _AnchoredListState<T> extends State<AnchoredList<T>> {
 
     final currentTop = _itemTopInViewport(targetId);
     if (currentTop == null) {
-      _jumpState.onScrollComplete();
+      _completeJump(reachedTarget: false);
       return;
     }
 
     final delta = currentTop - widget.topPadding;
     if (delta.abs() < _jumpAlignmentTolerance) {
-      _jumpState.onScrollComplete();
+      _completeJump(reachedTarget: true);
       return;
     }
 
@@ -859,14 +928,14 @@ class _AnchoredListState<T> extends State<AnchoredList<T>> {
 
     if ((clampedOffset - _scrollController.position.pixels).abs() <
         _jumpAlignmentTolerance) {
-      _jumpState.onScrollComplete();
+      _completeJump(reachedTarget: true);
       return;
     }
 
     _scrollController.jumpTo(clampedOffset);
 
     if (attempt >= _maxAlignmentAttempts) {
-      _jumpState.onScrollComplete();
+      _completeJump(reachedTarget: true);
       return;
     }
 
@@ -874,6 +943,17 @@ class _AnchoredListState<T> extends State<AnchoredList<T>> {
       if (!mounted) return;
       _alignVisibleTarget(targetId, attempt: attempt + 1);
     });
+  }
+
+  /// Resets jump state and, if [reachedTarget], notifies the controller
+  /// so listeners (e.g. target highlight) can react. Aborted jumps
+  /// (target disappeared, exhausted retries off-screen) don't notify.
+  void _completeJump({required bool reachedTarget}) {
+    final targetId = _jumpState.targetId;
+    _jumpState.onScrollComplete();
+    if (reachedTarget && targetId != null) {
+      _controller.notifyJumpedToId(targetId);
+    }
   }
 
   /// Iteratively jumps toward an off-screen item.
@@ -908,7 +988,7 @@ class _AnchoredListState<T> extends State<AnchoredList<T>> {
     }
 
     if (attempt >= _maxOffscreenJumpAttempts) {
-      _jumpState.onScrollComplete();
+      _completeJump(reachedTarget: false);
       return;
     }
 
@@ -936,7 +1016,7 @@ class _AnchoredListState<T> extends State<AnchoredList<T>> {
               _jumpAlignmentTolerance &&
           (nextOffset - clampedOffset).abs() < _jumpAlignmentTolerance;
       if (isStuck) {
-        _jumpState.onScrollComplete();
+        _completeJump(reachedTarget: false);
         return;
       }
 

--- a/app/lib/widgets/anchored_list/anchored_list.dart
+++ b/app/lib/widgets/anchored_list/anchored_list.dart
@@ -788,11 +788,12 @@ class _AnchoredListState<T> extends State<AnchoredList<T>> {
     if (cmd == null) return;
 
     switch (cmd) {
-      case GoToIdCommand(:final id):
+      case GoToIdCommand(:final id, :final intent):
         _jumpState.requestJump(
           id,
           isIdLoaded: (id) => _idToIndex.containsKey(id),
           onLoadAround: (id) => widget.onLoadAround?.call(id),
+          intent: intent,
         );
         if (_jumpState.phase == AnchoredListJumpPhase.scrolling) {
           _executeJumpScroll();
@@ -946,13 +947,15 @@ class _AnchoredListState<T> extends State<AnchoredList<T>> {
   }
 
   /// Resets jump state and, if [reachedTarget], notifies the controller
-  /// so listeners (e.g. target highlight) can react. Aborted jumps
-  /// (target disappeared, exhausted retries off-screen) don't notify.
+  /// with the jump's [JumpIntent] so listeners can react per situation.
+  /// Aborted jumps (target disappeared, exhausted retries off-screen)
+  /// don't notify.
   void _completeJump({required bool reachedTarget}) {
     final targetId = _jumpState.targetId;
+    final intent = _jumpState.intent;
     _jumpState.onScrollComplete();
     if (reachedTarget && targetId != null) {
-      _controller.notifyJumpedToId(targetId);
+      _controller.notifyJumpedToId(targetId, intent: intent);
     }
   }
 

--- a/app/lib/widgets/anchored_list/controller.dart
+++ b/app/lib/widgets/anchored_list/controller.dart
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+import 'dart:async';
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 
@@ -46,6 +48,8 @@ class AnchoredListController extends ChangeNotifier {
       ValueNotifier<bool>(false);
   ScrollController? scrollController;
   AnchoredListCommand? _pendingCommand;
+  final StreamController<Object> _jumpedToIdController =
+      StreamController<Object>.broadcast();
 
   /// Whether the list is currently at or near the bottom.
   ValueListenable<bool> get isAtBottom => isAtBottomNotifier;
@@ -98,8 +102,15 @@ class AnchoredListController extends ChangeNotifier {
     return cmd;
   }
 
+  /// Fires after a jump-to-id scroll has completed.
+  Stream<Object> get jumpedToId => _jumpedToIdController.stream;
+
+  /// Called by the widget when a jump-to-id scroll completes.
+  void notifyJumpedToId(Object id) => _jumpedToIdController.add(id);
+
   @override
   void dispose() {
+    _jumpedToIdController.close();
     isAtBottomNotifier.dispose();
     newestVisibleIdNotifier.dispose();
     oldestVisibleIdNotifier.dispose();

--- a/app/lib/widgets/anchored_list/controller.dart
+++ b/app/lib/widgets/anchored_list/controller.dart
@@ -7,6 +7,20 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 
+/// States why a jump was requested:
+///
+/// - [quotedMessage]: navigating to a message that was quoted
+/// - [firstUnread]: landing on the first unread message
+enum JumpIntent { quotedMessage, firstUnread }
+
+/// Emitted on [AnchoredListController.jumpedToId] when a jump-to-id
+/// scroll completes successfully.
+class JumpedToEvent {
+  const JumpedToEvent(this.id, this.intent);
+  final Object id;
+  final JumpIntent intent;
+}
+
 /// Command types the controller queues for the widget to execute.
 ///
 /// Only one command is pending at a time — issuing a new command replaces
@@ -16,8 +30,9 @@ sealed class AnchoredListCommand {
 }
 
 class GoToIdCommand extends AnchoredListCommand {
-  const GoToIdCommand(this.id);
+  const GoToIdCommand(this.id, this.intent);
   final Object id;
+  final JumpIntent intent;
 }
 
 class ScrollToBottomCommand extends AnchoredListCommand {
@@ -48,8 +63,8 @@ class AnchoredListController extends ChangeNotifier {
       ValueNotifier<bool>(false);
   ScrollController? scrollController;
   AnchoredListCommand? _pendingCommand;
-  final StreamController<Object> _jumpedToIdController =
-      StreamController<Object>.broadcast();
+  final StreamController<JumpedToEvent> _jumpedToIdController =
+      StreamController<JumpedToEvent>.broadcast();
 
   /// Whether the list is currently at or near the bottom.
   ValueListenable<bool> get isAtBottom => isAtBottomNotifier;
@@ -84,8 +99,11 @@ class AnchoredListController extends ChangeNotifier {
   /// The widget decides the scroll strategy: if the item is already
   /// visible it animates smoothly, otherwise it jumps instantly.
   /// If not loaded, triggers `onLoadAround`.
-  void goToId(Object id) {
-    _pendingCommand = GoToIdCommand(id);
+  ///
+  /// [intent] describes the situation triggering the jump and is
+  /// forwarded on [jumpedToId] so consumers can react accordingly.
+  void goToId(Object id, {required JumpIntent intent}) {
+    _pendingCommand = GoToIdCommand(id, intent);
     notifyListeners();
   }
 
@@ -103,10 +121,11 @@ class AnchoredListController extends ChangeNotifier {
   }
 
   /// Fires after a jump-to-id scroll has completed.
-  Stream<Object> get jumpedToId => _jumpedToIdController.stream;
+  Stream<JumpedToEvent> get jumpedToId => _jumpedToIdController.stream;
 
   /// Called by the widget when a jump-to-id scroll completes.
-  void notifyJumpedToId(Object id) => _jumpedToIdController.add(id);
+  void notifyJumpedToId(Object id, {required JumpIntent intent}) =>
+      _jumpedToIdController.add(JumpedToEvent(id, intent));
 
   @override
   void dispose() {

--- a/app/lib/widgets/anchored_list/jump_state.dart
+++ b/app/lib/widgets/anchored_list/jump_state.dart
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+import 'controller.dart';
+
 /// Phases of the jump-to-message lifecycle.
 ///
 /// - [idle]: no jump in progress.
@@ -23,6 +25,7 @@ enum AnchoredListJumpPhase { idle, loading, scrolling }
 class AnchoredListJumpState {
   AnchoredListJumpPhase phase = AnchoredListJumpPhase.idle;
   Object? targetId;
+  JumpIntent intent = JumpIntent.quotedMessage;
 
   /// Request a jump to [id].
   ///
@@ -33,8 +36,10 @@ class AnchoredListJumpState {
     Object id, {
     required bool Function(Object id) isIdLoaded,
     required void Function(Object id) onLoadAround,
+    required JumpIntent intent,
   }) {
     targetId = id;
+    this.intent = intent;
 
     if (isIdLoaded(id)) {
       phase = AnchoredListJumpPhase.scrolling;
@@ -67,5 +72,6 @@ class AnchoredListJumpState {
   void _reset() {
     phase = AnchoredListJumpPhase.idle;
     targetId = null;
+    intent = JumpIntent.quotedMessage;
   }
 }

--- a/app/test/widgets/anchored_list_test.dart
+++ b/app/test/widgets/anchored_list_test.dart
@@ -218,7 +218,7 @@ void main() {
       );
       await tester.pump();
 
-      controller.goToId(20);
+      controller.goToId(20, intent: JumpIntent.quotedMessage);
       await tester.pumpAndSettle();
 
       final viewportTopY = tester.getTopLeft(find.byType(AnchoredList<int>)).dy;
@@ -254,7 +254,7 @@ void main() {
 
         // Land at item 20 (top inset), then nudge the scroll so item 18
         // sits partially under the top inset — clipped, not fully visible.
-        controller.goToId(20);
+        controller.goToId(20, intent: JumpIntent.quotedMessage);
         await tester.pumpAndSettle();
         controller.position!.jumpTo(controller.position!.pixels - 240);
         await tester.pump();
@@ -266,7 +266,7 @@ void main() {
         expect(clippedTop, lessThan(topPadding));
         expect(clippedTop, greaterThan(0));
 
-        controller.goToId(18);
+        controller.goToId(18, intent: JumpIntent.quotedMessage);
         await tester.pumpAndSettle();
 
         final alignedTop = (await rectOf(tester, 18)).top - viewportTopY;
@@ -301,13 +301,13 @@ void main() {
 
       // After landing at 20 (top inset), 18 sits two rows below it, well
       // inside the unobscured viewport.
-      controller.goToId(20);
+      controller.goToId(20, intent: JumpIntent.quotedMessage);
       await tester.pumpAndSettle();
 
       final pixelsBefore = controller.position!.pixels;
       final rectBefore = await rectOf(tester, 18);
 
-      controller.goToId(18);
+      controller.goToId(18, intent: JumpIntent.quotedMessage);
       await tester.pumpAndSettle();
 
       // No scroll, no movement: highlight is the only effect.
@@ -354,7 +354,7 @@ void main() {
 
       // Probe across each cluster.
       for (final target in const [12, 20, 30, 35]) {
-        controller.goToId(target);
+        controller.goToId(target, intent: JumpIntent.quotedMessage);
         await tester.pumpAndSettle();
 
         final viewportTopY = tester
@@ -402,7 +402,7 @@ void main() {
 
       // Probe several targets — both odd (tall) and even (short).
       for (final target in const [10, 13, 20, 25, 30]) {
-        controller.goToId(target);
+        controller.goToId(target, intent: JumpIntent.quotedMessage);
         await tester.pumpAndSettle();
 
         final viewportTopY = tester

--- a/app/test/widgets/anchored_list_test.dart
+++ b/app/test/widgets/anchored_list_test.dart
@@ -221,14 +221,60 @@ void main() {
       controller.goToId(20);
       await tester.pumpAndSettle();
 
-      final viewportTopY =
-          tester.getTopLeft(find.byType(AnchoredList<int>)).dy;
+      final viewportTopY = tester.getTopLeft(find.byType(AnchoredList<int>)).dy;
       final targetRect = await rectOf(tester, 20);
       final relativeTop = targetRect.top - viewportTopY;
       expect(relativeTop, closeTo(topPadding, 0.5));
     });
 
-    testWidgets('on-screen jump lands target below the top inset', (
+    testWidgets(
+      'on-screen jump aligns target when it straddles the top inset',
+      (tester) async {
+        tester.view.physicalSize = const Size(400, 800);
+        tester.view.devicePixelRatio = 1.0;
+        addTearDown(() {
+          tester.view.resetPhysicalSize();
+          tester.view.resetDevicePixelRatio();
+        });
+
+        final data = AnchoredListData<int>(List.generate(40, (index) => index));
+        final controller = AnchoredListController();
+        const topPadding = 120.0;
+
+        await tester.pumpWidget(
+          buildSubject(
+            data: data,
+            controller: controller,
+            canLoadNewer: false,
+            onLoadNewer: () {},
+            topPadding: topPadding,
+          ),
+        );
+        await tester.pump();
+
+        // Land at item 20 (top inset), then nudge the scroll so item 18
+        // sits partially under the top inset — clipped, not fully visible.
+        controller.goToId(20);
+        await tester.pumpAndSettle();
+        controller.position!.jumpTo(controller.position!.pixels - 240);
+        await tester.pump();
+
+        final viewportTopY = tester
+            .getTopLeft(find.byType(AnchoredList<int>))
+            .dy;
+        final clippedTop = (await rectOf(tester, 18)).top - viewportTopY;
+        expect(clippedTop, lessThan(topPadding));
+        expect(clippedTop, greaterThan(0));
+
+        controller.goToId(18);
+        await tester.pumpAndSettle();
+
+        final alignedTop = (await rectOf(tester, 18)).top - viewportTopY;
+        expect(alignedTop, closeTo(topPadding, 0.5));
+      },
+    );
+
+    testWidgets('on-screen jump leaves a fully-visible target in place', (
       tester,
     ) async {
       tester.view.physicalSize = const Size(400, 800);
@@ -253,19 +299,20 @@ void main() {
       );
       await tester.pump();
 
-      // Scroll item 18 into view but below the inset, then jump to it.
+      // After landing at 20 (top inset), 18 sits two rows below it, well
+      // inside the unobscured viewport.
       controller.goToId(20);
       await tester.pumpAndSettle();
-      expect(find.byKey(const ValueKey('item-18')), findsOneWidget);
+
+      final pixelsBefore = controller.position!.pixels;
+      final rectBefore = await rectOf(tester, 18);
 
       controller.goToId(18);
       await tester.pumpAndSettle();
 
-      final viewportTopY =
-          tester.getTopLeft(find.byType(AnchoredList<int>)).dy;
-      final targetRect = await rectOf(tester, 18);
-      final relativeTop = targetRect.top - viewportTopY;
-      expect(relativeTop, closeTo(topPadding, 0.5));
+      // No scroll, no movement: highlight is the only effect.
+      expect(controller.position!.pixels, pixelsBefore);
+      expect((await rectOf(tester, 18)).top, rectBefore.top);
     });
 
     testWidgets('jumps land below the top inset across clustered heights', (
@@ -282,11 +329,12 @@ void main() {
       // match any cluster's actual height. This catches alignment that
       // relies on cache averages instead of measuring the rendered box.
       final heights = <int, double>{
-        for (var i = 0; i < 40; i++) i: i < 10
-            ? 40.0
-            : i < 25
-                ? 200.0
-                : 80.0,
+        for (var i = 0; i < 40; i++)
+          i: i < 10
+              ? 40.0
+              : i < 25
+              ? 200.0
+              : 80.0,
       };
       final data = AnchoredListData<int>(List.generate(40, (index) => index));
       final controller = AnchoredListController();
@@ -309,8 +357,9 @@ void main() {
         controller.goToId(target);
         await tester.pumpAndSettle();
 
-        final viewportTopY =
-            tester.getTopLeft(find.byType(AnchoredList<int>)).dy;
+        final viewportTopY = tester
+            .getTopLeft(find.byType(AnchoredList<int>))
+            .dy;
         final targetRect = await rectOf(tester, target);
         final relativeTop = targetRect.top - viewportTopY;
         expect(
@@ -356,8 +405,9 @@ void main() {
         controller.goToId(target);
         await tester.pumpAndSettle();
 
-        final viewportTopY =
-            tester.getTopLeft(find.byType(AnchoredList<int>)).dy;
+        final viewportTopY = tester
+            .getTopLeft(find.byType(AnchoredList<int>))
+            .dy;
         final targetRect = await rectOf(tester, target);
         final relativeTop = targetRect.top - viewportTopY;
         expect(

--- a/app/test/widgets/anchored_list_test.dart
+++ b/app/test/widgets/anchored_list_test.dart
@@ -16,6 +16,7 @@ void main() {
     required VoidCallback onLoadNewer,
     double viewportHeight = 800,
     Map<int, double> itemHeights = const {},
+    double topPadding = 0.0,
   }) {
     return MaterialApp(
       home: Scaffold(
@@ -31,6 +32,7 @@ void main() {
               canLoadNewer: canLoadNewer,
               paginationThreshold: 100,
               onLoadNewer: onLoadNewer,
+              topPadding: topPadding,
               itemBuilder: (context, item, index) => KeyedSubtree(
                 key: ValueKey('item-$item'),
                 child: SizedBox(
@@ -180,6 +182,190 @@ void main() {
 
       expect(find.byKey(const ValueKey('item-0')), findsNothing);
       expect(controller.currentNewestVisibleId, 1);
+    });
+  });
+
+  group('AnchoredList jump', () {
+    Future<Rect> rectOf(WidgetTester tester, Object id) async {
+      final finder = find.byKey(ValueKey('item-$id'));
+      final renderBox = tester.renderObject<RenderBox>(finder);
+      final topLeft = renderBox.localToGlobal(Offset.zero);
+      return topLeft & renderBox.size;
+    }
+
+    testWidgets('off-screen jump lands target below the top inset', (
+      tester,
+    ) async {
+      tester.view.physicalSize = const Size(400, 800);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(() {
+        tester.view.resetPhysicalSize();
+        tester.view.resetDevicePixelRatio();
+      });
+
+      final data = AnchoredListData<int>(List.generate(40, (index) => index));
+      final controller = AnchoredListController();
+      const topPadding = 120.0;
+
+      await tester.pumpWidget(
+        buildSubject(
+          data: data,
+          controller: controller,
+          canLoadNewer: false,
+          onLoadNewer: () {},
+          topPadding: topPadding,
+        ),
+      );
+      await tester.pump();
+
+      controller.goToId(20);
+      await tester.pumpAndSettle();
+
+      final viewportTopY =
+          tester.getTopLeft(find.byType(AnchoredList<int>)).dy;
+      final targetRect = await rectOf(tester, 20);
+      final relativeTop = targetRect.top - viewportTopY;
+      expect(relativeTop, closeTo(topPadding, 0.5));
+    });
+
+    testWidgets('on-screen jump lands target below the top inset', (
+      tester,
+    ) async {
+      tester.view.physicalSize = const Size(400, 800);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(() {
+        tester.view.resetPhysicalSize();
+        tester.view.resetDevicePixelRatio();
+      });
+
+      final data = AnchoredListData<int>(List.generate(40, (index) => index));
+      final controller = AnchoredListController();
+      const topPadding = 120.0;
+
+      await tester.pumpWidget(
+        buildSubject(
+          data: data,
+          controller: controller,
+          canLoadNewer: false,
+          onLoadNewer: () {},
+          topPadding: topPadding,
+        ),
+      );
+      await tester.pump();
+
+      // Scroll item 18 into view but below the inset, then jump to it.
+      controller.goToId(20);
+      await tester.pumpAndSettle();
+      expect(find.byKey(const ValueKey('item-18')), findsOneWidget);
+
+      controller.goToId(18);
+      await tester.pumpAndSettle();
+
+      final viewportTopY =
+          tester.getTopLeft(find.byType(AnchoredList<int>)).dy;
+      final targetRect = await rectOf(tester, 18);
+      final relativeTop = targetRect.top - viewportTopY;
+      expect(relativeTop, closeTo(topPadding, 0.5));
+    });
+
+    testWidgets('jumps land below the top inset across clustered heights', (
+      tester,
+    ) async {
+      tester.view.physicalSize = const Size(400, 800);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(() {
+        tester.view.resetPhysicalSize();
+        tester.view.resetDevicePixelRatio();
+      });
+
+      // Clusters of dissimilar heights — average across the list does not
+      // match any cluster's actual height. This catches alignment that
+      // relies on cache averages instead of measuring the rendered box.
+      final heights = <int, double>{
+        for (var i = 0; i < 40; i++) i: i < 10
+            ? 40.0
+            : i < 25
+                ? 200.0
+                : 80.0,
+      };
+      final data = AnchoredListData<int>(List.generate(40, (index) => index));
+      final controller = AnchoredListController();
+      const topPadding = 100.0;
+
+      await tester.pumpWidget(
+        buildSubject(
+          data: data,
+          controller: controller,
+          canLoadNewer: false,
+          onLoadNewer: () {},
+          topPadding: topPadding,
+          itemHeights: heights,
+        ),
+      );
+      await tester.pump();
+
+      // Probe across each cluster.
+      for (final target in const [12, 20, 30, 35]) {
+        controller.goToId(target);
+        await tester.pumpAndSettle();
+
+        final viewportTopY =
+            tester.getTopLeft(find.byType(AnchoredList<int>)).dy;
+        final targetRect = await rectOf(tester, target);
+        final relativeTop = targetRect.top - viewportTopY;
+        expect(
+          relativeTop,
+          closeTo(topPadding, 0.5),
+          reason: 'item $target landed at $relativeTop, expected $topPadding',
+        );
+      }
+    });
+
+    testWidgets('jumps land below the top inset for variable item heights', (
+      tester,
+    ) async {
+      tester.view.physicalSize = const Size(400, 800);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(() {
+        tester.view.resetPhysicalSize();
+        tester.view.resetDevicePixelRatio();
+      });
+
+      // Mix of heights: short and tall items alternate.
+      final heights = <int, double>{
+        for (var i = 0; i < 40; i++) i: i.isEven ? 60.0 : 180.0,
+      };
+      final data = AnchoredListData<int>(List.generate(40, (index) => index));
+      final controller = AnchoredListController();
+      const topPadding = 120.0;
+
+      await tester.pumpWidget(
+        buildSubject(
+          data: data,
+          controller: controller,
+          canLoadNewer: false,
+          onLoadNewer: () {},
+          topPadding: topPadding,
+          itemHeights: heights,
+        ),
+      );
+      await tester.pump();
+
+      // Probe several targets — both odd (tall) and even (short).
+      for (final target in const [10, 13, 20, 25, 30]) {
+        controller.goToId(target);
+        await tester.pumpAndSettle();
+
+        final viewportTopY =
+            tester.getTopLeft(find.byType(AnchoredList<int>)).dy;
+        final targetRect = await rectOf(tester, target);
+        final relativeTop = targetRect.top - viewportTopY;
+        expect(
+          relativeTop,
+          closeTo(topPadding, 0.5),
+          reason: 'item $target landed at $relativeTop, expected $topPadding',
+        );
+      }
     });
   });
 }


### PR DESCRIPTION
This PR
 - fixes an issue where the target message was not always in the desired location after the jump
 - shows a highlight on the target message after the jump (a glowing border in the color used for links)
 - no longer scrolls the message list if the target message is already in the viewport (we have the highlight for that now)