### PR TITLE
fix(app): fix backwards incompatible serde in openmls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1803,7 +1803,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2654,7 +2654,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5049,7 +5049,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 [[package]]
 name = "openmls"
 version = "0.8.1"
-source = "git+https://github.com/boxdot/openmls?branch=dima%2Fpost-quantum-support#6ca897d6c635cfe4e7e07adf836d15118fcd21de"
+source = "git+https://github.com/boxdot/openmls?branch=dima%2Fpost-quantum-support#bd5760e0080beb8c9c73213a19febe3a9482c26c"
 dependencies = [
  "log",
  "openmls_basic_credential",
@@ -5069,7 +5069,7 @@ dependencies = [
 [[package]]
 name = "openmls_basic_credential"
 version = "0.5.0"
-source = "git+https://github.com/boxdot/openmls?branch=dima%2Fpost-quantum-support#6ca897d6c635cfe4e7e07adf836d15118fcd21de"
+source = "git+https://github.com/boxdot/openmls?branch=dima%2Fpost-quantum-support#bd5760e0080beb8c9c73213a19febe3a9482c26c"
 dependencies = [
  "ed25519-dalek",
  "ml-dsa",
@@ -5085,7 +5085,7 @@ dependencies = [
 [[package]]
 name = "openmls_libcrux_crypto"
 version = "0.3.1"
-source = "git+https://github.com/boxdot/openmls?branch=dima%2Fpost-quantum-support#6ca897d6c635cfe4e7e07adf836d15118fcd21de"
+source = "git+https://github.com/boxdot/openmls?branch=dima%2Fpost-quantum-support#bd5760e0080beb8c9c73213a19febe3a9482c26c"
 dependencies = [
  "hpke-rs",
  "hpke-rs-crypto",
@@ -5106,7 +5106,7 @@ dependencies = [
 [[package]]
 name = "openmls_memory_storage"
 version = "0.5.0"
-source = "git+https://github.com/boxdot/openmls?branch=dima%2Fpost-quantum-support#6ca897d6c635cfe4e7e07adf836d15118fcd21de"
+source = "git+https://github.com/boxdot/openmls?branch=dima%2Fpost-quantum-support#bd5760e0080beb8c9c73213a19febe3a9482c26c"
 dependencies = [
  "hex",
  "log",
@@ -5119,7 +5119,7 @@ dependencies = [
 [[package]]
 name = "openmls_rust_crypto"
 version = "0.5.1"
-source = "git+https://github.com/boxdot/openmls?branch=dima%2Fpost-quantum-support#6ca897d6c635cfe4e7e07adf836d15118fcd21de"
+source = "git+https://github.com/boxdot/openmls?branch=dima%2Fpost-quantum-support#bd5760e0080beb8c9c73213a19febe3a9482c26c"
 dependencies = [
  "aes-gcm",
  "chacha20poly1305",
@@ -5146,7 +5146,7 @@ dependencies = [
 [[package]]
 name = "openmls_sqlite_storage"
 version = "0.2.0"
-source = "git+https://github.com/boxdot/openmls?branch=dima%2Fpost-quantum-support#6ca897d6c635cfe4e7e07adf836d15118fcd21de"
+source = "git+https://github.com/boxdot/openmls?branch=dima%2Fpost-quantum-support#bd5760e0080beb8c9c73213a19febe3a9482c26c"
 dependencies = [
  "log",
  "openmls_traits",
@@ -5159,7 +5159,7 @@ dependencies = [
 [[package]]
 name = "openmls_traits"
 version = "0.5.0"
-source = "git+https://github.com/boxdot/openmls?branch=dima%2Fpost-quantum-support#6ca897d6c635cfe4e7e07adf836d15118fcd21de"
+source = "git+https://github.com/boxdot/openmls?branch=dima%2Fpost-quantum-support#bd5760e0080beb8c9c73213a19febe3a9482c26c"
 dependencies = [
  "serde",
  "tls_codec",
@@ -6411,7 +6411,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7167,10 +7167,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8277,7 +8277,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]


### PR DESCRIPTION
The actual fix is this commit https://github.com/boxdot/openmls/commit/bd5760e0080beb8c9c73213a19febe3a9482c26c now included in tree.