### PR TITLE
fix(app): enable current Air features on group update

### DIFF
--- a/app/lib/chat/add_members_cubit.dart
+++ b/app/lib/chat/add_members_cubit.dart
@@ -15,12 +15,15 @@ sealed class AddMembersState with _$AddMembersState {
   const factory AddMembersState({
     required List<UiContact> contacts,
     required Set<UiUserId> selectedContacts,
+    required bool isApq,
   }) = _AddMembersState;
 }
 
 class AddMembersCubit extends Cubit<AddMembersState> {
   AddMembersCubit()
-    : super(const AddMembersState(contacts: [], selectedContacts: {}));
+    : super(
+        const AddMembersState(contacts: [], selectedContacts: {}, isApq: false),
+      );
 
   void loadContacts(Future<List<UiContact>> futureContacts) async {
     final contacts = await futureContacts;
@@ -35,5 +38,9 @@ class AddMembersCubit extends Cubit<AddMembersState> {
       selectedContacts.add(userId);
     }
     emit(state.copyWith(selectedContacts: selectedContacts));
+  }
+
+  void enableApq(bool isApq) {
+    emit(state.copyWith(isApq: isApq));
   }
 }

--- a/app/lib/chat/add_members_cubit.freezed.dart
+++ b/app/lib/chat/add_members_cubit.freezed.dart
@@ -14,7 +14,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$AddMembersState {
 
- List<UiContact> get contacts; Set<UiUserId> get selectedContacts;
+ List<UiContact> get contacts; Set<UiUserId> get selectedContacts; bool get isApq;
 /// Create a copy of AddMembersState
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -25,16 +25,16 @@ $AddMembersStateCopyWith<AddMembersState> get copyWith => _$AddMembersStateCopyW
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is AddMembersState&&const DeepCollectionEquality().equals(other.contacts, contacts)&&const DeepCollectionEquality().equals(other.selectedContacts, selectedContacts));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is AddMembersState&&const DeepCollectionEquality().equals(other.contacts, contacts)&&const DeepCollectionEquality().equals(other.selectedContacts, selectedContacts)&&(identical(other.isApq, isApq) || other.isApq == isApq));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(contacts),const DeepCollectionEquality().hash(selectedContacts));
+int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(contacts),const DeepCollectionEquality().hash(selectedContacts),isApq);
 
 @override
 String toString() {
-  return 'AddMembersState(contacts: $contacts, selectedContacts: $selectedContacts)';
+  return 'AddMembersState(contacts: $contacts, selectedContacts: $selectedContacts, isApq: $isApq)';
 }
 
 
@@ -45,7 +45,7 @@ abstract mixin class $AddMembersStateCopyWith<$Res>  {
   factory $AddMembersStateCopyWith(AddMembersState value, $Res Function(AddMembersState) _then) = _$AddMembersStateCopyWithImpl;
 @useResult
 $Res call({
- List<UiContact> contacts, Set<UiUserId> selectedContacts
+ List<UiContact> contacts, Set<UiUserId> selectedContacts, bool isApq
 });
 
 
@@ -62,11 +62,12 @@ class _$AddMembersStateCopyWithImpl<$Res>
 
 /// Create a copy of AddMembersState
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? contacts = null,Object? selectedContacts = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? contacts = null,Object? selectedContacts = null,Object? isApq = null,}) {
   return _then(_self.copyWith(
 contacts: null == contacts ? _self.contacts : contacts // ignore: cast_nullable_to_non_nullable
 as List<UiContact>,selectedContacts: null == selectedContacts ? _self.selectedContacts : selectedContacts // ignore: cast_nullable_to_non_nullable
-as Set<UiUserId>,
+as Set<UiUserId>,isApq: null == isApq ? _self.isApq : isApq // ignore: cast_nullable_to_non_nullable
+as bool,
   ));
 }
 
