### PR TITLE
chore(ci): platform code warnings

### DIFF
--- a/.github/workflows/android_build.yml
+++ b/.github/workflows/android_build.yml
@@ -17,6 +17,7 @@ env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0
   SQLX_OFFLINE: true
+  RUSTFLAGS: "-D warnings"
 
 jobs:
   android-build:

--- a/.github/workflows/ios_build.yml
+++ b/.github/workflows/ios_build.yml
@@ -17,6 +17,7 @@ env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0
   SQLX_OFFLINE: true
+  RUSTFLAGS: "-D warnings"
 
 jobs:
   ios-build:

--- a/.github/workflows/macos_build.yml
+++ b/.github/workflows/macos_build.yml
@@ -17,6 +17,7 @@ env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0
   SQLX_OFFLINE: true
+  RUSTFLAGS: "-D warnings"
 
 jobs:
   macos-build:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -17,6 +17,7 @@ env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0
   SQLX_OFFLINE: true
+  RUSTFLAGS: "-D warnings"
 
 jobs:
   windows-build:

--- a/applogic/src/background_execution/java_api.rs
+++ b/applogic/src/background_execution/java_api.rs
@@ -21,7 +21,7 @@ pub extern "C" fn process_new_messages(
     // Convert Java string to Rust string
     let input: String = match env.get_string(&content) {
         Ok(value) => value.into(),
-        Err(error) => {
+        Err(_error) => {
             let _ = env.throw_new(
                 "java/lang/IllegalArgumentException",
                 "Failed to read content string from Java",
@@ -44,6 +44,7 @@ pub extern "C" fn process_new_messages(
     let response = match serde_json::to_string(&batch) {
         Ok(json) => json,
         Err(error) => {
+            error!(%error, "Failed to serialize notification batch");
             let _ = env.throw_new(
                 "java/lang/RuntimeException",
                 "Failed to serialize notification batch",
@@ -55,7 +56,8 @@ pub extern "C" fn process_new_messages(
     // Convert Rust string back to Java string
     match env.new_string(response) {
         Ok(output) => output.into_raw(),
-        Err(_error) => {
+        Err(error) => {
+            error!(%error, "Failed to create Java string from Rust");
             let _ = env.throw_new(
                 "java/lang/RuntimeException",
                 "Failed to create Java string from Rust",


### PR DESCRIPTION
Enables warnings for Rust builds on all platforms (and fixes said warnings).