### PR TITLE
fix(app): classify non-network errors as such on retry

### DIFF
--- a/app/lib/chat/chat_debug_info_view.dart
+++ b/app/lib/chat/chat_debug_info_view.dart
@@ -22,12 +22,14 @@ class ChatDebugInfoView extends HookWidget {
     required this.title,
     required this.debugInfo,
     required this.onRequestResync,
+    required this.onEraseLocalChat,
     super.key,
   });
 
   final String title;
   final Future<GroupDebugInfo> debugInfo;
   final VoidCallback onRequestResync;
+  final VoidCallback onEraseLocalChat;
 
   @override
   Widget build(BuildContext context) {
@@ -40,6 +42,7 @@ class ChatDebugInfoView extends HookWidget {
         AsyncSnapshot(hasData: true, :final data) => _GroupDebugInfoBody(
           info: data!,
           onRequestResync: onRequestResync,
+          onEraseLocalChat: onEraseLocalChat,
         ),
         AsyncSnapshot(hasError: true, :final error) => Center(
           child: Padding(
@@ -72,10 +75,12 @@ class _GroupDebugInfoBody extends StatelessWidget {
   const _GroupDebugInfoBody({
     required this.info,
     required this.onRequestResync,
+    required this.onEraseLocalChat,
   });
 
   final GroupDebugInfo info;
   final VoidCallback onRequestResync;
+  final VoidCallback onEraseLocalChat;
 
   @override
   Widget build(BuildContext context) {
@@ -132,6 +137,8 @@ class _GroupDebugInfoBody extends StatelessWidget {
         ],
         const SizedBox(height: Spacing.px32),
         _RequestResyncButton(onTapped: onRequestResync),
+        const SizedBox(height: Spacing.px16),
+        _DeleteLocalChatButton(onTapped: onEraseLocalChat),
       ],
     );
   }
@@ -153,6 +160,26 @@ class _RequestResyncButton extends HookWidget {
       tone: AppButtonTone.danger,
       state: isTapped.value ? AppButtonState.inactive : AppButtonState.active,
       label: "DANGER: Request resync",
+    );
+  }
+}
+
+class _DeleteLocalChatButton extends HookWidget {
+  const _DeleteLocalChatButton({required this.onTapped});
+
+  final VoidCallback onTapped;
+
+  @override
+  Widget build(BuildContext context) {
+    final isTapped = useState(false);
+    return AppButton(
+      onPressed: () {
+        isTapped.value = true;
+        onTapped();
+      },
+      tone: AppButtonTone.danger,
+      state: isTapped.value ? AppButtonState.inactive : AppButtonState.active,
+      label: "DANGER: Delete local chat",
     );
   }
 }

--- a/app/lib/chat/chat_details_screen.dart
+++ b/app/lib/chat/chat_details_screen.dart
@@ -70,13 +70,15 @@ class ChatDetailsScreenView extends StatelessWidget {
             title: chat.title,
             onTitleLongPress: () {
               final chatDetailsCubit = context.read<ChatDetailsCubit>();
+              final userCubit = context.read<UserCubit>();
               final debugInfoFut = chatDetailsCubit.chatDebugInfo();
               Navigator.of(context).push(
                 MaterialPageRoute(
                   builder: (context) => ChatDebugInfoView(
                     title: chat.title,
                     debugInfo: debugInfoFut,
-                    onRequestResync: () => {chatDetailsCubit.requestResync()},
+                    onRequestResync: () => chatDetailsCubit.requestResync(),
+                    onEraseLocalChat: () => userCubit.devEraseChat(chat.id),
                   ),
                 ),
               );

--- a/app/lib/chat/chat_screen.dart
+++ b/app/lib/chat/chat_screen.dart
@@ -15,6 +15,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
+import 'chat_debug_info_view.dart';
 import 'chat_details_cubit.dart';
 import 'delete_contact_button.dart';
 import 'report_spam_button.dart';
@@ -236,6 +237,23 @@ class _ChatHeader extends StatelessWidget implements PreferredSizeWidget {
                   context.read<NavigationCubit>().openChatDetails();
                 }
               : null,
+          onLongPress: () {
+            final chatDetailsCubit = context.read<ChatDetailsCubit>();
+            final userCubit = context.read<UserCubit>();
+            final debugInfoFut = chatDetailsCubit.chatDebugInfo();
+            Navigator.of(context).push(
+              MaterialPageRoute(
+                builder: (context) => ChatDebugInfoView(
+                  title: title ?? "",
+                  debugInfo: debugInfoFut,
+                  onRequestResync: () => chatDetailsCubit.requestResync(),
+                  onEraseLocalChat: () {
+                    if (chatId != null) userCubit.devEraseChat(chatId);
+                  },
+                ),
+              ),
+            );
+          },
           child: Row(
             mainAxisSize: MainAxisSize.min,
             spacing: Spacing.px12,

--- a/app/lib/chat/group_details.dart
+++ b/app/lib/chat/group_details.dart
@@ -48,7 +48,8 @@ class GroupDetailsScreen extends StatelessWidget {
     return AppScaffold(
       title: chat.title,
       onTitleLongPress: () {
-        var chatDetailsCubit = context.read<ChatDetailsCubit>();
+        final chatDetailsCubit = context.read<ChatDetailsCubit>();
+        final userCubit = context.read<UserCubit>();
         final debugInfoFut = chatDetailsCubit.chatDebugInfo();
         Navigator.of(context).push(
           MaterialPageRoute(
@@ -56,6 +57,7 @@ class GroupDetailsScreen extends StatelessWidget {
               title: chat.title,
               debugInfo: debugInfoFut,
               onRequestResync: () => chatDetailsCubit.requestResync(),
+              onEraseLocalChat: () => userCubit.devEraseChat(chat.id),
             ),
           ),
         );

--- a/app/lib/core/api/user_cubit.dart
+++ b/app/lib/core/api/user_cubit.dart
@@ -79,6 +79,11 @@ abstract class UserCubitBase implements RustOpaqueInterface {
 
   Future<void> deleteChat(ChatId chatId);
 
+  /// Only delete the local chat data, do not delete the chat on the server or try to leave it.
+  ///
+  /// Used for development purposes.
+  Future<void> devEraseChat(ChatId chatId);
+
   bool get isClosed;
 
   Future<void> leaveChat(ChatId chatId);

--- a/app/lib/core/frb_generated.dart
+++ b/app/lib/core/frb_generated.dart
@@ -90,7 +90,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.12.0';
 
   @override
-  int get rustContentHash => 1549109689;
+  int get rustContentHash => -874195106;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -554,6 +554,11 @@ abstract class RustLibApi extends BaseApi {
   });
 
   Future<void> crateApiUserCubitUserCubitBaseDeleteChat({
+    required UserCubitBase that,
+    required ChatId chatId,
+  });
+
+  Future<void> crateApiUserCubitUserCubitBaseDevEraseChat({
     required UserCubitBase that,
     required ChatId chatId,
   });
@@ -4666,6 +4671,44 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
+  Future<void> crateApiUserCubitUserCubitBaseDevEraseChat({
+    required UserCubitBase that,
+    required ChatId chatId,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerUserCubitBase(
+            that,
+            serializer,
+          );
+          sse_encode_box_autoadd_chat_id(chatId, serializer);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 98,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_unit,
+          decodeErrorData: sse_decode_AnyhowException,
+        ),
+        constMeta: kCrateApiUserCubitUserCubitBaseDevEraseChatConstMeta,
+        argValues: [that, chatId],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiUserCubitUserCubitBaseDevEraseChatConstMeta =>
+      const TaskConstMeta(
+        debugName: "UserCubitBase_dev_erase_chat",
+        argNames: ["that", "chatId"],
+      );
+
+  @override
   bool crateApiUserCubitUserCubitBaseIsClosed({required UserCubitBase that}) {
     return handler.executeSync(
       SyncTask(
@@ -4675,7 +4718,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             that,
             serializer,
           );
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 98)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 99)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_bool,
@@ -4711,7 +4754,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 99,
+            funcId: 100,
             port: port_,
           );
         },
@@ -4752,7 +4795,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 100,
+            funcId: 101,
           )!;
         },
         codec: SseCodec(
@@ -4792,7 +4835,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 101,
+            funcId: 102,
             port: port_,
           );
         },
@@ -4831,7 +4874,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 102,
+            funcId: 103,
             port: port_,
           );
         },
@@ -4869,7 +4912,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 103,
+            funcId: 104,
             port: port_,
           );
         },
