### PR TITLE
fix(test): flaky outbound service test

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -7,15 +7,19 @@ experimental = ["setup-scripts"]
 # unit tests
 [profile.unit]
 default-filter = "not binary(integration)"
+fail-fast = false
 junit = { path = "junit.xml" }
 
 # integration tests
 [profile.integration]
 default-filter = "binary(integration)"
+fail-fast = false
 junit = { path = "junit.xml" }
 
+# integration tests (with APQ enabled for all tests)
 [profile.integration-with-apq]
 default-filter = "binary(integration)"
+fail-fast = false
 junit = { path = "junit.xml" }
 
 [scripts.setup.enable-apq]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,3 +185,4 @@ jobs:
           name: ${{ matrix.name }}
           path: target/nextest/${{ matrix.profile }}/junit.xml
           reporter: java-junit
+          fail-on-error: false

--- a/coreclient/src/clients/mod.rs
+++ b/coreclient/src/clients/mod.rs
@@ -607,7 +607,10 @@ impl CoreUser {
     > {
         let queue_ratchet = StorableQsQueueRatchet::load(self.db().read().await?).await?;
         let sequence_number_start = queue_ratchet.sequence_number();
-        info!(sequence_number_start, "listening to QS queue from sequence number");
+        info!(
+            sequence_number_start,
+            "listening to QS queue from sequence number"
+        );
         let api_client = self.inner.api_clients.default_client()?;
         let client_signing_key = &self.inner.key_store.qs_client_signing_key;
         let (stream, responder) = api_client

--- a/coreclient/src/clients/mod.rs
+++ b/coreclient/src/clients/mod.rs
@@ -607,6 +607,7 @@ impl CoreUser {
     > {
         let queue_ratchet = StorableQsQueueRatchet::load(self.db().read().await?).await?;
         let sequence_number_start = queue_ratchet.sequence_number();
+        info!(sequence_number_start, "listening to QS queue from sequence number");
         let api_client = self.inner.api_clients.default_client()?;
         let client_signing_key = &self.inner.key_store.qs_client_signing_key;
         let (stream, responder) = api_client

--- a/coreclient/src/clients/process/process_qs.rs
+++ b/coreclient/src/clients/process/process_qs.rs
@@ -1176,6 +1176,7 @@ impl CoreUser {
     ) -> anyhow::Result<()> {
         let qs_message_payload = StorableQsQueueRatchet::decrypt_qs_queue_message(txn, qs_message)
             .await
+            .inspect_err(|error| error!(%error, "QS queue message decryption failed"))
             .context("Decrypting message failed")?;
         let qs_message_plaintext = match qs_message_payload.extract() {
             Ok(extracted) => extracted,

--- a/coreclient/src/outbound_service/mod.rs
+++ b/coreclient/src/outbound_service/mod.rs
@@ -451,11 +451,9 @@ mod test {
         let context = DelayedCounterContext::default();
         let service = OutboundService::with_context(context.clone(), global_lock());
 
-        service.start().await;
-        sleep(Duration::from_millis(100)).await; // +1
-        service.notify_work();
-        sleep(Duration::from_millis(100)).await; // +1
-        service.notify_work();
+        service.start().await; // +1 => counter = 1
+        service.notify_work().await; // +1 => counter = 2
+        service.notify_work(); // asynchronously
         timeout(Duration::from_millis(100), service.stop())
             .await
             .unwrap(); // cancelled


### PR DESCRIPTION
We have 2 flaky tests:

* `aircoreclient::outbound_service::stop_and_wait`
* `integration::tests::process::process_qs_messages_cancellation_safety`

The first is not deterministic because it relies on a cancellation during a
timeout. It was changed to be deterministic.

The second is not reproducible locally. Instead of fixing it, there is now more
logging for the sequence number of the QS queue.

Additionally don't fail fast in CI tests to collect all failing tests.