### PR TITLE
feat(ci): build non-workspace Rust crates with opt-level=3 in dev profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -166,3 +166,10 @@ hpke-rs-rust-crypto = { git = "https://github.com/cryspen/hpke-rs", rev = "42f9b
 strip = true
 lto = true
 codegen-units = 1
+
+[profile.dev]
+opt-level = 0 # Keep your workspace crates compiling fast with no optimizations
+
+# This overrides the settings *only* for your external dependencies
+[profile.dev.package."*"]
+opt-level = 3 # Compile all external dependencies in release mode (full optimization)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -170,6 +170,9 @@ codegen-units = 1
 [profile.dev]
 opt-level = 0 # Keep your workspace crates compiling fast with no optimizations
 
+[profile.dev.package.openmls]
+opt-level = 0
+
 # This overrides the settings *only* for your external dependencies
 [profile.dev.package."*"]
 opt-level = 3 # Compile all external dependencies in release mode (full optimization)


### PR DESCRIPTION
This means by default, invoking `cargo test` (without `--release`) will run much faster.

On my machine:

- Before: `823.79user 33.41system 1:13.35elapsed 1168%CPU (0avgtext+0avgdata 1640900maxresident)k`
- After: `54.89user 45.77system 0:25.89elapsed 388%CPU (0avgtext+0avgdata 1450300maxresident)k`

Since I now don't use all of my CPUs (12 physical cores) it means the tests are most likely I/O bound after enabling this trick.