### PR TITLE
fix(app): fix notifications on GNOME 46+

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,6 +145,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
+ "zbus",
 ]
 
 [[package]]

--- a/app/linux/nfpm.yaml
+++ b/app/linux/nfpm.yaml
@@ -17,17 +17,17 @@ license: "AGPL-3.0-or-later"
 overrides:
   rpm:
     contents:
-      - src: ../build/linux/x64/debug/bundle/air
+      - src: ../build/linux/x64/release/bundle/air
         dst: /usr/lib64/air/air
         file_info:
           mode: 0755
       - src: /usr/lib64/air/air
         dst: /usr/bin/air
         type: symlink
-      - src: ../build/linux/x64/debug/bundle/data
+      - src: ../build/linux/x64/release/bundle/data
         dst: /usr/lib64/air/data
         type: tree
-      - src: ../build/linux/x64/debug/bundle/lib
+      - src: ../build/linux/x64/release/bundle/lib
         dst: /usr/lib64/air/lib
         type: tree
       - src: ./ms.air.desktop
@@ -42,17 +42,17 @@ overrides:
       - gtk3 >= 3.24.51
   deb:
     contents:
-      - src: ../build/linux/x64/debug/bundle/air
+      - src: ../build/linux/x64/release/bundle/air
         dst: /usr/lib/x86_64-linux-gnu/air/air
         file_info:
           mode: 0755
       - src: /usr/lib/x86_64-linux-gnu/air/air
         dst: /usr/bin/air
         type: symlink
-      - src: ../build/linux/x64/debug/bundle/data
+      - src: ../build/linux/x64/release/bundle/data
         dst: /usr/lib/x86_64-linux-gnu/air/data
         type: tree
-      - src: ../build/linux/x64/debug/bundle/lib
+      - src: ../build/linux/x64/release/bundle/lib
         dst: /usr/lib/x86_64-linux-gnu/air/lib
         type: tree
       - src: ./ms.air.desktop

--- a/app/linux/nfpm.yaml
+++ b/app/linux/nfpm.yaml
@@ -17,17 +17,17 @@ license: "AGPL-3.0-or-later"
 overrides:
   rpm:
     contents:
-      - src: ../build/linux/x64/release/bundle/air
+      - src: ../build/linux/x64/debug/bundle/air
         dst: /usr/lib64/air/air
         file_info:
           mode: 0755
       - src: /usr/lib64/air/air
         dst: /usr/bin/air
         type: symlink
-      - src: ../build/linux/x64/release/bundle/data
+      - src: ../build/linux/x64/debug/bundle/data
         dst: /usr/lib64/air/data
         type: tree
-      - src: ../build/linux/x64/release/bundle/lib
+      - src: ../build/linux/x64/debug/bundle/lib
         dst: /usr/lib64/air/lib
         type: tree
       - src: ./ms.air.desktop
@@ -42,17 +42,17 @@ overrides:
       - gtk3 >= 3.24.51
   deb:
     contents:
-      - src: ../build/linux/x64/release/bundle/air
+      - src: ../build/linux/x64/debug/bundle/air
         dst: /usr/lib/x86_64-linux-gnu/air/air
         file_info:
           mode: 0755
       - src: /usr/lib/x86_64-linux-gnu/air/air
         dst: /usr/bin/air
         type: symlink
-      - src: ../build/linux/x64/release/bundle/data
+      - src: ../build/linux/x64/debug/bundle/data
         dst: /usr/lib/x86_64-linux-gnu/air/data
         type: tree
-      - src: ../build/linux/x64/release/bundle/lib
+      - src: ../build/linux/x64/debug/bundle/lib
         dst: /usr/lib/x86_64-linux-gnu/air/lib
         type: tree
       - src: ./ms.air.desktop

--- a/applogic/Cargo.toml
+++ b/applogic/Cargo.toml
@@ -63,19 +63,18 @@ uuid = { workspace = true, features = ["v4"] }
 [target.'cfg(any(target_os = "android", target_os = "ios"))'.dependencies]
 libc = "0.2" # required for stack size in background execution on Android/iOS
 
-[target.'cfg(any(target_os = "windows"))'.dependencies]
+[target.'cfg(target_os = "windows")'.dependencies]
 notify-rust = "4"
-
-[target.'cfg(any(target_os = "linux"))'.dependencies]
-zbus = "5"
 
 # arboard is only supported on desktop platforms, so we only include it for
 # those targets. On Linux, we also want the wayland-data-control feature for
 # clipboard support in Wayland sessions.
 [target.'cfg(any(target_os = "windows", target_os = "macos"))'.dependencies]
 arboard = { workspace = true }
+
 [target.'cfg(target_os = "linux")'.dependencies]
 arboard = { workspace = true, features = ["wayland-data-control"] }
+zbus = "5"
 
 [dev-dependencies]
 mockall.workspace = true