@@ -78,7 +79,7 @@ as Set<UiUserId>,
 
 
 class _AddMembersState implements AddMembersState {
-  const _AddMembersState({required final  List<UiContact> contacts, required final  Set<UiUserId> selectedContacts}): _contacts = contacts,_selectedContacts = selectedContacts;
+  const _AddMembersState({required final  List<UiContact> contacts, required final  Set<UiUserId> selectedContacts, required this.isApq}): _contacts = contacts,_selectedContacts = selectedContacts;
   
 
  final  List<UiContact> _contacts;
@@ -95,6 +96,7 @@ class _AddMembersState implements AddMembersState {
   return EqualUnmodifiableSetView(_selectedContacts);
 }
 
+@override final  bool isApq;
 
 /// Create a copy of AddMembersState
 /// with the given fields replaced by the non-null parameter values.
@@ -106,16 +108,16 @@ _$AddMembersStateCopyWith<_AddMembersState> get copyWith => __$AddMembersStateCo
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _AddMembersState&&const DeepCollectionEquality().equals(other._contacts, _contacts)&&const DeepCollectionEquality().equals(other._selectedContacts, _selectedContacts));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _AddMembersState&&const DeepCollectionEquality().equals(other._contacts, _contacts)&&const DeepCollectionEquality().equals(other._selectedContacts, _selectedContacts)&&(identical(other.isApq, isApq) || other.isApq == isApq));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(_contacts),const DeepCollectionEquality().hash(_selectedContacts));
+int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(_contacts),const DeepCollectionEquality().hash(_selectedContacts),isApq);
 
 @override
 String toString() {
-  return 'AddMembersState(contacts: $contacts, selectedContacts: $selectedContacts)';
+  return 'AddMembersState(contacts: $contacts, selectedContacts: $selectedContacts, isApq: $isApq)';
 }
 
 
@@ -126,7 +128,7 @@ abstract mixin class _$AddMembersStateCopyWith<$Res> implements $AddMembersState
   factory _$AddMembersStateCopyWith(_AddMembersState value, $Res Function(_AddMembersState) _then) = __$AddMembersStateCopyWithImpl;
 @override @useResult
 $Res call({
- List<UiContact> contacts, Set<UiUserId> selectedContacts
+ List<UiContact> contacts, Set<UiUserId> selectedContacts, bool isApq
 });
 
 
@@ -143,11 +145,12 @@ class __$AddMembersStateCopyWithImpl<$Res>
 
 /// Create a copy of AddMembersState
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? contacts = null,Object? selectedContacts = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? contacts = null,Object? selectedContacts = null,Object? isApq = null,}) {
   return _then(_AddMembersState(
 contacts: null == contacts ? _self._contacts : contacts // ignore: cast_nullable_to_non_nullable
 as List<UiContact>,selectedContacts: null == selectedContacts ? _self._selectedContacts : selectedContacts // ignore: cast_nullable_to_non_nullable
-as Set<UiUserId>,
+as Set<UiUserId>,isApq: null == isApq ? _self.isApq : isApq // ignore: cast_nullable_to_non_nullable
+as bool,
   ));
 }
 

--- a/app/lib/chat/chat_debug_info_view.dart
+++ b/app/lib/chat/chat_debug_info_view.dart
@@ -642,6 +642,8 @@ class _MemberCard extends StatelessWidget {
                       .emptyConnectionGroupAttributes ==
                   true)
                 'empty_connection_group_attributes',
+              if (caps.appData?.airComponent?.features.pqGroups == true)
+                'pq_groups',
             ],
           ),
         ],

--- a/app/lib/chat/create_group_screen.dart
+++ b/app/lib/chat/create_group_screen.dart
@@ -14,6 +14,7 @@ import 'package:air/navigation/navigation.dart';
 import 'package:air/ds/theme/theme.dart';
 import 'package:air/ds/foundations/themes.dart';
 import 'package:air/ds/foundations/icons/app_icons.dart';
+import 'package:air/ds/foundations/font_size.dart';
 import 'package:air/user/user.dart';
 import 'package:air/util/scaffold_messenger.dart';
 import 'package:air/widgets/avatar.dart';
