### PR TITLE
fix(ci): use Xcode 26.5 on GitHub-hosted runners

### DIFF
--- a/.github/actions/setup-buildenv/action.yml
+++ b/.github/actions/setup-buildenv/action.yml
@@ -134,7 +134,7 @@ runs:
       name: Setup Xcode
       uses: maxim-lobanov/setup-xcode@v1
       with:
-        xcode-version: 26.1.1
+        xcode-version: 26.4.1
 
     ## JDK
 


### PR DESCRIPTION
It looks like iOS 26.1 is not installed anymore on GitHub-hosted runners. Xcode 26.5 should be setup with iOS 26.5.