--- a/applogic/Cargo.toml
+++ b/applogic/Cargo.toml
@@ -63,8 +63,11 @@ uuid = { workspace = true, features = ["v4"] }
 [target.'cfg(any(target_os = "android", target_os = "ios"))'.dependencies]
 libc = "0.2" # required for stack size in background execution on Android/iOS
 
-[target.'cfg(any(target_os = "linux", target_os = "windows"))'.dependencies]
+[target.'cfg(any(target_os = "windows"))'.dependencies]
 notify-rust = "4"
+
+[target.'cfg(any(target_os = "linux"))'.dependencies]
+zbus = "5"
 
 # arboard is only supported on desktop platforms, so we only include it for
 # those targets. On Linux, we also want the wayland-data-control feature for

--- a/applogic/src/notifications.rs
+++ b/applogic/src/notifications.rs
@@ -122,12 +122,6 @@ impl NotificationId {
     }
 }
 
-impl fmt::Display for NotificationId {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.0.fmt(f)
-    }
-}
-
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct NotificationContent {

--- a/applogic/src/notifications.rs
+++ b/applogic/src/notifications.rs
@@ -2,8 +2,12 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+use core::fmt;
+
 use aircoreclient::{ChatId, ChatMessage, ChatType};
 use serde::{Deserialize, Serialize};
+#[cfg(any(target_os = "linux"))]
+use tracing::error;
 use uuid::Uuid;
 
 use crate::api::{notifications::DartNotificationService, user::User};
@@ -118,6 +122,12 @@ impl NotificationId {
     }
 }
 