@@ -4907,7 +4950,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 104,
+            funcId: 105,
             port: port_,
           );
         },
@@ -4945,7 +4988,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 105,
+            funcId: 106,
             port: port_,
           );
         },
@@ -4985,7 +5028,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 106,
+            funcId: 107,
             port: port_,
           );
         },
@@ -5019,7 +5062,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 107,
+            funcId: 108,
           )!;
         },
         codec: SseCodec(
@@ -5058,7 +5101,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 108,
+              funcId: 109,
               port: port_,
             );
           },
@@ -5098,7 +5141,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 109,
+            funcId: 110,
             port: port_,
           );
         },
@@ -5134,7 +5177,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 110,
+            funcId: 111,
             port: port_,
           );
         },
@@ -5172,7 +5215,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 111,
+            funcId: 112,
           )!;
         },
         codec: SseCodec(
@@ -5214,7 +5257,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 112,
+            funcId: 113,
             port: port_,
           );
         },
@@ -5246,7 +5289,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 113,
+            funcId: 114,
           )!;
         },
         codec: SseCodec(
@@ -5280,7 +5323,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 114,
+            funcId: 115,
             port: port_,
           );
         },
@@ -5325,7 +5368,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 115,
+            funcId: 116,
             port: port_,
           );
         },
@@ -5370,7 +5413,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 116,
+            funcId: 117,
             port: port_,
           );
         },
