### PR TITLE
fix(ci): fix upload linux packages work dir

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -113,6 +113,7 @@ jobs:
             | awk -F: '/^grp:/ {print $10}')
 
       - name: Upload packages
+        working-directory: app/linux
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
The glob air-*.rpm found nothing because the working directory was the
root of the repository. The packages are built in the app/linux
directory though.