### PR TITLE
feat(CI): use release branches

### DIFF
--- a/.github/workflows/android_build.yml
+++ b/.github/workflows/android_build.yml
@@ -38,11 +38,11 @@ jobs:
           jdk: true
           cargo-binstall-tools: cargo-ndk
 
-      - name: Build Android app
+      - name: Build Android APK
         working-directory: app
         run: bundle exec fastlane android beta_android --verbose
 
-      - name: Upload Android app APK
+      - name: Upload Android APK
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: air-android

--- a/.github/workflows/android_publish.yml
+++ b/.github/workflows/android_publish.yml
@@ -12,14 +12,9 @@ on:
   push:
     branches:
       - main
-    paths:
-      - "coreclient/**"
-      - "apiclient/**"
-      - "applogic/**"
-      - "common/**"
-      - "app/**"
-      - "Cargo.toml"
-  workflow_dispatch:
+  pull_request:
+    branches:
+      - release/*
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/android_publish.yml
+++ b/.github/workflows/android_publish.yml
@@ -24,6 +24,7 @@ env:
 jobs:
   android-publish:
     runs-on: ubuntu-latest
+    environment: google-play-store
 
     steps:
       - name: Checkout code

--- a/.github/workflows/ios_publish.yml
+++ b/.github/workflows/ios_publish.yml
@@ -8,6 +8,7 @@ on:
   push:
     branches:
       - main
+      - release/*
     paths:
       - "coreclient/**"
       - "apiclient/**"
@@ -25,6 +26,7 @@ env:
 jobs:
   ios-publish:
     runs-on: macos-26
+    environment: apple-app-store
 
     steps:
       - name: Checkout code

--- a/.github/workflows/macos_publish.yml
+++ b/.github/workflows/macos_publish.yml
@@ -8,6 +8,7 @@ on:
   push:
     branches:
       - main
+      - release/*
     paths:
       - "coreclient/**"
       - "apiclient/**"
@@ -24,6 +25,7 @@ env:
 jobs:
   mac-publish:
     runs-on: macos-26
+    environment: apple-app-store
 
     steps:
       - name: Checkout code

--- a/app/fastlane/android.rb
+++ b/app/fastlane/android.rb
@@ -3,7 +3,10 @@ platform :android do
     lane :beta_android do |options|
       # Package name
       package_name = "ms.air"
-      track = "internal"
+
+      # Use the "alpha" track for PRs against a release branch, "internal" otherwise
+      is_release_pr = ENV["GITHUB_EVENT_NAME"] == "pull_request" && ENV["GITHUB_BASE_REF"].to_s.start_with?("release/")
+      track = is_release_pr ? "alpha" : "internal"
 
       # Determine if we should deploy to the Play Store
       upload_to_play_store = options[:upload_to_play_store]
@@ -69,10 +72,10 @@ platform :android do
         raise
       ensure
         # Clean up the temporary files
-         if upload_to_play_store
-           File.delete(keystore_path)
-           File.delete(playstore_key_path)
-         end
+        if upload_to_play_store
+          File.delete(keystore_path)
+          File.delete(playstore_key_path)
+        end
       end
     end
   end

--- a/app/fastlane/ios.rb
+++ b/app/fastlane/ios.rb
@@ -39,6 +39,9 @@ platform :ios do
     app_identifier = @app_store_params[:app_identifier]
     app_identifier_nse = @app_store_params[:app_identifier_nse]
 
+    # For now, we assign all builds to "Internal testing"
+    groups = ["Internal testing"]
+
     UI.user_error!("TEAM_ID must be provided for the beta_ios lane") if team_id.to_s.empty?
 
     # Load the app store connect API key
@@ -70,6 +73,7 @@ platform :ios do
         app_platform: "ios",
         skip_waiting_for_build_processing: true,
         distribute_external: false,
+        groups: groups,
       )
 
       # Find the app in ASC

--- a/justfile
+++ b/justfile
@@ -203,9 +203,9 @@ run-app-cached:
 run-server:
     cargo run --bin airserver | bunyan
 
-# Increment minor version numbers and update changelog.
-bump-version:
-    cargo xtask bump-version
+# Cut a release branch and increment minor or patch version numbers and update changelog.
+bump-version *args:
+    cargo xtask bump-version {{args}}
 
 # Install fvm.
 install-fvm:

--- a/xtask/src/bump_version.rs
+++ b/xtask/src/bump_version.rs
@@ -22,6 +22,9 @@ pub(crate) struct BumpArgs {
     /// Print actions without executing them.
     #[arg(long)]
     dry_run: bool,
+    /// Switch to main automatically instead of erroring when on another branch.
+    #[arg(long)]
+    force: bool,
 }
 
 #[derive(ValueEnum, Clone, Copy)]
@@ -39,15 +42,13 @@ pub(crate) fn run(args: BumpArgs) -> Result<()> {
         println!("[dry-run] no commands or file writes will be executed");
     }
 
-    ensure_fresh_main(&shell, args.dry_run)?;
+    ensure_fresh_main(&shell, args.dry_run, args.force)?;
 
     let current = determine_current_version(repo_root.as_ref())?;
     let next = match args.kind {
         BumpKind::Minor => increment_minor(&current),
         BumpKind::Patch => increment_patch(&current),
     };
-
-    cut_release_branch(&shell, &current, args.dry_run)?;
 
     println!("Bumping version {} -> {}", current, next);
     let next_string = next.to_string();
@@ -59,6 +60,27 @@ pub(crate) fn run(args: BumpArgs) -> Result<()> {
     update_nfpm_version(repo_root.as_ref(), &next, args.dry_run)?;
     println!("Updated nFPM version to {}", next);
 
+    open_bump_pr(&shell, &next, args.dry_run)?;
+
+    cut_release_branch(&shell, &current, &next, args.dry_run)?;
+
+    Ok(())
+}
+
+fn open_bump_pr(shell: &Shell, next: &Version, dry_run: bool) -> Result<()> {
+    let branch_name = format!("bump-version/v{next}");
+    let commit_message = format!("chore: v{next}");
+    println!("Opening pull request {branch_name}");
+    run_or_print(cmd!(shell, "git checkout -b {branch_name}"), dry_run)?;
+    run_or_print(cmd!(shell, "git commit -am {commit_message}"), dry_run)?;
+    run_or_print(cmd!(shell, "git push -u origin {branch_name}"), dry_run)?;
+    run_or_print(
+        cmd!(
+            shell,
+            "gh pr create --title {commit_message} --body {commit_message}"
+        ),
+        dry_run,
+    )?;
     Ok(())
 }
 
@@ -72,7 +94,7 @@ fn run_or_print(cmd: Cmd<'_>, dry_run: bool) -> Result<()> {
     }
 }
 
-fn ensure_fresh_main(shell: &Shell, dry_run: bool) -> Result<()> {
+fn ensure_fresh_main(shell: &Shell, dry_run: bool, force: bool) -> Result<()> {
     let status = cmd!(shell, "git status --porcelain").read()?;
     ensure!(
         status.is_empty(),
@@ -80,22 +102,39 @@ fn ensure_fresh_main(shell: &Shell, dry_run: bool) -> Result<()> {
     );
 
     let current_branch = cmd!(shell, "git rev-parse --abbrev-ref HEAD").read()?;
-    ensure!(
-        current_branch == "main",
-        "Must be on the main branch, currently on {current_branch}"
-    );
+    if current_branch != "main" {
+        ensure!(
+            force,
+            "Must be on the main branch, currently on {current_branch} (pass --force to switch automatically)"
+        );
+        println!("Currently on {current_branch}, switching to main");
+        run_or_print(cmd!(shell, "git checkout main"), dry_run)?;
+    }
 
     run_or_print(cmd!(shell, "git pull --ff-only origin main"), dry_run)?;
 
     Ok(())
 }
 
-fn cut_release_branch(shell: &Shell, current: &Version, dry_run: bool) -> Result<()> {
-    let branch_name = format!("release/{current}");
-    println!("Creating release branch {branch_name}");
-    run_or_print(cmd!(shell, "git checkout -b {branch_name}"), dry_run)?;
-    run_or_print(cmd!(shell, "git push -u origin {branch_name}"), dry_run)?;
-    run_or_print(cmd!(shell, "git checkout main"), dry_run)?;
+fn cut_release_branch(
+    shell: &Shell,
+    current: &Version,
+    next: &Version,
+    dry_run: bool,
+) -> Result<()> {
+    let release_branch = format!("release/{current}");
+    let bump_branch = format!("bump-version/v{next}");
+    let title = format!("chore: cut release v{current}");
+    println!("Creating release branch {release_branch}");
+    run_or_print(cmd!(shell, "git branch {release_branch} main"), dry_run)?;
+    run_or_print(cmd!(shell, "git push -u origin {release_branch}"), dry_run)?;
+    run_or_print(
+        cmd!(
+            shell,
+            "gh pr create --base {release_branch} --head {bump_branch} --title {title} --body {title}"
+        ),
+        dry_run,
+    )?;
     Ok(())
 }
 

--- a/xtask/src/bump_version.rs
+++ b/xtask/src/bump_version.rs
@@ -208,11 +208,7 @@ fn update_flutter_version(
     Ok(())
 }
 
-fn update_nfpm_version(
-    repo_root: &Utf8Path,
-    new_version: &Version,
-    dry_run: bool,
-) -> Result<()> {
+fn update_nfpm_version(repo_root: &Utf8Path, new_version: &Version, dry_run: bool) -> Result<()> {
     let nfpm_config_path = repo_root.join("app/linux/nfpm.yaml");
     ensure!(
         nfpm_config_path.exists(),

--- a/xtask/src/bump_version.rs
+++ b/xtask/src/bump_version.rs
@@ -45,6 +45,8 @@ pub(crate) fn run(args: BumpArgs) -> Result<()> {
     ensure_fresh_main(&shell, args.dry_run, args.force)?;
 
     let current = determine_current_version(repo_root.as_ref())?;
+    cut_release_branch(&shell, &current, args.dry_run)?;
+
     let next = match args.kind {
         BumpKind::Minor => increment_minor(&current),
         BumpKind::Patch => increment_patch(&current),
@@ -61,8 +63,6 @@ pub(crate) fn run(args: BumpArgs) -> Result<()> {
     println!("Updated nFPM version to {}", next);
 
     open_bump_pr(&shell, &next, args.dry_run)?;
-
-    cut_release_branch(&shell, &current, &next, args.dry_run)?;
 
     Ok(())
 }
@@ -116,22 +116,17 @@ fn ensure_fresh_main(shell: &Shell, dry_run: bool, force: bool) -> Result<()> {
     Ok(())
 }
 
-fn cut_release_branch(
-    shell: &Shell,
-    current: &Version,
-    next: &Version,
-    dry_run: bool,
-) -> Result<()> {
+/// Cuts a release branch from HEAD without switching to it, then opens a PR into main.
+fn cut_release_branch(shell: &Shell, current: &Version, dry_run: bool) -> Result<()> {
     let release_branch = format!("release/{current}");
-    let bump_branch = format!("bump-version/v{next}");
-    let title = format!("chore: cut release v{current}");
+    let title = format!("chore: release v{current}");
     println!("Creating release branch {release_branch}");
     run_or_print(cmd!(shell, "git branch {release_branch} main"), dry_run)?;
     run_or_print(cmd!(shell, "git push -u origin {release_branch}"), dry_run)?;
     run_or_print(
         cmd!(
             shell,
-            "gh pr create --base {release_branch} --head {bump_branch} --title {title} --body {title}"
+            "gh pr create --base main --head {release_branch} --title {title} --body {title}"
         ),
         dry_run,
     )?;

--- a/xtask/src/bump_version.rs
+++ b/xtask/src/bump_version.rs
@@ -7,30 +7,95 @@ use std::fs;
 use anyhow::{Context, Result, anyhow, ensure};
 use camino::Utf8Path;
 use cargo_metadata::MetadataCommand;
+use clap::{Args, ValueEnum};
 use regex::Regex;
 use semver::Version;
-use xshell::{Shell, cmd};
+use xshell::{Cmd, Shell, cmd};
 
 use crate::util::workspace_root;
 
-pub(crate) fn run() -> Result<()> {
+#[derive(Args)]
+pub(crate) struct BumpArgs {
+    /// Which version component to increment.
+    #[arg(value_enum, default_value_t = BumpKind::Minor)]
+    kind: BumpKind,
+    /// Print actions without executing them.
+    #[arg(long)]
+    dry_run: bool,
+}
+
+#[derive(ValueEnum, Clone, Copy)]
+enum BumpKind {
+    Minor,
+    Patch,
+}
+
+pub(crate) fn run(args: BumpArgs) -> Result<()> {
     let repo_root = workspace_root();
     let shell = Shell::new()?;
     shell.change_dir(repo_root.as_std_path());
 
+    if args.dry_run {
+        println!("[dry-run] no commands or file writes will be executed");
+    }
+
+    ensure_fresh_main(&shell, args.dry_run)?;
+
     let current = determine_current_version(repo_root.as_ref())?;
-    let next = increment_minor(&current);
+    let next = match args.kind {
+        BumpKind::Minor => increment_minor(&current),
+        BumpKind::Patch => increment_patch(&current),
+    };
+
+    cut_release_branch(&shell, &current, args.dry_run)?;
+
     println!("Bumping version {} -> {}", current, next);
-
     let next_string = next.to_string();
-    cmd!(shell, "cargo set-version {next_string}").run()?;
+    run_or_print(cmd!(shell, "cargo set-version {next_string}"), args.dry_run)?;
 
-    update_flutter_version(repo_root.as_ref(), &next)?;
+    update_flutter_version(repo_root.as_ref(), &next, args.dry_run)?;
     println!("Updated Flutter version to {}+1", next);
 
-    update_nfpm_version(repo_root.as_ref(), &next)?;
-    println!("Updated nFPM version to {}+1", next);
+    update_nfpm_version(repo_root.as_ref(), &next, args.dry_run)?;
+    println!("Updated nFPM version to {}", next);
 
+    Ok(())
+}
+
+fn run_or_print(cmd: Cmd<'_>, dry_run: bool) -> Result<()> {
+    if dry_run {
+        println!("[dry-run] would run: {cmd}");
+        Ok(())
+    } else {
+        cmd.run()?;
+        Ok(())
+    }
+}
+
+fn ensure_fresh_main(shell: &Shell, dry_run: bool) -> Result<()> {
+    let status = cmd!(shell, "git status --porcelain").read()?;
+    ensure!(
+        status.is_empty(),
+        "Working tree is not clean, commit or stash changes first"
+    );
+
+    let current_branch = cmd!(shell, "git rev-parse --abbrev-ref HEAD").read()?;
+    ensure!(
+        current_branch == "main",
+        "Must be on the main branch, currently on {current_branch}"
+    );
+
+    run_or_print(cmd!(shell, "git pull --ff-only origin main"), dry_run)?;
+
+    Ok(())
+}
+
+fn cut_release_branch(shell: &Shell, current: &Version, dry_run: bool) -> Result<()> {
+    let branch_name = format!("release/{current}");
+    println!("Creating release branch {branch_name}");
+    run_or_print(cmd!(shell, "git checkout -b {branch_name}"), dry_run)?;
+    run_or_print(cmd!(shell, "git push -u origin {branch_name}"), dry_run)?;
+    run_or_print(cmd!(shell, "git checkout main"), dry_run)?;
     Ok(())
 }
 
@@ -63,7 +128,21 @@ fn increment_minor(current: &Version) -> Version {
     }
 }
 
-fn update_flutter_version(repo_root: &Utf8Path, new_version: &Version) -> Result<()> {
+fn increment_patch(current: &Version) -> Version {
+    Version {
+        major: current.major,
+        minor: current.minor,
+        patch: current.patch + 1,
+        pre: current.pre.clone(),
+        build: current.build.clone(),
+    }
+}
+
+fn update_flutter_version(
+    repo_root: &Utf8Path,
+    new_version: &Version,
+    dry_run: bool,
+) -> Result<()> {
     let pubspec_path = repo_root.join("app/pubspec.yaml");
     ensure!(
         pubspec_path.exists(),
@@ -80,13 +159,21 @@ fn update_flutter_version(repo_root: &Utf8Path, new_version: &Version) -> Result
     );
 
     let replacement = format!("version: {}+1", new_version);
+    if dry_run {
+        println!("[dry-run] would write {pubspec_path} with `{replacement}`");
+        return Ok(());
+    }
     let updated = regex.replace(&content, replacement).to_string();
     fs::write(&pubspec_path, updated)
         .with_context(|| format!("Failed to write {}", pubspec_path))?;
     Ok(())
 }
 
-fn update_nfpm_version(repo_root: &Utf8Path, new_version: &Version) -> Result<()> {
+fn update_nfpm_version(
+    repo_root: &Utf8Path,
+    new_version: &Version,
+    dry_run: bool,
+) -> Result<()> {
     let nfpm_config_path = repo_root.join("app/linux/nfpm.yaml");
     ensure!(
         nfpm_config_path.exists(),
@@ -99,10 +186,14 @@ fn update_nfpm_version(repo_root: &Utf8Path, new_version: &Version) -> Result<()
     let regex = Regex::new(r"(?m)^version:\s*.+$").expect("valid regex");
     ensure!(
         regex.is_match(&content),
-        "Could not locate version line in pubspec.yaml"
+        "Could not locate version line in nfpm.yaml"
     );
 
     let replacement = format!("version: {}", new_version);
+    if dry_run {
+        println!("[dry-run] would write {nfpm_config_path} with `{replacement}`");
+        return Ok(());
+    }
     let updated = regex.replace(&content, replacement).to_string();
     fs::write(&nfpm_config_path, updated)
         .with_context(|| format!("Failed to write {}", nfpm_config_path))?;

--- a/xtask/src/bump_version.rs
+++ b/xtask/src/bump_version.rs
@@ -67,23 +67,6 @@ pub(crate) fn run(args: BumpArgs) -> Result<()> {
     Ok(())
 }
 
-fn open_bump_pr(shell: &Shell, next: &Version, dry_run: bool) -> Result<()> {
-    let branch_name = format!("bump-version/v{next}");
-    let commit_message = format!("chore: v{next}");
-    println!("Opening pull request {branch_name}");
-    run_or_print(cmd!(shell, "git checkout -b {branch_name}"), dry_run)?;
-    run_or_print(cmd!(shell, "git commit -am {commit_message}"), dry_run)?;
-    run_or_print(cmd!(shell, "git push -u origin {branch_name}"), dry_run)?;
-    run_or_print(
-        cmd!(
-            shell,
-            "gh pr create --title {commit_message} --body {commit_message}"
-        ),
-        dry_run,
-    )?;
-    Ok(())
-}
-
 fn run_or_print(cmd: Cmd<'_>, dry_run: bool) -> Result<()> {
     if dry_run {
         println!("[dry-run] would run: {cmd}");
@@ -97,7 +80,7 @@ fn run_or_print(cmd: Cmd<'_>, dry_run: bool) -> Result<()> {
 fn ensure_fresh_main(shell: &Shell, dry_run: bool, force: bool) -> Result<()> {
     let status = cmd!(shell, "git status --porcelain").read()?;
     ensure!(
-        status.is_empty(),
+        force || status.is_empty(),
         "Working tree is not clean, commit or stash changes first"
     );
 
@@ -113,23 +96,6 @@ fn ensure_fresh_main(shell: &Shell, dry_run: bool, force: bool) -> Result<()> {
 
     run_or_print(cmd!(shell, "git pull --ff-only origin main"), dry_run)?;
 
-    Ok(())
-}
-
-/// Cuts a release branch from HEAD without switching to it, then opens a PR into main.
-fn cut_release_branch(shell: &Shell, current: &Version, dry_run: bool) -> Result<()> {
-    let release_branch = format!("release/{current}");
-    let title = format!("chore: release v{current}");
-    println!("Creating release branch {release_branch}");
-    run_or_print(cmd!(shell, "git branch {release_branch} main"), dry_run)?;
-    run_or_print(cmd!(shell, "git push -u origin {release_branch}"), dry_run)?;
-    run_or_print(
-        cmd!(
-            shell,
-            "gh pr create --base main --head {release_branch} --title {title} --body {title}"
-        ),
-        dry_run,
-    )?;
     Ok(())
 }
 
@@ -170,6 +136,45 @@ fn increment_patch(current: &Version) -> Version {
         pre: current.pre.clone(),
         build: current.build.clone(),
     }
+}
+
+/// Cuts a release branch from HEAD without switching to it, then opens a PR into main.
+fn cut_release_branch(shell: &Shell, current: &Version, dry_run: bool) -> Result<()> {
+    let release_branch = format!("release/{current}");
+    let commit_msg = format!("chore: release v{current}");
+    println!("Creating release branch {release_branch}");
+    run_or_print(cmd!(shell, "git branch {release_branch} main"), dry_run)?;
+    run_or_print(
+        cmd!(shell, "git commit --allow-empty -m {commit_msg}"),
+        dry_run,
+    )?;
+    run_or_print(cmd!(shell, "git push -u origin {release_branch}"), dry_run)?;
+    run_or_print(
+        cmd!(
+            shell,
+            "gh pr create --base main --head {release_branch} --title {commit_msg}"
+        ),
+        dry_run,
+    )?;
+    Ok(())
+}
+
+/// Switch to a fresh branch and commit the bump, then open a PR into main.
+fn open_bump_pr(shell: &Shell, next: &Version, dry_run: bool) -> Result<()> {
+    let branch_name = format!("bump-version/v{next}");
+    let commit_message = format!("chore: v{next}");
+    println!("Opening pull request {branch_name}");
+    run_or_print(cmd!(shell, "git checkout -b {branch_name}"), dry_run)?;
+    run_or_print(cmd!(shell, "git commit -am {commit_message}"), dry_run)?;
+    run_or_print(cmd!(shell, "git push -u origin {branch_name}"), dry_run)?;
+    run_or_print(
+        cmd!(
+            shell,
+            "gh pr create --title {commit_message} --body {commit_message}"
+        ),
+        dry_run,
+    )?;
+    Ok(())
 }
 
 fn update_flutter_version(

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -23,7 +23,7 @@ struct Cli {
 enum Commands {
     /// Bump the workspace crate versions, update Flutter metadata, add a changelog entry, and tag the commit.
     #[command(name = "bump-version")]
-    BumpVersion,
+    BumpVersion(bump_version::BumpArgs),
     /// Scan Flutter / mobile sources for unused localization keys and prune them from ARB files.
     #[command(name = "prune-unused-l10n")]
     PruneUnusedL10n(prune_unused_l10n::PruneArgs),
@@ -32,7 +32,7 @@ enum Commands {
 fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
     match cli.command {
-        Commands::BumpVersion => bump_version::run(),
+        Commands::BumpVersion(args) => bump_version::run(args),
         Commands::PruneUnusedL10n(args) => prune_unused_l10n::run(args),
     }
 }


### PR DESCRIPTION
- Assign environments to the Android and iOS publish jobs, to be able to gate their secrets and permissions (the @phnx-im/maintainers team is now responsible for allowing builds on these environments).
- Trigger the two relevant workflows on both commits on `main` (when a PR is merged) and pull requests on `release/*` branches
- Adjust the `bump-version` script to:
  - check that your local git clone is on the latest remote `HEAD` of `main`
  - cut a release branch from `main` and open a PR against `main` with a single empty starting commit
  - bump the (minor or patch) version, commit and open a PR against `main`
  - bonus: add a `--dry-run` flag to the script for testing as well as `--force` if you are have powah