@@ -5415,7 +5458,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 117,
+            funcId: 118,
             port: port_,
           );
         },
@@ -5460,7 +5503,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 118,
+            funcId: 119,
             port: port_,
           );
         },
@@ -5505,7 +5548,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 119,
+            funcId: 120,
             port: port_,
           );
         },
@@ -5543,7 +5586,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 120,
+            funcId: 121,
           )!;
         },
         codec: SseCodec(
@@ -5583,7 +5626,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 121,
+              funcId: 122,
               port: port_,
             );
           },
@@ -5621,7 +5664,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 122,
+            funcId: 123,
             port: port_,
           );
         },
@@ -5656,7 +5699,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 123,
+            funcId: 124,
             port: port_,
           );
         },
@@ -5689,7 +5732,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 124,
+            funcId: 125,
             port: port_,
           );
         },
@@ -5720,7 +5763,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 125,
+            funcId: 126,
             port: port_,
           );
         },
@@ -5761,7 +5804,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 126,
+            funcId: 127,
             port: port_,
           );
         },
@@ -5809,7 +5852,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 127,
+            funcId: 128,
             port: port_,
           );
         },
@@ -5843,7 +5886,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 128,
+            funcId: 129,
           )!;
         },
         codec: SseCodec(
@@ -5880,7 +5923,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 129,
+            funcId: 130,
             port: port_,
           );
         },
@@ -5914,7 +5957,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 130,
+            funcId: 131,
             port: port_,
           );
         },
@@ -5948,7 +5991,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 131,
+            funcId: 132,
           )!;
         },
         codec: SseCodec(
@@ -5980,7 +6023,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 132,
+            funcId: 133,
             port: port_,
           );
         },
@@ -6016,7 +6059,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 133,
+            funcId: 134,
           )!;
         },
         codec: SseCodec(
@@ -6051,7 +6094,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 134,
+            funcId: 135,
           )!;
         },
         codec: SseCodec(
@@ -6087,7 +6130,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 135,
+            funcId: 136,
           )!;
         },
         codec: SseCodec(
@@ -6129,7 +6172,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 136,
+              funcId: 137,
               port: port_,
             );
           },
@@ -6169,7 +6212,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 137,
+            funcId: 138,
           )!;
         },
         codec: SseCodec(
@@ -6206,7 +6249,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 138,
+            funcId: 139,
           )!;
         },
         codec: SseCodec(
@@ -6243,7 +6286,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 139,
+            funcId: 140,
           )!;
         },
         codec: SseCodec(
@@ -6272,7 +6315,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 140,
+            funcId: 141,
             port: port_,
           );
         },
@@ -6302,7 +6345,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 141,
+            funcId: 142,
             port: port_,
           );
         },
@@ -6334,7 +6377,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 142,
+            funcId: 143,
             port: port_,
           );
         },
@@ -6364,7 +6407,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 143,
+            funcId: 144,
             port: port_,
           );
         },
@@ -6392,7 +6435,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 144,
+            funcId: 145,
             port: port_,
           );
         },
@@ -6425,7 +6468,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 145,
+              funcId: 146,
               port: port_,
             );
           },
@@ -6459,7 +6502,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 146,
+            funcId: 147,
             port: port_,
           );
         },
@@ -6490,7 +6533,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 147,
+            funcId: 148,
             port: port_,
           );
         },
@@ -6518,7 +6561,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 148,
+            funcId: 149,
             port: port_,
           );
         },
@@ -6549,7 +6592,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 149,
+            funcId: 150,
             port: port_,
           );
         },
@@ -6577,7 +6620,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 150,
+            funcId: 151,
           )!;
         },
         codec: SseCodec(
@@ -6607,7 +6650,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 151,
+            funcId: 152,
           )!;
         },
         codec: SseCodec(
@@ -6638,7 +6681,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 152,
+            funcId: 153,
             port: port_,
           );
         },
@@ -6671,7 +6714,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 153,
+            funcId: 154,
             port: port_,
           );
         },
@@ -6699,7 +6742,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 154,
+            funcId: 155,
             port: port_,
           );
         },
@@ -6734,7 +6777,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 155,
+            funcId: 156,
             port: port_,
           );
         },
@@ -6767,7 +6810,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 156,
+            funcId: 157,
             port: port_,
           );
         },
@@ -6800,7 +6843,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 157,
+            funcId: 158,
           )!;
         },
         codec: SseCodec(
@@ -6829,7 +6872,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 158,
+            funcId: 159,
             port: port_,
           );
         },
@@ -6859,7 +6902,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 159,
+            funcId: 160,
             port: port_,
           );
         },
@@ -6887,7 +6930,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 160,
+            funcId: 161,
             port: port_,
           );
         },
@@ -6917,7 +6960,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 161,
+            funcId: 162,
             port: port_,
           );
         },
@@ -6944,7 +6987,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 162,
+            funcId: 163,
             port: port_,
           );
         },
