### PR TITLE
fix(app): fix for SwiftKey "send with ENTER"

### DIFF
--- a/app/lib/message_list/message_composer.dart
+++ b/app/lib/message_list/message_composer.dart
@@ -379,6 +379,10 @@ class _MessageComposerState extends State<MessageComposer>
         HardwareKeyboard.instance.isMetaPressed ||
         HardwareKeyboard.instance.isControlPressed;
 
+    // On desktop, Enter always sends (Shift+Enter inserts newline via the
+    // modifier check above). On mobile, ignore Enter key events entirely:
+    // sending is handled by onEditingComplete (IME callback),
+    // which hardware USB keyboards also use/go through on Android.
     if (!modifierKeyPressed &&
         evt.logicalKey == LogicalKeyboardKey.enter &&
         evt is KeyDownEvent &&

--- a/app/lib/message_list/message_composer.dart
+++ b/app/lib/message_list/message_composer.dart
@@ -381,7 +381,8 @@ class _MessageComposerState extends State<MessageComposer>
 
     if (!modifierKeyPressed &&
         evt.logicalKey == LogicalKeyboardKey.enter &&
-        evt is KeyDownEvent) {
+        evt is KeyDownEvent &&
+        PlatformExtension.isDesktop) {
       final chatDetailsCubit = context.read<ChatDetailsCubit>();
       _submitMessage(chatDetailsCubit);
       return KeyEventResult.handled;


### PR DESCRIPTION
In Flutter, onKeyEvent listeners are not supposed to receive events from software keyboards, but SwiftKey does send it as a physical keyboard on Android (bad SwiftKey!).

Adding a guard to check if we're on a desktop computer is a good workaround for the time being IMO.

On Android, physical keyboards still go through the IME (for auto-complete functionalities) which means we don't have another behaviour to cover here.

I tested this fix with SwiftKey 9.12.29.12 and a Keychron K14 physical keyboard connected in Bluetooth.