### PR TITLE
fix(app): fix leave cleanup bug

### DIFF
--- a/coreclient/src/groups/process.rs
+++ b/coreclient/src/groups/process.rs
@@ -158,8 +158,11 @@ impl Group {
                 {
                     let commit_contains_our_self_remove =
                         staged_commit.queued_proposals().any(|p| {
+                            let Sender::Member(proposal_sender_index) = p.sender() else {
+                                return false;
+                            };
                             matches!(p.proposal(), Proposal::SelfRemove)
-                                && sender_index == self.mls_group().own_leaf_index()
+                                && proposal_sender_index == &self.mls_group().own_leaf_index()
                         });
                     if !pending_chat_operation.is_leave() || commit_contains_our_self_remove {
                         PendingChatOperation::delete(&mut *txn, &group_id).await?;

--- a/server/tests/tests/jobs.rs
+++ b/server/tests/tests/jobs.rs
@@ -316,3 +316,45 @@ async fn leave_with_wrong_epoch_applies_locally_and_keeps_pending() {
         "pending operation should be deleted after successful retry"
     );
 }
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn pending_leave_is_deleted_when_another_member_commits_self_remove() {
+    let (setup, alice, bob, _charlie, chat_id) = setup_group_with_contacts().await;
+    let alice_user = &setup.get_user(&alice).user;
+    let bob_user = &setup.get_user(&bob).user;
+
+    setup.listener_control_handle().set_drop_next_response();
+    alice_user.leave_chat(chat_id).await.unwrap();
+
+    let pending = alice_user
+        .pending_chat_operation_info(chat_id)
+        .await
+        .unwrap()
+        .expect("pending leave should remain after dropped response");
+    assert_eq!(pending.operation_type, "leave");
+
+    let qs_messages = bob_user.qs_fetch_messages().await.unwrap();
+    let result = bob_user.fully_process_qs_messages(qs_messages).await;
+    assert!(
+        result.errors.is_empty(),
+        "Bob should process Alice's self-remove proposal without errors"
+    );
+
+    bob_user.update_key(chat_id).await.unwrap();
+
+    let qs_messages = alice_user.qs_fetch_messages().await.unwrap();
+    let result = alice_user.fully_process_qs_messages(qs_messages).await;
+    assert!(
+        result.errors.is_empty(),
+        "Alice should process Bob's commit without errors"
+    );
+
+    let pending_after = alice_user
+        .pending_chat_operation_info(chat_id)
+        .await
+        .unwrap();
+    assert!(
+        pending_after.is_none(),
+        "pending leave should be deleted once another member commits our self-remove"
+    );
+}


### PR DESCRIPTION
In cases where we missed the immediate DS response, clients would check the wrong index when looking for their own leave proposal in a commit. This PR fixes that and adds a test.