@@ -6972,7 +7015,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 163,
+            funcId: 164,
             port: port_,
           );
         },
@@ -7002,7 +7045,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 164,
+            funcId: 165,
           )!;
         },
         codec: SseCodec(
@@ -7035,7 +7078,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 165,
+            funcId: 166,
           )!;
         },
         codec: SseCodec(
@@ -17667,6 +17710,12 @@ class UserCubitBaseImpl extends RustOpaque implements UserCubitBase {
 
   Future<void> deleteChat(ChatId chatId) => RustLib.instance.api
       .crateApiUserCubitUserCubitBaseDeleteChat(that: this, chatId: chatId);
+
+  /// Only delete the local chat data, do not delete the chat on the server or try to leave it.
+  ///
+  /// Used for development purposes.
+  Future<void> devEraseChat(ChatId chatId) => RustLib.instance.api
+      .crateApiUserCubitUserCubitBaseDevEraseChat(that: this, chatId: chatId);
 
   bool get isClosed =>
       RustLib.instance.api.crateApiUserCubitUserCubitBaseIsClosed(that: this);

--- a/app/lib/user/user_cubit.dart
+++ b/app/lib/user/user_cubit.dart
@@ -68,6 +68,8 @@ class UserCubit implements StateStreamableSource<UiUser> {
 
   Future<void> deleteChat(ChatId chatId) => _impl.deleteChat(chatId);
 
+  Future<void> devEraseChat(ChatId chatId) => _impl.devEraseChat(chatId);
+
   Future<List<UiContact>> get contacts => _impl.contacts;
 
   Future<bool> addUsername(UiUsername username) =>

--- a/applogic/src/api/user_cubit/mod.rs
+++ b/applogic/src/api/user_cubit/mod.rs
@@ -285,6 +285,15 @@ impl UserCubitBase {
         Ok(())
     }
 
+    /// Only delete the local chat data, do not delete the chat on the server or try to leave it.
+    ///
+    /// Used for development purposes.
+    #[frb(positional)]
+    pub async fn dev_erase_chat(&self, chat_id: ChatId) -> anyhow::Result<()> {
+        self.context.core_user.erase_chat(chat_id).await?;
+        Ok(())
+    }
+
     #[frb(positional)]
     pub async fn leave_chat(&self, chat_id: ChatId) -> anyhow::Result<()> {
         self.context.core_user.leave_chat(chat_id).await

--- a/applogic/src/frb_generated.rs
+++ b/applogic/src/frb_generated.rs
@@ -53,7 +53,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.12.0";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 1549109689;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -874195106;
 
 // Section: executor
 
@@ -5140,6 +5140,66 @@ fn wire__crate__api__user_cubit__UserCubitBase_delete_chat_impl(
                         }
                         let api_that_guard = api_that_guard.unwrap();
                         let output_ok = crate::api::user_cubit::UserCubitBase::delete_chat(
+                            &*api_that_guard,
+                            api_chat_id,
+                        )
+                        .await?;
+                        Ok(output_ok)
+                    })()
+                    .await,
+                )
+            }
+        },
+    )
+}
+fn wire__crate__api__user_cubit__UserCubitBase_dev_erase_chat_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_async::<flutter_rust_bridge::for_generated::SseCodec, _, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "UserCubitBase_dev_erase_chat",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_that = <RustOpaqueMoi<
+                flutter_rust_bridge::for_generated::RustAutoOpaqueInner<UserCubitBase>,
+            >>::sse_decode(&mut deserializer);
+            let api_chat_id = <crate::api::types::ChatId>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| async move {
+                transform_result_sse::<_, flutter_rust_bridge::for_generated::anyhow::Error>(
+                    (move || async move {
+                        let mut api_that_guard = None;
+                        let decode_indices_ =
+                            flutter_rust_bridge::for_generated::lockable_compute_decode_order(
+                                vec![flutter_rust_bridge::for_generated::LockableOrderInfo::new(
+                                    &api_that, 0, false,
+                                )],
+                            );
+                        for i in decode_indices_ {
+                            match i {
+                                0 => {
+                                    api_that_guard =
+                                        Some(api_that.lockable_decode_async_ref().await)
+                                }
+                                _ => unreachable!(),
+                            }
+                        }
+                        let api_that_guard = api_that_guard.unwrap();
+                        let output_ok = crate::api::user_cubit::UserCubitBase::dev_erase_chat(
                             &*api_that_guard,
                             api_chat_id,
                         )
@@ -11598,55 +11658,56 @@ fn pde_ffi_dispatcher_primary_impl(
 95 => wire__crate__api__user_cubit__UserCubitBase_contacts_impl(port, ptr, rust_vec_len, data_len),
 96 => wire__crate__api__user_cubit__UserCubitBase_delete_account_impl(port, ptr, rust_vec_len, data_len),
 97 => wire__crate__api__user_cubit__UserCubitBase_delete_chat_impl(port, ptr, rust_vec_len, data_len),
-99 => wire__crate__api__user_cubit__UserCubitBase_leave_chat_impl(port, ptr, rust_vec_len, data_len),
-101 => wire__crate__api__user_cubit__UserCubitBase_remove_user_from_chat_impl(port, ptr, rust_vec_len, data_len),
-102 => wire__crate__api__user_cubit__UserCubitBase_remove_username_impl(port, ptr, rust_vec_len, data_len),
-103 => wire__crate__api__user_cubit__UserCubitBase_report_spam_impl(port, ptr, rust_vec_len, data_len),
-104 => wire__crate__api__user_cubit__UserCubitBase_safety_codes_impl(port, ptr, rust_vec_len, data_len),
-105 => wire__crate__api__user_cubit__UserCubitBase_set_app_state_impl(port, ptr, rust_vec_len, data_len),
-106 => wire__crate__api__user_cubit__UserCubitBase_set_profile_impl(port, ptr, rust_vec_len, data_len),
-108 => wire__crate__api__user_cubit__UserCubitBase_stream_impl(port, ptr, rust_vec_len, data_len),
-109 => wire__crate__api__user_cubit__UserCubitBase_unblock_contact_impl(port, ptr, rust_vec_len, data_len),
-110 => wire__crate__api__user_settings_cubit__UserSettingsCubitBase_close_impl(port, ptr, rust_vec_len, data_len),
-112 => wire__crate__api__user_settings_cubit__UserSettingsCubitBase_load_state_impl(port, ptr, rust_vec_len, data_len),
-114 => wire__crate__api__user_settings_cubit__UserSettingsCubitBase_reset_impl(port, ptr, rust_vec_len, data_len),
-115 => wire__crate__api__user_settings_cubit__UserSettingsCubitBase_set_interface_scale_impl(port, ptr, rust_vec_len, data_len),
-116 => wire__crate__api__user_settings_cubit__UserSettingsCubitBase_set_locale_impl(port, ptr, rust_vec_len, data_len),
-117 => wire__crate__api__user_settings_cubit__UserSettingsCubitBase_set_read_receipts_impl(port, ptr, rust_vec_len, data_len),
-118 => wire__crate__api__user_settings_cubit__UserSettingsCubitBase_set_send_on_enter_impl(port, ptr, rust_vec_len, data_len),
-119 => wire__crate__api__user_settings_cubit__UserSettingsCubitBase_set_sidebar_width_impl(port, ptr, rust_vec_len, data_len),
-121 => wire__crate__api__user_settings_cubit__UserSettingsCubitBase_stream_impl(port, ptr, rust_vec_len, data_len),
-122 => wire__crate__api__user__User_global_unread_messages_count_impl(port, ptr, rust_vec_len, data_len),
-123 => wire__crate__api__user__User_load_impl(port, ptr, rust_vec_len, data_len),
-124 => wire__crate__api__user__User_load_client_records_impl(port, ptr, rust_vec_len, data_len),
-125 => wire__crate__api__user__User_load_default_impl(port, ptr, rust_vec_len, data_len),
-126 => wire__crate__api__user__User_new_impl(port, ptr, rust_vec_len, data_len),
-127 => wire__crate__api__user__User_prepare_for_background_impl(port, ptr, rust_vec_len, data_len),
-129 => wire__crate__api__user__User_update_push_token_impl(port, ptr, rust_vec_len, data_len),
-130 => wire__crate__api__user__User_user_debug_info_impl(port, ptr, rust_vec_len, data_len),
-132 => wire__crate__api__users_cubit__UsersCubitBase_close_impl(port, ptr, rust_vec_len, data_len),
-136 => wire__crate__api__users_cubit__UsersCubitBase_stream_impl(port, ptr, rust_vec_len, data_len),
-140 => wire__crate__api__chat_details_cubit__chat_details_state_default_impl(port, ptr, rust_vec_len, data_len),
-141 => wire__crate__api__chat_list_cubit__chat_list_state_default_impl(port, ptr, rust_vec_len, data_len),
-142 => wire__crate__api__invitation_code__check_invitation_code_impl(port, ptr, rust_vec_len, data_len),
-143 => wire__crate__api__logging__clear_app_logs_impl(port, ptr, rust_vec_len, data_len),
-144 => wire__crate__api__logging__clear_background_logs_impl(port, ptr, rust_vec_len, data_len),
-145 => wire__crate__api__logging__create_log_stream_impl(port, ptr, rust_vec_len, data_len),
-146 => wire__crate__api__utils__delete_client_database_impl(port, ptr, rust_vec_len, data_len),
-147 => wire__crate__api__utils__delete_databases_impl(port, ptr, rust_vec_len, data_len),
-148 => wire__crate__api__navigation_cubit__home_navigation_state_default_impl(port, ptr, rust_vec_len, data_len),
-149 => wire__crate__api__navigation_cubit__home_tab_default_impl(port, ptr, rust_vec_len, data_len),
-152 => wire__crate__api__invitation_codes_cubit__invitation_codes_state_default_impl(port, ptr, rust_vec_len, data_len),
-153 => wire__crate__api__utils__is_image_file_impl(port, ptr, rust_vec_len, data_len),
-154 => wire__crate__api__member_details_cubit__member_details_state_default_impl(port, ptr, rust_vec_len, data_len),
-155 => wire__crate__api__markdown__message_content_error_impl(port, ptr, rust_vec_len, data_len),
-156 => wire__crate__api__markdown__message_content_parse_markdown_impl(port, ptr, rust_vec_len, data_len),
-158 => wire__crate__api__message_list_cubit__message_list_state_default_impl(port, ptr, rust_vec_len, data_len),
-159 => wire__crate__api__logging__read_app_logs_impl(port, ptr, rust_vec_len, data_len),
-160 => wire__crate__api__logging__read_background_logs_impl(port, ptr, rust_vec_len, data_len),
-161 => wire__crate__api__utils__read_clipboard_file_paths_impl(port, ptr, rust_vec_len, data_len),
-162 => wire__crate__api__utils__read_clipboard_image_impl(port, ptr, rust_vec_len, data_len),
-163 => wire__crate__api__logging__tar_logs_impl(port, ptr, rust_vec_len, data_len),
+98 => wire__crate__api__user_cubit__UserCubitBase_dev_erase_chat_impl(port, ptr, rust_vec_len, data_len),
+100 => wire__crate__api__user_cubit__UserCubitBase_leave_chat_impl(port, ptr, rust_vec_len, data_len),
+102 => wire__crate__api__user_cubit__UserCubitBase_remove_user_from_chat_impl(port, ptr, rust_vec_len, data_len),
+103 => wire__crate__api__user_cubit__UserCubitBase_remove_username_impl(port, ptr, rust_vec_len, data_len),
+104 => wire__crate__api__user_cubit__UserCubitBase_report_spam_impl(port, ptr, rust_vec_len, data_len),
+105 => wire__crate__api__user_cubit__UserCubitBase_safety_codes_impl(port, ptr, rust_vec_len, data_len),
+106 => wire__crate__api__user_cubit__UserCubitBase_set_app_state_impl(port, ptr, rust_vec_len, data_len),
+107 => wire__crate__api__user_cubit__UserCubitBase_set_profile_impl(port, ptr, rust_vec_len, data_len),
+109 => wire__crate__api__user_cubit__UserCubitBase_stream_impl(port, ptr, rust_vec_len, data_len),
+110 => wire__crate__api__user_cubit__UserCubitBase_unblock_contact_impl(port, ptr, rust_vec_len, data_len),
+111 => wire__crate__api__user_settings_cubit__UserSettingsCubitBase_close_impl(port, ptr, rust_vec_len, data_len),
+113 => wire__crate__api__user_settings_cubit__UserSettingsCubitBase_load_state_impl(port, ptr, rust_vec_len, data_len),
+115 => wire__crate__api__user_settings_cubit__UserSettingsCubitBase_reset_impl(port, ptr, rust_vec_len, data_len),
+116 => wire__crate__api__user_settings_cubit__UserSettingsCubitBase_set_interface_scale_impl(port, ptr, rust_vec_len, data_len),
+117 => wire__crate__api__user_settings_cubit__UserSettingsCubitBase_set_locale_impl(port, ptr, rust_vec_len, data_len),
+118 => wire__crate__api__user_settings_cubit__UserSettingsCubitBase_set_read_receipts_impl(port, ptr, rust_vec_len, data_len),
+119 => wire__crate__api__user_settings_cubit__UserSettingsCubitBase_set_send_on_enter_impl(port, ptr, rust_vec_len, data_len),
+120 => wire__crate__api__user_settings_cubit__UserSettingsCubitBase_set_sidebar_width_impl(port, ptr, rust_vec_len, data_len),
+122 => wire__crate__api__user_settings_cubit__UserSettingsCubitBase_stream_impl(port, ptr, rust_vec_len, data_len),
+123 => wire__crate__api__user__User_global_unread_messages_count_impl(port, ptr, rust_vec_len, data_len),
+124 => wire__crate__api__user__User_load_impl(port, ptr, rust_vec_len, data_len),
+125 => wire__crate__api__user__User_load_client_records_impl(port, ptr, rust_vec_len, data_len),
+126 => wire__crate__api__user__User_load_default_impl(port, ptr, rust_vec_len, data_len),
+127 => wire__crate__api__user__User_new_impl(port, ptr, rust_vec_len, data_len),
+128 => wire__crate__api__user__User_prepare_for_background_impl(port, ptr, rust_vec_len, data_len),
+130 => wire__crate__api__user__User_update_push_token_impl(port, ptr, rust_vec_len, data_len),
+131 => wire__crate__api__user__User_user_debug_info_impl(port, ptr, rust_vec_len, data_len),
+133 => wire__crate__api__users_cubit__UsersCubitBase_close_impl(port, ptr, rust_vec_len, data_len),
+137 => wire__crate__api__users_cubit__UsersCubitBase_stream_impl(port, ptr, rust_vec_len, data_len),
+141 => wire__crate__api__chat_details_cubit__chat_details_state_default_impl(port, ptr, rust_vec_len, data_len),
+142 => wire__crate__api__chat_list_cubit__chat_list_state_default_impl(port, ptr, rust_vec_len, data_len),
+143 => wire__crate__api__invitation_code__check_invitation_code_impl(port, ptr, rust_vec_len, data_len),
+144 => wire__crate__api__logging__clear_app_logs_impl(port, ptr, rust_vec_len, data_len),
+145 => wire__crate__api__logging__clear_background_logs_impl(port, ptr, rust_vec_len, data_len),
+146 => wire__crate__api__logging__create_log_stream_impl(port, ptr, rust_vec_len, data_len),
+147 => wire__crate__api__utils__delete_client_database_impl(port, ptr, rust_vec_len, data_len),
+148 => wire__crate__api__utils__delete_databases_impl(port, ptr, rust_vec_len, data_len),
+149 => wire__crate__api__navigation_cubit__home_navigation_state_default_impl(port, ptr, rust_vec_len, data_len),
+150 => wire__crate__api__navigation_cubit__home_tab_default_impl(port, ptr, rust_vec_len, data_len),
+153 => wire__crate__api__invitation_codes_cubit__invitation_codes_state_default_impl(port, ptr, rust_vec_len, data_len),
+154 => wire__crate__api__utils__is_image_file_impl(port, ptr, rust_vec_len, data_len),
+155 => wire__crate__api__member_details_cubit__member_details_state_default_impl(port, ptr, rust_vec_len, data_len),
+156 => wire__crate__api__markdown__message_content_error_impl(port, ptr, rust_vec_len, data_len),
+157 => wire__crate__api__markdown__message_content_parse_markdown_impl(port, ptr, rust_vec_len, data_len),
+159 => wire__crate__api__message_list_cubit__message_list_state_default_impl(port, ptr, rust_vec_len, data_len),
+160 => wire__crate__api__logging__read_app_logs_impl(port, ptr, rust_vec_len, data_len),
+161 => wire__crate__api__logging__read_background_logs_impl(port, ptr, rust_vec_len, data_len),
+162 => wire__crate__api__utils__read_clipboard_file_paths_impl(port, ptr, rust_vec_len, data_len),
+163 => wire__crate__api__utils__read_clipboard_image_impl(port, ptr, rust_vec_len, data_len),
+164 => wire__crate__api__logging__tar_logs_impl(port, ptr, rust_vec_len, data_len),
                         _ => unreachable!(),
                     }
 }
@@ -11794,61 +11855,61 @@ fn pde_ffi_dispatcher_sync_impl(
         ),
         85 => wire__crate__api__user_cubit__UiUser_user_id_impl(ptr, rust_vec_len, data_len),
         86 => wire__crate__api__user_cubit__UiUser_usernames_impl(ptr, rust_vec_len, data_len),
-        98 => {
+        99 => {
             wire__crate__api__user_cubit__UserCubitBase_is_closed_impl(ptr, rust_vec_len, data_len)
         }
-        100 => wire__crate__api__user_cubit__UserCubitBase_new_impl(ptr, rust_vec_len, data_len),
-        107 => wire__crate__api__user_cubit__UserCubitBase_state_impl(ptr, rust_vec_len, data_len),
-        111 => wire__crate__api__user_settings_cubit__UserSettingsCubitBase_is_closed_impl(
+        101 => wire__crate__api__user_cubit__UserCubitBase_new_impl(ptr, rust_vec_len, data_len),
+        108 => wire__crate__api__user_cubit__UserCubitBase_state_impl(ptr, rust_vec_len, data_len),
+        112 => wire__crate__api__user_settings_cubit__UserSettingsCubitBase_is_closed_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        113 => wire__crate__api__user_settings_cubit__UserSettingsCubitBase_new_impl(
+        114 => wire__crate__api__user_settings_cubit__UserSettingsCubitBase_new_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        120 => wire__crate__api__user_settings_cubit__UserSettingsCubitBase_state_impl(
+        121 => wire__crate__api__user_settings_cubit__UserSettingsCubitBase_state_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        128 => wire__crate__api__user__User_signal_pending_store_notifications_impl(
+        129 => wire__crate__api__user__User_signal_pending_store_notifications_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        131 => wire__crate__api__user__User_user_id_impl(ptr, rust_vec_len, data_len),
-        133 => wire__crate__api__users_cubit__UsersCubitBase_is_closed_impl(
+        132 => wire__crate__api__user__User_user_id_impl(ptr, rust_vec_len, data_len),
+        134 => wire__crate__api__users_cubit__UsersCubitBase_is_closed_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        134 => wire__crate__api__users_cubit__UsersCubitBase_new_impl(ptr, rust_vec_len, data_len),
-        135 => {
+        135 => wire__crate__api__users_cubit__UsersCubitBase_new_impl(ptr, rust_vec_len, data_len),
+        136 => {
             wire__crate__api__users_cubit__UsersCubitBase_state_impl(ptr, rust_vec_len, data_len)
         }
-        137 => {
+        138 => {
             wire__crate__api__users_cubit__UsersState_display_name_impl(ptr, rust_vec_len, data_len)
         }
-        138 => wire__crate__api__users_cubit__UsersState_profile_impl(ptr, rust_vec_len, data_len),
-        139 => wire__crate__api__users_cubit__UsersState_profile_picture_impl(
+        139 => wire__crate__api__users_cubit__UsersState_profile_impl(ptr, rust_vec_len, data_len),
+        140 => wire__crate__api__users_cubit__UsersState_profile_picture_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        150 => wire__crate__api__types__image_data_compute_hash_impl(ptr, rust_vec_len, data_len),
-        151 => wire__crate__api__logging__init_rust_logging_impl(ptr, rust_vec_len, data_len),
-        157 => wire__crate__api__markdown__message_content_parse_markdown_raw_impl(
+        151 => wire__crate__api__types__image_data_compute_hash_impl(ptr, rust_vec_len, data_len),
+        152 => wire__crate__api__logging__init_rust_logging_impl(ptr, rust_vec_len, data_len),
+        158 => wire__crate__api__markdown__message_content_parse_markdown_raw_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        164 => {
+        165 => {
             wire__crate__api__types__ui_username_validation_error_impl(ptr, rust_vec_len, data_len)
         }
-        165 => wire__crate__api__username_suggestions__username_from_display_impl(
+        166 => wire__crate__api__username_suggestions__username_from_display_impl(
             ptr,
             rust_vec_len,
             data_len,

--- a/coreclient/src/job/pending_chat_operation.rs
+++ b/coreclient/src/job/pending_chat_operation.rs
@@ -147,6 +147,27 @@ impl Job for PendingChatOperation {
                     .await?;
                 Err(JobError::NotFound)
             }
+            fatal_error @ Err(JobError::Fatal(_)) => {
+                // Clean up job after fatal error
+                context
+                    .db
+                    .write()
+                    .await?
+                    .with_transaction(async |txn| -> anyhow::Result<()> {
+                        self.group
+                            .group_mut()
+                            .discard_pending_commit(&mut *txn)
+                            .await?;
+                        Self::delete(txn, self.group.group_id()).await?;
+                        Ok(())
+                    })
+                    .await
+                    .inspect_err(|error| {
+                        error!(%error, "Failed to delete pending chat operation");
+                    })
+                    .ok();
+                fatal_error
+            }
             res => res,
         }
     }
@@ -377,7 +398,7 @@ impl PendingChatOperation {
 
     async fn handle_error(
         &mut self,
-        mut connection: impl WriteConnection,
+        connection: impl WriteConnection,
         error: DsRequestError,
     ) -> Result<JobError<ChatOperationError>, JobError<ChatOperationError>> {
         debug!(?error, "DS request failed");
@@ -389,30 +410,12 @@ impl PendingChatOperation {
             self.mark_as_waiting_for_queue_response(connection).await?;
 
             Err(JobError::Blocked)
-        } else if error.is_not_found() {
-            Err(JobError::NotFound)
-        } else if (error.is_network_error() || self.number_of_attempts > 0)
-            && self.number_of_attempts < MAX_RETRIES
-        {
-            // If we either get a network error (which means we don't know
-            // whether the request has been processed by the DS), or if we've
-            // gotten a network error in the past, we want to try again until
-            // we've either succeeded or reached a max number of retries.
+        } else if error.is_network_error() && self.number_of_attempts < MAX_RETRIES {
+            // If we get a network error (which means we don't know whether the request has been
+            // processed by the DS), we want to try again until we've either succeeded or reached a
+            // max number of retries.
             Ok(JobError::NetworkError)
         } else {
-            // For other errors or if the max number of retries has been
-            // reached, we consider the operation failed and delete the job.
-            connection
-                .with_transaction(async |txn| -> anyhow::Result<_> {
-                    self.group
-                        .group_mut()
-                        .discard_pending_commit(&mut *txn)
-                        .await?;
-                    Self::delete(txn, self.group.group_id()).await?;
-                    Ok(())
-                })
-                .await?;
-
             let error = if self.number_of_attempts >= MAX_RETRIES {
                 anyhow!(
                     "Job failed after {} attempts due to DS errors: {:?}",


### PR DESCRIPTION
When retrying a pending chat operation, we classified non-network errors
from the server as network operations. In particular, when server was
rejecting a commit with an invalid argument error, we still retried the
operation. This blocked outbound service operation like sending
messages.

Additionally add chat debug view to pending connection chats. Also allow
to delete a chat locally in the debug view.

Co-authored-by: Konrad Kohbrok <konrad.kohbrok@datashrine.de>