### PR TITLE
fix(app): don't switch between mobile and tablet layout on Android phones

### DIFF
--- a/app/lib/ds/theme/responsive_screen.dart
+++ b/app/lib/ds/theme/responsive_screen.dart
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import 'dart:io';
+import 'dart:math' show min;
 
 import 'package:flutter/widgets.dart';
 
@@ -19,10 +20,15 @@ enum ResponsiveScreenType {
 }
 
 /// Breakpoint between the mobile (tab bar) and non-mobile (sidebar) layouts.
+///
+/// Applied to the *shortest* side of the window so that orientation changes
+/// don't flip the layout (which means tearing down the declarative page stack
+/// in [AppRouterDelegate], which in turn means discarding any pageless routes
+/// pushed on top like the attachment upload preview!).
 const double kMobileBreakpoint = 576;
 
-ResponsiveScreenType _screenType(double width) {
-  if (width < kMobileBreakpoint) {
+ResponsiveScreenType _screenType(double shortestSide) {
+  if (shortestSide < kMobileBreakpoint) {
     return ResponsiveScreenType.mobile;
   } else if (ResponsiveScreen.isTouch) {
     return ResponsiveScreenType.tablet;
@@ -33,11 +39,11 @@ ResponsiveScreenType _screenType(double width) {
 
 extension BuildContextScreenTypeExtension on BuildContext {
   ResponsiveScreenType get responsiveScreenType =>
-      _screenType(MediaQuery.of(this).size.width);
+      _screenType(MediaQuery.of(this).size.shortestSide);
 }
 
 extension BoxConstraintsScreenTypeExtension on BoxConstraints {
-  ResponsiveScreenType get screenType => _screenType(maxWidth);
+  ResponsiveScreenType get screenType => _screenType(min(maxWidth, maxHeight));
 }
 
 class ResponsiveScreen extends StatefulWidget {

--- a/app/lib/ds/theme/styles.dart
+++ b/app/lib/ds/theme/styles.dart
@@ -12,11 +12,11 @@ import 'dart:io' show Platform;
 // === Devices ===
 
 bool isSmallScreen(BuildContext context) {
-  return MediaQuery.sizeOf(context).width < kMobileBreakpoint;
+  return MediaQuery.sizeOf(context).shortestSide < kMobileBreakpoint;
 }
 
 bool isLargeScreen(BuildContext context) {
-  return MediaQuery.sizeOf(context).width >= kMobileBreakpoint;
+  return MediaQuery.sizeOf(context).shortestSide >= kMobileBreakpoint;
 }
 
 bool isTouch() {

--- a/applogic/src/background_execution/java_api.rs
+++ b/applogic/src/background_execution/java_api.rs
@@ -21,7 +21,7 @@ pub extern "C" fn process_new_messages(
     // Convert Java string to Rust string
     let input: String = match env.get_string(&content) {
         Ok(value) => value.into(),
-        Err(error) => {
+        Err(_) => {
             let _ = env.throw_new(
                 "java/lang/IllegalArgumentException",
                 "Failed to read content string from Java",
@@ -43,7 +43,7 @@ pub extern "C" fn process_new_messages(
 
     let response = match serde_json::to_string(&batch) {
         Ok(json) => json,
-        Err(error) => {
+        Err(_) => {
             let _ = env.throw_new(
                 "java/lang/RuntimeException",
                 "Failed to serialize notification batch",
@@ -55,7 +55,7 @@ pub extern "C" fn process_new_messages(
     // Convert Rust string back to Java string
     match env.new_string(response) {
         Ok(output) => output.into_raw(),
-        Err(_error) => {
+        Err(_) => {
             let _ = env.throw_new(
                 "java/lang/RuntimeException",
                 "Failed to create Java string from Rust",


### PR DESCRIPTION
The bug I was chasing: take a picture in landscape, send it to the app, turn the app back to portrait, the picture then "disappears".

On my Pixel 8, the `screenType` would change from `mobile` to `tablet` when turning the phone, which rebuilt the `AppRouterDelegate` from scratch. This meant we lost the stack of page-less routes.

Note: the Rust change is unrelated and just removes a warning when building