### PR TITLE
fix(CI): split sccache GHA cache per job

### DIFF
--- a/.github/actions/setup-buildenv/action.yml
+++ b/.github/actions/setup-buildenv/action.yml
@@ -88,7 +88,7 @@ runs:
           ~/.rustup
         key: "sccache-${{ github.job }}-${{ hashFiles('.github/actions/setup-buildenv/action.yml', 'Cargo.lock', '.config/cargo.toml', 'rust-toolchain.toml', 'app/pubspec.lock', 'app/.fvmrc') }}"
         restore-keys: |
-          sccache-${{ runner.os }}-${{ runner.arch }}
+          sccache-${{ github.job }}
 
     - name: Download Rust GitHub Actions cache
       if: github.ref != 'refs/heads/main'
@@ -100,7 +100,7 @@ runs:
           ~/.rustup
         key: "sccache-${{ github.job }}-${{ hashFiles('.github/actions/setup-buildenv/action.yml', 'Cargo.lock', '.config/cargo.toml', 'rust-toolchain.toml', 'app/pubspec.lock', 'app/.fvmrc') }}"
         restore-keys: |
-          sccache-${{ runner.os }}-${{ runner.arch }}
+          sccache-${{ github.job }}
 
     - name: Start sccache daemon
       uses: gacts/run-and-post-run@v1

--- a/.github/actions/setup-buildenv/action.yml
+++ b/.github/actions/setup-buildenv/action.yml
@@ -86,7 +86,7 @@ runs:
           ${{ inputs.sccache-dir }}
           ~/.cargo
           ~/.rustup
-        key: "sccache-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.github/actions/setup-buildenv/action.yml', 'Cargo.lock', '.config/cargo.toml', 'rust-toolchain.toml', 'app/pubspec.lock', 'app/.fvmrc') }}"
+        key: "sccache-${{ github.job }}-${{ hashFiles('.github/actions/setup-buildenv/action.yml', 'Cargo.lock', '.config/cargo.toml', 'rust-toolchain.toml', 'app/pubspec.lock', 'app/.fvmrc') }}"
         restore-keys: |
           sccache-${{ runner.os }}-${{ runner.arch }}
 
@@ -98,7 +98,7 @@ runs:
           ${{ inputs.sccache-dir }}
           ~/.cargo
           ~/.rustup
-        key: "sccache-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.github/actions/setup-buildenv/action.yml', 'Cargo.lock', '.config/cargo.toml', 'rust-toolchain.toml', 'app/pubspec.lock', 'app/.fvmrc') }}"
+        key: "sccache-${{ github.job }}-${{ hashFiles('.github/actions/setup-buildenv/action.yml', 'Cargo.lock', '.config/cargo.toml', 'rust-toolchain.toml', 'app/pubspec.lock', 'app/.fvmrc') }}"
         restore-keys: |
           sccache-${{ runner.os }}-${{ runner.arch }}
 


### PR DESCRIPTION
https://github.com/phnx-im/air/pull/1217/changes revealed that the `sccache` hit rate is close to 0% for Android builds. It turns out I made a mistake in my assumptions when keying the cache, since both Android and Desktop Linux builds use `Linux-X64` as their platforms, they ended up having the same cache hash and erased/competed with each other.

Once/if we manage to use `sccache` on macOS, we'll also avoid the same issue there between macOS and iOS builds.