+impl fmt::Display for NotificationId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct NotificationContent {
@@ -137,6 +147,8 @@ pub struct NotificationHandle {
 pub(crate) struct NotificationService {
     #[cfg(any(target_os = "ios", target_os = "android", target_os = "macos"))]
     dart_service: DartNotificationService,
+    #[cfg(any(target_os = "linux"))]
+    zbus_connection: Option<zbus::blocking::Connection>,
 }
 
 impl NotificationService {
@@ -145,22 +157,82 @@ impl NotificationService {
         Self {
             #[cfg(any(target_os = "ios", target_os = "android", target_os = "macos"))]
             dart_service,
+            #[cfg(any(target_os = "linux"))]
+            zbus_connection: zbus::blocking::Connection::session()
+                .inspect_err(|error| error!(%error, "failed to connect to DBus"))
+                .ok(),
         }
     }
 
     pub(crate) async fn show_notification(&self, notification: NotificationContent) {
         #[cfg(any(target_os = "ios", target_os = "android", target_os = "macos"))]
         self.dart_service.send_notification(notification).await;
-        #[cfg(any(target_os = "linux", target_os = "windows"))]
+        #[cfg(any(target_os = "windows"))]
         {
             if let Err(error) = notify_rust::Notification::new()
                 .summary(notification.title.as_str())
                 .body(notification.body.as_str())
                 .show()
             {
-                tracing::error!(%error, "Failed to send desktop notification");
+                error!(%error, "Failed to send desktop notification");
             }
         }
+        #[cfg(any(target_os = "linux"))]
+        if let Err(error) = self.send_xdg_portal_notification(notification) {
+            error!(%error, "Failed to send desktop notification");
+        }
+    }
+
+    // notify-rusty v4 does not set the sender-pid hint, which is required for GNOME 46+ compatibility.
+    // doing it manually also lets us enable notifications grouping per chat
+    //
+    // the future is to use the XDG Portal API instead, but it is only supported (not buggy) on GNOME 46+
+    // and does not support notifications grouping. It also currently has sparse support on
+    // other Desktop Environments.
+    #[cfg(any(target_os = "linux"))]
+    pub(crate) fn send_xdg_portal_notification(
+        &self,
+        NotificationContent {
+            chat_id,
+            title,
+            body,
+            ..
+        }: NotificationContent,
+    ) -> anyhow::Result<()> {
+        use std::collections::HashMap;
+
+        use zbus::{blocking::Proxy, zvariant::Value};
+
+        let Some(zbus_connection) = self.zbus_connection.as_ref() else {
+            return Ok(());
+        };
+        let proxy = Proxy::new(
+            zbus_connection,
+            "org.freedesktop.Notifications",
+            "/org/freedesktop/Notifications",
+            "org.freedesktop.Notifications",
+        )?;
+
+        let mut hints: HashMap<&str, Value> = HashMap::new();
+        // for GNOME 46+ compatibility
+        hints.insert("sender-pid", std::process::id().into());
+        hints.insert("x-gnome-stack-group", format!("air-chat-{chat_id}").into());
+
+        proxy.call_method(
+            "Notify",
+            &(
+                "Air",              // app_name
+                0u32,               // replaces_id
+                "ms.air",           // icon
+                title,              // summary
+                body,               // body
+                Vec::<&str>::new(), // actions
+                hints,
+                -1i32, // timeout (-1 = default)
+            ),
+        )?;
+
+        Ok(())
     }
 
     pub(crate) async fn get_active_notifications(&self) -> Vec<NotificationHandle> {

--- a/applogic/src/notifications.rs
+++ b/applogic/src/notifications.rs
@@ -2,12 +2,8 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-use core::fmt;
-
 use aircoreclient::{ChatId, ChatMessage, ChatType};
 use serde::{Deserialize, Serialize};
-#[cfg(any(target_os = "linux"))]
-use tracing::error;
 use uuid::Uuid;
 
 use crate::api::{notifications::DartNotificationService, user::User};
@@ -141,7 +137,7 @@ pub struct NotificationHandle {
 pub(crate) struct NotificationService {
     #[cfg(any(target_os = "ios", target_os = "android", target_os = "macos"))]
     dart_service: DartNotificationService,
-    #[cfg(any(target_os = "linux"))]
+    #[cfg(target_os = "linux")]
     zbus_connection: Option<zbus::blocking::Connection>,
 }
 
@@ -151,9 +147,9 @@ impl NotificationService {
         Self {
             #[cfg(any(target_os = "ios", target_os = "android", target_os = "macos"))]
             dart_service,
-            #[cfg(any(target_os = "linux"))]
+            #[cfg(target_os = "linux")]
             zbus_connection: zbus::blocking::Connection::session()
-                .inspect_err(|error| error!(%error, "failed to connect to DBus"))
+                .inspect_err(|error| tracing::error!(%error, "failed to connect to D-Bus"))
                 .ok(),
         }
     }
@@ -161,19 +157,19 @@ impl NotificationService {
     pub(crate) async fn show_notification(&self, notification: NotificationContent) {
         #[cfg(any(target_os = "ios", target_os = "android", target_os = "macos"))]
         self.dart_service.send_notification(notification).await;
-        #[cfg(any(target_os = "windows"))]
+        #[cfg(target_os = "windows")]
         {
             if let Err(error) = notify_rust::Notification::new()
                 .summary(notification.title.as_str())
                 .body(notification.body.as_str())
                 .show()
             {
-                error!(%error, "Failed to send desktop notification");
+                tracing::error!(%error, "Failed to send desktop notification");
             }
         }
-        #[cfg(any(target_os = "linux"))]
+        #[cfg(target_os = "linux")]
         if let Err(error) = self.send_xdg_portal_notification(notification) {
-            error!(%error, "Failed to send desktop notification");
+            tracing::error!(%error, "Failed to send desktop notification");
         }
     }
 
@@ -183,7 +179,7 @@ impl NotificationService {
     // The future is to use the XDG Portal API instead, but it is only supported (= not buggy) on GNOME 46+
     // and does not support notifications grouping. It also currently has sparse support on
     // other Desktop Environments.
-    #[cfg(any(target_os = "linux"))]
+    #[cfg(target_os = "linux")]
     pub(crate) fn send_xdg_portal_notification(
         &self,
         NotificationContent {

--- a/applogic/src/notifications.rs
+++ b/applogic/src/notifications.rs
@@ -177,10 +177,10 @@ impl NotificationService {
         }
     }
 
-    // notify-rusty v4 does not set the sender-pid hint, which is required for GNOME 46+ compatibility.
-    // doing it manually also lets us enable notifications grouping per chat
+    // Version 4.x of `notify-rust` does not set the `sender-pid` hint, which is required for GNOME 46+ compatibility.
+    // Doing it manually also lets us enable notifications grouping per chat.
     //
-    // the future is to use the XDG Portal API instead, but it is only supported (not buggy) on GNOME 46+
+    // The future is to use the XDG Portal API instead, but it is only supported (= not buggy) on GNOME 46+
     // and does not support notifications grouping. It also currently has sparse support on
     // other Desktop Environments.
     #[cfg(any(target_os = "linux"))]


### PR DESCRIPTION
Replaces the `notify-rust` notification path on Linux with a manual D-Bus call via `zbus` (the library that was already in our dependencies tree). `notify-rust` v4 does not set the `sender-pid` hint, which GNOME 46+ requires to display notifications.

The manual implementation also adds the ``x-gnome-stack-group` hint to group notifications per chat. Windows continues to use notify-rust unchanged.

Tested on GNOME 46+ with the installed app (this is important, it has to be launched from the `.desktop` file, which is also what a launcher like `dmenu` alos does) and I can see the notification correctly, with the Air icon.

API reference: https://specifications.freedesktop.org/notification/1.3/

<img width="789" height="232" alt="Screenshot From 2026-06-01 12-00-28" src="https://github.com/user-attachments/assets/c6f6fc71-cc2e-4727-9610-32440014b0c7" />
