### PR TITLE
fix(app): more granular fails during self-update

### DIFF
--- a/app/macos/Podfile.lock
+++ b/app/macos/Podfile.lock
@@ -14,7 +14,7 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral
 
 SPEC CHECKSUMS:
-  airapplogic: 05eeef9c81bfbcb9ee695ce8041b1d3c34e6310a
+  airapplogic: 771c36a647af7daa7625dac9637abf1853c5b549
   FlutterMacOS: d0db08ddef1a9af05a5ec4b724367152bb0500b1
 
 PODFILE CHECKSUM: ef2a2c38c4c8d76a07ab60f845d4062e841ebd54

--- a/coreclient/src/outbound_service/timed_tasks.rs
+++ b/coreclient/src/outbound_service/timed_tasks.rs
@@ -682,12 +682,17 @@ impl OutboundServiceContext {
 
         match res {
             Ok(_messages) => Ok(true),
+            // A network error is likely something transient that would affect
+            // all chats, so we return the error to retry the task with backoff.
+            Err(error @ JobError::NetworkError) => Err(error.into()),
+            // The operation is no longer applicable to this chat, so we skip
+            // it.
             Err(JobError::NotFound | JobError::Blocked) => Ok(false),
-            // Fatal or network errors abort the whole batch because we assume that they will
-            // persist for the next chat in the batch.
-            Err(error @ (JobError::Fatal(_) | JobError::NetworkError | JobError::Domain(_))) => {
-                debug!(?chat_id, %error, "Failed to self-update in chat");
-                Err(error.into())
+            // Any other failure is specific to this chat, so we log and skip
+            // it, but continue with the rest of the batch.
+            Err(error) => {
+                warn!(?chat_id, %error, "Skipping self-update in chat due to unexpected error");
+                Ok(false)
             }
         }
     }


### PR DESCRIPTION
Fixes a bug where the self-update operation would fail the whole batch instead of just failing a specific self-update. Reoccuring problems at the beginning of the batch would forever block the rest of the batch.
One such instance could have been an issue with self-updates in older groups that don't have an app data component. The update would fail and block the migration of the group chats.