### PR TITLE
fix(app): don't flatten animated images from clipboard

### DIFF
--- a/app/android/app/src/main/kotlin/ms/air/MainActivity.kt
+++ b/app/android/app/src/main/kotlin/ms/air/MainActivity.kt
@@ -179,31 +179,47 @@ class MainActivity : FlutterActivity() {
                 "getClipboardImage" -> {
                     val clipboard = getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
                     val clip = clipboard.primaryClip
-                    if (clip != null && clip.itemCount > 0) {
-                        val item = clip.getItemAt(0)
-                        val uri = item.uri
-                        if (uri != null) {
-                            val mimeType = contentResolver.getType(uri)
-                            if (mimeType != null && mimeType.startsWith("image/")) {
-                                try {
-                                    contentResolver.openInputStream(uri)?.use { stream ->
-                                        // Decode through BitmapFactory to handle any
-                                        // format Android supports (including HEIC),
-                                        // then re-encode as JPEG so the Dart side
-                                        // always receives a widely supported format.
-                                        val bitmap = BitmapFactory.decodeStream(stream)
-                                        if (bitmap != null) {
-                                            val outputStream = java.io.ByteArrayOutputStream()
-                                            bitmap.compress(Bitmap.CompressFormat.JPEG, 99, outputStream)
-                                            bitmap.recycle()
-                                            result.success(outputStream.toByteArray())
-                                            return@setMethodCallHandler
-                                        }
-                                    }
-                                } catch (e: Exception) {
-                                    Log.e(TAG, "Failed to read clipboard image", e)
+                    val item = if (clip != null && clip.itemCount > 0) clip.getItemAt(0) else null
+                    val uri = item?.uri
+                    val mimeType = uri?.let { contentResolver.getType(it) }
+
+                    // Animated formats and formats image-rs supports are passed to Rust
+                    // directly.
+                    val preferred = setOf("image/gif", "image/webp", "image/png", "image/jpeg")
+
+                    if (uri != null && mimeType != null && mimeType in preferred) {
+                        try {
+                            contentResolver.openInputStream(uri)?.use { stream ->
+                                val bytes = stream.readBytes()
+                                result.success(mapOf("bytes" to bytes, "mimeType" to mimeType))
+                                return@setMethodCallHandler
+                            }
+                        } catch (e: Exception) {
+                            Log.e(TAG, "Failed to read clipboard image bytes", e)
+                        }
+                    }
+
+                    // Fallback for HEIC and other formats the Rust image crate
+                    // can't decode.
+                    if (uri != null && mimeType != null && mimeType.startsWith("image/")) {
+                        try {
+                            contentResolver.openInputStream(uri)?.use { stream ->
+                                val bitmap = BitmapFactory.decodeStream(stream)
+                                if (bitmap != null) {
+                                    val outputStream = java.io.ByteArrayOutputStream()
+                                    bitmap.compress(Bitmap.CompressFormat.PNG, 100, outputStream)
+                                    bitmap.recycle()
+                                    result.success(
+                                        mapOf(
+                                            "bytes" to outputStream.toByteArray(),
+                                            "mimeType" to "image/png",
+                                        )
+                                    )
+                                    return@setMethodCallHandler
                                 }
                             }
+                        } catch (e: Exception) {
+                            Log.e(TAG, "Failed to read clipboard image", e)
                         }
                     }
                     result.success(null)

--- a/app/ios/Runner/AppDelegate.swift
+++ b/app/ios/Runner/AppDelegate.swift
@@ -228,13 +228,37 @@ private let kStoreNotificationsPendingName =
                         details: nil))
             }
         } else if call.method == "getClipboardImage" {
-            if let image = UIPasteboard.general.image,
-                let data = image.jpegData(compressionQuality: 0.99)
-            {
-                result(FlutterStandardTypedData(bytes: data))
-            } else {
-                result(nil)
+            let pasteboard = UIPasteboard.general
+            // Animated formats and formats image-rs supports are passed to Rust
+            // directly.
+            let preferred: [(uti: String, mime: String)] = [
+                ("com.compuserve.gif", "image/gif"),
+                ("org.webmproject.webp", "image/webp"),
+                ("public.png", "image/png"),
+                ("public.jpeg", "image/jpeg"),
+            ]
+            var payload: [String: Any]?
+            for (uti, mime) in preferred {
+                if let data = pasteboard.data(forPasteboardType: uti) {
+                    payload = [
+                        "bytes": FlutterStandardTypedData(bytes: data),
+                        "mimeType": mime,
+                    ]
+                    break
+                }
             }
+            // Fallback for HEIC and other formats UIImage decodes but the
+            // Rust image crate does not.
+            if payload == nil,
+                let image = pasteboard.image,
+                let png = image.pngData()
+            {
+                payload = [
+                    "bytes": FlutterStandardTypedData(bytes: png),
+                    "mimeType": "image/png",
+                ]
+            }
+            result(payload)
         } else if call.method == "beginBackgroundTask" {
             let taskId = self.beginBackgroundTask()
             result(Int(taskId.rawValue))

--- a/app/lib/core/api/utils.dart
+++ b/app/lib/core/api/utils.dart
@@ -35,7 +35,7 @@ Future<bool> isImageFile({required String path}) =>
 Future<List<String>?> readClipboardFilePaths() =>
     RustLib.instance.api.crateApiUtilsReadClipboardFilePaths();
 
-/// Reads an image from the system clipboard and returns it as JPEG bytes. Only
+/// Reads an image from the system clipboard and returns it as PNG bytes. Only
 /// supported on desktop platforms (Linux, Windows, macOS).
 ///
 /// Returns `None` if the clipboard does not contain image data, or when called

--- a/app/lib/message_list/message_composer.dart
+++ b/app/lib/message_list/message_composer.dart
@@ -36,7 +36,11 @@ import 'package:air/ds/foundations/font_size.dart';
 import 'package:provider/provider.dart';
 
 import 'package:air/util/platform.dart'
-    show getClipboardFilePaths, getClipboardImage, PlatformExtension;
+    show
+        ClipboardImage,
+        getClipboardFilePaths,
+        getClipboardImage,
+        PlatformExtension;
 
 import 'message_renderer.dart';
 import 'text_message_tile.dart' show messageHorizontalPadding;
@@ -415,9 +419,9 @@ class _MessageComposerState extends State<MessageComposer>
       return;
     }
 
-    final imageBytes = await getClipboardImage();
-    if (imageBytes != null && imageBytes.isNotEmpty) {
-      _handleImagePaste(imageBytes);
+    final image = await getClipboardImage();
+    if (image != null && image.bytes.isNotEmpty) {
+      _handleImagePaste(image);
       return;
     }
     // No image — fall back to text paste
@@ -531,14 +535,15 @@ class _MessageComposerState extends State<MessageComposer>
     _navigateToUploadPreview(context, file, chatTitle: chatTitle);
   }
 
-  void _handleImagePaste(Uint8List imageBytes) async {
+  void _handleImagePaste(ClipboardImage image) async {
     final chatTitle = _chatDetailsCubit.state.chat?.title;
     if (chatTitle == null) return;
 
+    final ext = image.mimeType.split('/').last;
     final tempDir = await getTemporaryDirectory();
-    final tempFile = File('${tempDir.path}/clipboard_paste.jpg');
-    await tempFile.writeAsBytes(imageBytes);
-    final file = XFile(tempFile.path);
+    final tempFile = File('${tempDir.path}/clipboard_paste.$ext');
+    await tempFile.writeAsBytes(image.bytes);
+    final file = XFile(tempFile.path, mimeType: image.mimeType);
 
     if (!mounted) return;
     await _navigateToUploadPreview(
@@ -669,7 +674,7 @@ class _MessageInput extends StatelessWidget {
   final LayerLink layerLink;
   final GlobalKey inputKey;
   final VoidCallback onSubmitMessage;
-  final ValueChanged<Uint8List> onImagePasted;
+  final ValueChanged<ClipboardImage> onImagePasted;
   final ValueChanged<String> onFilePasted;
   final ValueChanged<KeyboardInsertedContent> onContentInserted;
 
@@ -839,10 +844,10 @@ class _MessageInput extends StatelessWidget {
               onFilePasted(filePaths.first);
               return;
             }
-            final imageBytes = await getClipboardImage();
-            if (imageBytes != null && imageBytes.isNotEmpty) {
+            final image = await getClipboardImage();
+            if (image != null && image.bytes.isNotEmpty) {
               editableTextState.hideToolbar();
-              onImagePasted(imageBytes);
+              onImagePasted(image);
               return;
             }
             // No image — default text paste
@@ -866,10 +871,10 @@ class _MessageInput extends StatelessWidget {
               onFilePasted(filePaths.first);
               return;
             }
-            final imageBytes = await getClipboardImage();
-            if (imageBytes != null && imageBytes.isNotEmpty) {
+            final image = await getClipboardImage();
+            if (image != null && image.bytes.isNotEmpty) {
               editableTextState.hideToolbar();
-              onImagePasted(imageBytes);
+              onImagePasted(image);
             }
           },
         ),

--- a/app/lib/util/platform.dart
+++ b/app/lib/util/platform.dart
@@ -146,11 +146,19 @@ Future<List<String>?> getClipboardFilePaths() async {
   return null;
 }
 
-Future<Uint8List?> getClipboardImage() async {
+typedef ClipboardImage = ({Uint8List bytes, String mimeType});
+
+Future<ClipboardImage?> getClipboardImage() async {
   if (Platform.isIOS || Platform.isAndroid) {
     try {
-      final bytes = await platform.invokeMethod<Uint8List>('getClipboardImage');
-      return bytes;
+      final map = await platform.invokeMapMethod<String, dynamic>(
+        'getClipboardImage',
+      );
+      if (map == null) return null;
+      final bytes = map['bytes'] as Uint8List?;
+      final mimeType = map['mimeType'] as String?;
+      if (bytes == null || mimeType == null) return null;
+      return (bytes: bytes, mimeType: mimeType);
     } on PlatformException catch (e, stacktrace) {
       _log.severe(
         "Failed to get clipboard image: '${e.message}'.",
@@ -160,7 +168,10 @@ Future<Uint8List?> getClipboardImage() async {
     }
   } else if (Platform.isMacOS || Platform.isWindows || Platform.isLinux) {
     try {
-      return await rust_utils.readClipboardImage();
+      final bytes = await rust_utils.readClipboardImage();
+      if (bytes == null) return null;
+      // Desktop path re-encodes to PNG (lossless, alpha-preserving).
+      return (bytes: bytes, mimeType: 'image/png');
     } catch (e, stacktrace) {
       _log.severe("Failed to get clipboard image: '$e'.", e, stacktrace);
     }

--- a/applogic/src/api/utils.rs
+++ b/applogic/src/api/utils.rs
@@ -50,7 +50,7 @@ pub fn read_clipboard_file_paths() -> Option<Vec<String>> {
     }
 }
 
-/// Reads an image from the system clipboard and returns it as JPEG bytes. Only
+/// Reads an image from the system clipboard and returns it as PNG bytes. Only
 /// supported on desktop platforms (Linux, Windows, macOS).
 ///
 /// Returns `None` if the clipboard does not contain image data, or when called
@@ -59,22 +59,25 @@ pub fn read_clipboard_image() -> Option<Vec<u8>> {
     // arboard is only supported on desktop platforms
     #[cfg(any(target_os = "linux", target_os = "windows", target_os = "macos"))]
     {
-        use image::codecs::jpeg::JpegEncoder;
-        use std::io::Cursor;
+        use image::ImageEncoder;
+        use image::codecs::png::PngEncoder;
 
         let mut clipboard = arboard::Clipboard::new().ok()?;
         let img_data = clipboard.get_image().ok()?;
 
-        let rgba = image::RgbaImage::from_raw(
-            img_data.width as u32,
-            img_data.height as u32,
-            img_data.bytes.into_owned(),
-        )?;
+        let width = img_data.width as u32;
+        let height = img_data.height as u32;
+        let rgba = image::RgbaImage::from_raw(width, height, img_data.bytes.into_owned())?;
 
         let mut buf = Vec::new();
-        let mut cursor = Cursor::new(&mut buf);
-        let mut encoder = JpegEncoder::new_with_quality(&mut cursor, 99);
-        encoder.encode_image(&rgba).ok()?;
+        PngEncoder::new(&mut buf)
+            .write_image(
+                rgba.as_raw(),
+                width,
+                height,
+                image::ExtendedColorType::Rgba8,
+            )
+            .ok()?;
 
         Some(buf)
     }


### PR DESCRIPTION
With this fix, we no longer flatten animated images from the clipboard on Android and iOS.
For formats like HEIC, where we have a double conversion, we now use PNG as the intermediary format.

Note that this does not apply to desktop platforms. The fix there would be more involved, while the likelihood of users pasting the contents of files rather than the file path is rather slim.