@@ -58,7 +59,6 @@ class _CreateGroupFlow extends HookWidget {
   @override
   Widget build(BuildContext context) {
     final showDetails = useState(false);
-    final isApq = useState(false);
 
     return PopScope(
       canPop: !showDetails.value,
@@ -70,14 +70,8 @@ class _CreateGroupFlow extends HookWidget {
       child: IndexedStack(
         index: showDetails.value ? 1 : 0,
         children: [
-          _MemberSelectionStep(
-            isApq: isApq.value,
-            onNext: () => showDetails.value = true,
-          ),
-          _CreateGroupDetailsStep(
-            isApq: isApq,
-            onBack: () => showDetails.value = false,
-          ),
+          _MemberSelectionStep(onNext: () => showDetails.value = true),
+          _CreateGroupDetailsStep(onBack: () => showDetails.value = false),
         ],
       ),
     );
@@ -85,19 +79,21 @@ class _CreateGroupFlow extends HookWidget {
 }
 
 class _MemberSelectionStep extends HookWidget {
-  const _MemberSelectionStep({required this.onNext, required this.isApq});
+  const _MemberSelectionStep({required this.onNext});
 
   final VoidCallback onNext;
-  final bool isApq;
 
   @override
   Widget build(BuildContext context) {
     final searchController = useTextEditingController();
     final query = useState('');
 
-    final (contacts, selectedContacts) = context.select(
-      (AddMembersCubit cubit) =>
-          (cubit.state.contacts, cubit.state.selectedContacts),
+    final (contacts, selectedContacts, isApq) = context.select(
+      (AddMembersCubit cubit) => (
+        cubit.state.contacts,
+        cubit.state.selectedContacts,
+        cubit.state.isApq,
+      ),
     );
     final loc = AppLocalizations.of(context);
 
@@ -156,15 +152,15 @@ class _MemberSelectionStep extends HookWidget {
 }
 
 class _CreateGroupDetailsStep extends HookWidget {
-  const _CreateGroupDetailsStep({required this.onBack, required this.isApq});
+  const _CreateGroupDetailsStep({required this.onBack});
 
   final VoidCallback onBack;
-  final ValueNotifier<bool> isApq;
 
   @override
   Widget build(BuildContext context) {
-    final selectedIds = context.select(
-      (AddMembersCubit cubit) => cubit.state.selectedContacts,
+    final (selectedIds, isApq) = context.select(
+      (AddMembersCubit cubit) =>
+          (cubit.state.selectedContacts, cubit.state.isApq),
     );
 
     final selectedProfiles = context.select(
@@ -194,7 +190,6 @@ class _CreateGroupDetailsStep extends HookWidget {
     final isCreating = useState(false);
     final nameFocusNode = useFocusNode();
     final showHiddenSettings = useState(false);
-    final isApq = useState(false);
 
     final isGroupNameValid = groupName.value.trim().isNotEmpty;
     final showHelperText = nameFocusNode.hasFocus && !isGroupNameValid;
@@ -220,7 +215,7 @@ class _CreateGroupDetailsStep extends HookWidget {
                     groupName.value.trim(),
                     isCreating,
                     picture.value,
-                    isApq.value,
+                    isApq,
                   )
                 : null,
 
@@ -304,9 +299,9 @@ class _CreateGroupDetailsStep extends HookWidget {
                     ],
                     if (showHiddenSettings.value) ...[
                       const SizedBox(height: Spacing.px32),
-                      SwitchField(
-                        onSubmit: (value) {
-                          isApq.value = value;
+                      _SwitchField(
+                        onChanged: (value) {
+                          context.read<AddMembersCubit>().enableApq(value);
                         },
                         value: isApq,
                         label: "Post-Quantum Encryption",
@@ -325,8 +320,7 @@ class _CreateGroupDetailsStep extends HookWidget {
                           }
                           final features = selectedFeatures[userId];
                           final isSupported =
-                              features?.isSupported(isApq: isApq.value) ??
-                              false;
+                              features?.isSupported(isApq: isApq) ?? false;
                           return Opacity(
                             opacity: isSupported ? 1.0 : 0.5,
                             child: _SelectedParticipant(
@@ -602,6 +596,53 @@ class _CircularBackButton extends StatelessWidget {
             color: colors.backgroundBase.secondary,
           ),
           child: const Center(child: AppIcon.arrowLeft(size: 16)),
+        ),
+      ),
+    );
+  }
+}
+
+/// A switch field that reflects [value] and reports toggles via [onChanged].
+class _SwitchField extends StatelessWidget {
+  const _SwitchField({
+    required this.onChanged,
+    required this.value,
+    required this.label,
+  });
+
+  final ValueChanged<bool> onChanged;
+  final bool value;
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = CustomColorScheme.of(context);
+
+    return InkWell(
+      onTap: () => onChanged(!value),
+      child: Container(
+        decoration: BoxDecoration(
+          color: colors.backgroundBase.secondary,
+          borderRadius: BorderRadius.circular(Spacing.px16),
+        ),
+        padding: const EdgeInsets.symmetric(horizontal: Spacing.px12),
+        height: 42,
+        child: Row(
+          children: [
+            Text(
+              label,
+              style: TextStyle(
+                color: colors.text.primary,
+                fontSize: BodyFontSize.base.size,
+              ),
+            ),
+            const Spacer(),
+            Switch(
+              value: value,
+              padding: const EdgeInsets.symmetric(horizontal: 0),
+              onChanged: (_) => onChanged(!value),
+            ),
+          ],
         ),
       ),
     );

--- a/app/lib/user/user_settings_screen.dart
+++ b/app/lib/user/user_settings_screen.dart
@@ -340,7 +340,7 @@ class _CommonSettings extends HookWidget {
         const _LanguageSetting(),
 
         const SizedBox(height: Spacing.px12),
-        SwitchField(
+        _SwitchField(
           onSubmit: (value) {
             context.read<UserSettingsCubit>().setReadReceipts(
               userCubit: context.read(),
@@ -484,7 +484,7 @@ class _MobileSettings extends HookWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        SwitchField(
+        _SwitchField(
           label: loc.userSettingsScreen_sendWithEnter,
           value: sendOnEnter,
           onSubmit: (value) {
@@ -710,9 +710,10 @@ class _SectionHeader extends StatelessWidget {
   }
 }
 
-class SwitchField extends HookWidget {
-  const SwitchField({
-    super.key,
+/// A switch field that toggles a [ValueNotifier] optimistically and submits
+/// the final value after a debounce delay.
+class _SwitchField extends HookWidget {
+  const _SwitchField({
     required this.onSubmit,
     required this.value,
     required this.label,

--- a/app/test/chat/goldens/create_group_details_apq_enabled.linux.png
+++ b/app/test/chat/goldens/create_group_details_apq_enabled.linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a12ff8e54e55a52f22a7a03b67cca6b734b934bdc6c0c465a317519d478ff919
-size 101085
+oid sha256:df60d2db2ad1a081449b78153a6a928e6dd22f21693ad391f3b8ffcf2efed545
+size 101215

--- a/app/test/chat/goldens/create_group_details_apq_enabled.macos.png
+++ b/app/test/chat/goldens/create_group_details_apq_enabled.macos.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c1dec9ba56bf5d9a9a272cbc02a70c96ea4fc856ea4a927b98112c6df791dbda
-size 101676
+oid sha256:6cf481745f198a6b9e1f2f40dd69024c649f2c2edc5bf645cb9d381eb9394d73
+size 101086

--- a/app/test/chat/goldens/create_group_details_apq_enabled.windows.png
+++ b/app/test/chat/goldens/create_group_details_apq_enabled.windows.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a91d2a0876bc7222132456792024b8ed809dd2025896da30bfe6b12dff575d71
-size 94537
+oid sha256:b725cebdd441831de493f6e2e6ccaca0ea2ddd4687566eeb04eab39151252f8c
+size 94540

--- a/app/test/chat/goldens/create_group_details_hidden_settings.linux.png
+++ b/app/test/chat/goldens/create_group_details_hidden_settings.linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b192dba81e1b31a93a4ebcc5cc0270b1bb43ef19b40c811870f6b87e88763199
-size 100396
+oid sha256:16c24a905a8be71f11866e865b28a42efec8ee2e1d0348bc20d99cbc98c33f87
+size 100556

--- a/app/test/chat/goldens/create_group_details_hidden_settings.macos.png
+++ b/app/test/chat/goldens/create_group_details_hidden_settings.macos.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:209d45d1cf7681431b5c3021199934bff1a80787e53a07c8d2df46fd126ee1af
-size 100690
+oid sha256:e143465567bf4cf8a988fab6c59944ad8852aa6e182cbd2a0f8715229eb035d7
+size 99895

--- a/app/test/chat/goldens/create_group_details_hidden_settings.windows.png
+++ b/app/test/chat/goldens/create_group_details_hidden_settings.windows.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6da7a735442d18a963741d35b454a10fada8d7dfcb9cc32ec83e11011a34bc5a
-size 92632
+oid sha256:2c34c1b37df4dd7916fd55d7b19925639d04e493c3cf377b6c0394aff10446d8
+size 92666

--- a/app/test/chat/goldens/create_group_selection_apq.linux.png
+++ b/app/test/chat/goldens/create_group_selection_apq.linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c8102b9bf081a1dedd86aba4119aa8d4ea7ad8596dfb2dff6c08a2a74e002836
-size 54227
+oid sha256:c95c3958eceb6a4acaf9972f8ad70e7ba2134eea5e4ee0e579885594bfd9468e
+size 53362

--- a/app/test/chat/goldens/create_group_selection_apq.macos.png
+++ b/app/test/chat/goldens/create_group_selection_apq.macos.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3c21ca596e1025072d98ead890be470bc33cef30e0b0a6df8396d23da7ab0649
-size 54219
+oid sha256:1e4b5d7144ab1b1c19d080d27e725bb8354fb808217104fc2304b86e73a3341b
+size 53570

--- a/app/test/chat/goldens/create_group_selection_apq.windows.png
+++ b/app/test/chat/goldens/create_group_selection_apq.windows.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0b366b990bde6e4014d2aefc26f6e3a715ef06b9b2be6ae1fe5bf9d69ddbef84
-size 49825
+oid sha256:4cf3e7b566c905c344add15858308028a0cfa3f38221d7f8e2ef76079ffaa56e
+size 49065

--- a/coreclient/src/groups/mod.rs
+++ b/coreclient/src/groups/mod.rs
@@ -59,7 +59,9 @@ use aircommon::{
     time::TimeStamp,
     utils::removed_client,
 };
-use airprotos::client::component::{AIR_COMPONENT_ID, AirComponent, SUPPORTED_COMPONENTS};
+use airprotos::client::component::{
+    AIR_COMPONENT_ID, AirComponent, AirFeatures, SUPPORTED_COMPONENTS,
+};
 use anyhow::{Context, Result, anyhow, bail, ensure};
 use mimi_content::MimiContent;
 use mimi_room_policy::{MimiProposal, RoleIndex, RoomPolicy, VerifiedRoomState};
@@ -282,6 +284,7 @@ impl Group {
                 .map(|c| c.user_id() == user_id)
                 .unwrap_or(false)
         })?;
+
         let leaf_node = self.mls_group.public_group().leaf(member.index)?;
         leaf_node
             .extensions()
@@ -1553,9 +1556,10 @@ impl Group {
                     })
                     .ok()
             }) {
-                // Enabled encrypted group profiles
-                if !air_component.features.encrypted_group_profiles {
-                    air_component.features.encrypted_group_profiles = true;
+                // Update features to the current version of the client
+                let current_features = AirFeatures::default_leaf_or_key_package_features();
+                if air_component.features != current_features {
+                    air_component.features = current_features;
                     updated_dict
                         .get_or_insert_with(|| dict.clone())
                         .insert(AIR_COMPONENT_ID, air_component.to_bytes()?);

--- a/coreclient/src/outbound_service/timed_tasks.rs
+++ b/coreclient/src/outbound_service/timed_tasks.rs
@@ -218,9 +218,6 @@ impl OutboundServiceContext {
             .into_operation()
             .enqueue_if_not_exists(self.db.write().await?)
             .await?;
-        // For now, the APQ feature is not fully released, so we don't enable APQ key package
-        // uploads yet.
-        #[cfg(any(feature = "test_utils", test))]
         TimedTask::new(TimedTaskKind::ApqKeyPackageUpload)
             .into_operation()
             .enqueue_if_not_exists(self.db.write().await?)

--- a/protos/src/client/component.rs
+++ b/protos/src/client/component.rs
@@ -54,11 +54,7 @@ impl AirComponent {
     /// supported features of the current version of the client.
     pub fn default_leaf_or_key_package_component() -> Self {
         Self {
-            features: AirFeatures {
-                encrypted_group_profiles: true,
-                empty_connection_group_attributes: true,
-                pq_groups: true,
-            },
+            features: AirFeatures::default_leaf_or_key_package_features(),
         }
     }
 
@@ -68,6 +64,20 @@ impl AirComponent {
 
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, codec::Error> {
         PersistenceCodec::from_slice(bytes)
+    }
+}
+
+impl AirFeatures {
+    /// The features that are supported by the current version of the client.
+    ///
+    /// Note: This is *not* the default implementation of `AirFeatures::default`. It contains all
+    /// supported features of the current version of the client.
+    pub fn default_leaf_or_key_package_features() -> Self {
+        Self {
+            encrypted_group_profiles: true,
+            empty_connection_group_attributes: true,
+            pq_groups: true,
+        }
     }
 }
 


### PR DESCRIPTION
On group update, we never enabled the supported Air features of the
current client.

Additionally, fix greying out the contacts in the first group creation
step when PQ is enabled. The toggle was not propagated from the second
step to the first step.

Also enable the APQ key package upload task again.