### PR TITLE
fix(app, server): resync in groups with blank leaves

### DIFF
--- a/backend/src/ds/group_operation.rs
+++ b/backend/src/ds/group_operation.rs
@@ -647,7 +647,7 @@ impl DsGroupState {
     }
 
     /// Removes user and client profiles based on the list of removed clients.
-    fn remove_profiles(&mut self, removed_clients: Vec<LeafNodeIndex>) {
+    pub(crate) fn remove_profiles(&mut self, removed_clients: Vec<LeafNodeIndex>) {
         for client_index in removed_clients {
             let removed_client_profile_option = self.member_profiles.remove(&client_index);
             debug_assert!(removed_client_profile_option.is_some());

--- a/backend/src/ds/resync.rs
+++ b/backend/src/ds/resync.rs
@@ -2,7 +2,8 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-use aircommon::time::Duration;
+use aircommon::{credentials::VerifiableClientCredential, time::Duration, utils::removed_clients};
+use mimi_room_policy::RoleIndex;
 use mls_assist::{
     group::ProcessedAssistedMessage, messages::SerializedMlsMessage, openmls::prelude::Sender,
     provider_traits::MlsAssistProvider,
@@ -11,6 +12,7 @@ use mls_assist::{
     messages::AssistedMessageIn,
     openmls::prelude::{LeafNodeIndex, ProcessedMessageContent},
 };
+use tracing::error;
 
 use crate::errors::ResyncClientError;
 
@@ -54,19 +56,73 @@ impl DsGroupState {
             return Err(ResyncClientError::InvalidMessage);
         }
 
-        let Some(remove_proposal) = staged_commit_message.remove_proposals().next() else {
-            // This should contain a remove proposal.
+        if !staged_commit_message
+            .remove_proposals()
+            .any(|p| p.remove_proposal().removed() == sender_index)
+        {
+            // There must be a remove proposal for the sender.
+            //
+            // Note: The commit might contain multiple remove proposals.
             return Err(ResyncClientError::InvalidMessage);
-        };
+        }
 
-        if remove_proposal.remove_proposal().removed() != sender_index {
-            // The sender index in the remove proposal should match the sender
-            // index in the params.
-            return Err(ResyncClientError::InvalidMessage);
+        let sender = VerifiableClientCredential::from_basic_credential(
+            self.group
+                .leaf(sender_index)
+                .ok_or_else(|| {
+                    error!(%sender_index, "Leaf node for sender not found");
+                    ResyncClientError::InvalidMessage
+                })?
+                .credential(),
+        )
+        .map_err(|error| {
+            error!(%error, "Credential of sender is invalid");
+            ResyncClientError::InvalidMessage
+        })?;
+
+        // Collect all removed clients except the sender.
+        let mut removed_indices = removed_clients(staged_commit_message);
+        let sender_index_pos = removed_indices
+            .iter()
+            .position(|&index| index == sender_index)
+            .ok_or_else(|| {
+                error!(%sender_index, "Sender not found in removed clients");
+                ResyncClientError::InvalidMessage
+            })?;
+        removed_indices.swap_remove(sender_index_pos);
+
+        // Change room state roles of removed clients to outsider.
+        for &removed_index in &removed_indices {
+            let removed = VerifiableClientCredential::from_basic_credential(
+                self.group()
+                    .leaf(removed_index)
+                    .ok_or_else(|| {
+                        error!(%removed_index, "Leaf node for removed client not found");
+                        ResyncClientError::InvalidMessage
+                    })?
+                    .credential(),
+            )
+            .map_err(|error| {
+                error!(%error, "Credential of removed user is invalid");
+                ResyncClientError::InvalidMessage
+            })?;
+            self.room_state_change_role(sender.user_id(), removed.user_id(), RoleIndex::Outsider)
+                .ok_or_else(|| {
+                    error!(%removed_index, "Failed to change role of removed client");
+                    ResyncClientError::InvalidMessage
+                })?;
         }
 
         // Everything seems to be okay.
         // Now we have to update the group state and distribute.
+
+        let new_sender_index = self
+            .group()
+            .ext_commit_sender_index(staged_commit_message)
+            .map_err(|error| {
+                error!(%error, "Error getting sender index");
+                ResyncClientError::InvalidMessage
+            })?;
 
         // We just accept the message into the group state.
         self.group.accept_processed_message(
@@ -75,10 +131,21 @@ impl DsGroupState {
             Duration::days(USER_EXPIRATION_DAYS),
         )?;
 
-        // No need to update the user profile, since the client was re-added on
-        // the same position.
-        // No need to update the client profile either, since all data (leaf
-        // index, credential, qs client ref, etc.) remains the same.
+        self.remove_profiles(removed_indices);
+
+        // An external commit re-adds the client at the leftmost blank leaf. If it differs from the
+        // original leaf index, we need to re-key the member profile accordingly, so that fan-out
+        // exclusion and QS references stay correct.
+        if new_sender_index != sender_index
+            && let Some(mut profile) = self.member_profiles.remove(&sender_index)
+        {
+            profile.leaf_index = new_sender_index;
+            // The external committer joins at the leftmost blank leaf. At this point all profiles
+            // of clients removed by this commit (including the sender's old entry) have been
+            // removed, so the new index is guaranteed to be vacant.
+            debug_assert!(!self.member_profiles.contains_key(&new_sender_index));
+            self.member_profiles.insert(new_sender_index, profile);
+        }
 
         Ok(processed_assisted_message_plus.serialized_mls_message)
     }

--- a/coreclient/src/groups/mod.rs
+++ b/coreclient/src/groups/mod.rs
@@ -2,11 +2,11 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+pub(crate) mod apq_group;
 pub(crate) mod client_auth_info;
+pub(crate) mod debug_info;
 // TODO: Allowing dead code here for now. We'll need diffs when we start
 // rotating keys.
-pub(crate) mod apq_group;
-pub(crate) mod debug_info;
 #[allow(dead_code)]
 pub(crate) mod diff;
 pub(crate) mod error;
@@ -16,6 +16,8 @@ pub(crate) mod process;
 
 pub(crate) use error::*;
 pub(crate) use persistence::VerifiedGroup;
+
+use std::collections::{HashMap, HashSet};
 
 use aircommon::{
     credentials::{
@@ -86,7 +88,6 @@ use crate::{
     key_stores::as_credentials::AsCredentials,
     outbound_service::resync::Resync,
 };
-use std::collections::HashSet;
 
 use openmls::{
     component::ComponentType,
@@ -761,20 +762,9 @@ impl Group {
             })
             .collect();
 
-        // Figure out who was removed so we can filter out the encrypted profile keys later.
-        let removed_members: Vec<_> = proposals
-            .iter()
-            .filter_map(|pm| {
-                let Sender::Member(sender) = pm.sender() else {
-                    return None;
-                };
-                Some(*sender)
-            })
-            .collect();
-
         // Let's create the group first so that we can access the GroupId.
         // Phase 1: Create and store the group
-        let (mls_group, commit, group_info) = {
+        let (mls_group, commit, group_info, encrypted_profile_keys) = {
             let provider = AirOpenMlsProvider::new(txn.as_mut());
             // Prepare PSK proposal if we have a connection offer hash.
             let psk_proposal = match connection_offer_hash {
@@ -795,6 +785,18 @@ impl Group {
                 .with_capabilities(default_leaf_node_capabilities())
                 .with_extensions(default_leaf_node_extensions::<AirComponent>())
                 .build();
+
+            let encrypted_profile_keys: HashMap<UserId, EncryptedUserProfileKey> = ratchet_tree_in
+                .leaves()
+                .zip(encrypted_user_profile_keys)
+                .filter_map(|(leaf_node, profile_key)| {
+                    let cred =
+                        VerifiableClientCredential::from_basic_credential(leaf_node.credential())
+                            .ok()?;
+                    // Credentials will be verified below
+                    Some((cred.user_id().clone(), profile_key))
+                })
+                .collect();
 
             let mut builder = ExternalCommitBuilder::new()
                 .with_proposals(proposals)
@@ -825,6 +827,7 @@ impl Group {
                 mls_group,
                 commit,
                 group_info.context("No group info found")?,
+                encrypted_profile_keys,
             )
         };
 
@@ -845,32 +848,31 @@ impl Group {
         // If the group previously existed, delete it first.
         Group::delete_from_db(txn, group.group_id()).await?;
         group.store(&mut *txn).await?;
-        for credential in &credentials {
-            credential.store(&mut *txn).await?;
-        }
-        // Also store own credential
-        let own_credential = signer.credential().clone();
-        StorableClientCredential::from(own_credential)
-            .store(&mut *txn)
-            .await?;
 
-        // Compile a list of user profile keys for the members.
-        let member_profile_info = encrypted_user_profile_keys
-            .into_iter()
-            .enumerate()
-            .filter_map(|(index, eupk)| {
-                (!removed_members.contains(&LeafNodeIndex::new(index as u32))).then_some(eupk)
+        // Store credentials and accumulate member profile keys (excl. own member)
+        let mut member_profile_info = Vec::with_capacity(credentials.len());
+        for credential in credentials {
+            credential.store(&mut *txn).await?; // store everyone incl. self
+
+            // Decrypt the user profile key
+            if credential.user_id() == signer.credential().user_id() {
+                continue; // skip profile-key lookup for self
+            }
+            let eupk = encrypted_profile_keys
+                .get(credential.user_id())
+                .context("Missing user profile key")?;
+            let profile_info = UserProfileKey::decrypt(
+                &group.identity_link_wrapper_key,
+                eupk,
+                credential.user_id(),
+            )
+            .map(|user_profile_key| ProfileInfo {
+                user_profile_key,
+                client_credential: credential.into(),
             })
-            .zip(credentials)
-            .map(|(eupk, ci)| {
-                UserProfileKey::decrypt(&group.identity_link_wrapper_key, &eupk, ci.user_id()).map(
-                    |user_profile_key| ProfileInfo {
-                        user_profile_key,
-                        client_credential: ci.into(),
-                    },
-                )
-            })
-            .collect::<Result<Vec<_>, _>>()?;
+            .context("Failed to decrypt user profile key")?;
+            member_profile_info.push(profile_info);
+        }
 
         Ok(Ok((group, commit, group_info.into(), member_profile_info)))
     }

--- a/mls-assist/src/group/mod.rs
+++ b/mls-assist/src/group/mod.rs
@@ -10,6 +10,7 @@ use apqmls::{messages::ApqGroupInfo, processing::ApqProcessedMessage};
 use chrono::Duration;
 use errors::StorageError;
 use openmls::{
+    error::LibraryError,
     framing::PrivateMessageIn,
     group::{GroupId, MergeCommitError},
     prelude::{
@@ -192,6 +193,13 @@ impl Group {
 
     pub fn members(&self) -> impl Iterator<Item = Member> + '_ {
         self.public_group.members()
+    }
+
+    pub fn ext_commit_sender_index(
+        &self,
+        staged_commit: &StagedCommit,
+    ) -> Result<LeafNodeIndex, LibraryError> {
+        self.public_group.ext_commit_sender_index(staged_commit)
     }
 }
 

--- a/server/tests/tests/server.rs
+++ b/server/tests/tests/server.rs
@@ -14,7 +14,7 @@ use aircommon::{
     mls_group_config::MAX_PAST_EPOCHS,
 };
 use aircoreclient::{
-    ChatId,
+    ChatId, DisplayName, UserProfile,
     clients::{ListenResponse, listen_response, process::process_qs::ProcessedQsMessages},
     outbound_service::{APQ_KEY_PACKAGES, KEY_PACKAGES},
 };
@@ -673,6 +673,189 @@ async fn resync_valid_group_succeeds() {
 
     // Bob should be able to send messages normally.
     setup.send_message(chat_id, &bob, vec![&alice], None).await;
+}
+
+/// Resync with holes in the leaf nodes: Alice creates a group with Bob,
+/// Charlie and Dave (leaf indices 0, 1, 2, 3), and then removes Bob. This
+/// blanks Bob's leaf, leaving a hole in the leaf nodes, so that leaf indices
+/// no longer match positions in flattened member lists. Charlie then leaves
+/// the chat, which puts a pending SelfRemove proposal (for leaf index 2) on
+/// the DS. Alice resyncs first, then Dave; both resyncs must succeed.
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[tracing::instrument(name = "Resync with blank leaf", skip_all)]
+async fn resync_with_blank_leaf_succeeds() {
+    let mut setup = TestBackend::single().await;
+
+    let alice = setup.add_user().await;
+    let bob = setup.add_user().await;
+    let charlie = setup.add_user().await;
+    let dave = setup.add_user().await;
+    setup.connect_users(&alice, &bob).await;
+    setup.connect_users(&alice, &charlie).await;
+    setup.connect_users(&alice, &dave).await;
+
+    let chat_id = setup.create_group(&alice).await;
+    setup
+        .invite_to_group(chat_id, &alice, vec![&bob, &charlie, &dave])
+        .await;
+
+    // Removing Bob blanks his leaf, creating a hole in the leaf nodes.
+    setup
+        .remove_from_group(chat_id, &alice, vec![&bob])
+        .await
+        .unwrap();
+
+    // Charlie leaves the chat. This puts a pending SelfRemove proposal for leaf index 2 on the DS,
+    // which is committed by the next resync's external commit.
+    let charlie_user = &setup.get_user(&charlie).user;
+    charlie_user.leave_chat(chat_id).await.unwrap();
+
+    // Alice and Dave observe Charlie's proposal.
+    for user_id in [&alice, &dave] {
+        let user = &setup.get_user(user_id).user;
+        let qs_messages = user.qs_fetch_messages().await.unwrap();
+        let result = user.fully_process_qs_messages(qs_messages).await;
+        assert!(
+            result.errors.is_empty(),
+            "{user_id:?} should process Charlie's proposal without errors: {:?}",
+            result.errors
+        );
+    }
+
+    // Dave changes his profile. This rotates his user profile key, so Alice's post-resync profile
+    // fetch must decrypt it with the key from the external commit info.
+    let dave_user = &setup.get_user(&dave).user;
+    let dave_display_name: DisplayName = "D4v3".parse().unwrap();
+    dave_user
+        .set_own_user_profile(UserProfile {
+            user_id: dave.clone(),
+            display_name: dave_display_name.clone(),
+            profile_picture: None,
+        })
+        .await
+        .unwrap();
+
+    // Alice resyncs first.
+    let alice_user = &setup.get_user(&alice).user;
+    alice_user.enqueue_group_resync(chat_id).await.unwrap();
+    assert!(
+        alice_user.is_resync_pending(chat_id).await.unwrap(),
+        "resync should be queued"
+    );
+
+    // Run outbound service — resync should succeed despite the blank leaves.
+    alice_user.outbound_service().run_once().await;
+
+    assert!(
+        !alice_user.is_resync_pending(chat_id).await.unwrap(),
+        "resync should have completed"
+    );
+
+    // Run the outbound service again to process the user profile fetch operations enqueued by the
+    // resync.
+    alice_user.outbound_service().run_once().await;
+
+    // Alice should see Dave's updated profile after the resync.
+    let dave_profile = alice_user.user_profile(&dave).await;
+    assert_eq!(dave_profile.display_name, dave_display_name);
+
+    // Alice must not have received her own external commit from the DS.
+    let qs_messages = alice_user.qs_fetch_messages().await.unwrap();
+    let result = alice_user.fully_process_qs_messages(qs_messages).await;
+    assert!(
+        result.errors.is_empty(),
+        "Alice should process her queue without errors: {:?}",
+        result.errors
+    );
+
+    // Dave processes Alice's rejoin commit.
+    let dave_user = &setup.get_user(&dave).user;
+    let qs_messages = dave_user.qs_fetch_messages().await.unwrap();
+    let result = dave_user.fully_process_qs_messages(qs_messages).await;
+    assert!(
+        result.errors.is_empty(),
+        "Dave should process Alice's rejoin without errors: {:?}",
+        result.errors
+    );
+
+    // Now Dave resyncs as well.
+    dave_user.enqueue_group_resync(chat_id).await.unwrap();
+    assert!(
+        dave_user.is_resync_pending(chat_id).await.unwrap(),
+        "resync should be queued"
+    );
+
+    dave_user.outbound_service().run_once().await;
+
+    assert!(
+        !dave_user.is_resync_pending(chat_id).await.unwrap(),
+        "resync should have completed"
+    );
+
+    // Run the outbound service again to process the user profile fetch operations enqueued by the
+    // resync.
+    dave_user.outbound_service().run_once().await;
+
+    // Dave must not have received his own external commit from the DS.
+    let qs_messages = dave_user.qs_fetch_messages().await.unwrap();
+    let result = dave_user.fully_process_qs_messages(qs_messages).await;
+    assert!(
+        result.errors.is_empty(),
+        "Dave should process his queue without errors: {:?}",
+        result.errors
+    );
+
+    // Alice processes Dave's rejoin commit.
+    let alice_user = &setup.get_user(&alice).user;
+    let qs_messages = alice_user.qs_fetch_messages().await.unwrap();
+    let result = alice_user.fully_process_qs_messages(qs_messages).await;
+    assert!(
+        result.errors.is_empty(),
+        "Alice should process Dave's rejoin without errors"
+    );
+
+    // Both group members should agree on the group membership.
+    let expected_members: HashSet<_> = [alice.clone(), dave.clone()].into_iter().collect();
+    let participants = alice_user.group_members(chat_id).await.unwrap();
+    assert_eq!(participants, expected_members);
+    let dave_user = &setup.get_user(&dave).user;
+    let participants = dave_user.group_members(chat_id).await.unwrap();
+    assert_eq!(participants, expected_members);
+
+    // Dave sends a message.
+    //
+    // Note: the external commit re-added Dave at the leftmost blank leaf (Bob's old position), i.e.
+    // his leaf index changed.
+    dave_user
+        .send_message(
+            chat_id,
+            MimiContent::simple_markdown_message("message".to_owned(), [0; 16]),
+            None,
+        )
+        .await
+        .unwrap();
+    // Actually send the queued message to the DS.
+    dave_user.outbound_service().run_once().await;
+
+    // Alice receives the message.
+    let alice_user = &setup.get_user(&alice).user;
+    let qs_messages = alice_user.qs_fetch_messages().await.unwrap();
+    let result = alice_user.fully_process_qs_messages(qs_messages).await;
+    assert!(
+        result.errors.is_empty(),
+        "Alice should process Dave's message without errors: {:?}",
+        result.errors
+    );
+
+    // The DS must not fan out Dave's own message back to him.
+    let dave_user = &setup.get_user(&dave).user;
+    let qs_messages = dave_user.qs_fetch_messages().await.unwrap();
+    let result = dave_user.fully_process_qs_messages(qs_messages).await;
+    assert!(
+        result.errors.is_empty(),
+        "Dave should not receive his own message: {:?}",
+        result.errors
+    );
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]


### PR DESCRIPTION
An external commit re-adds the resyncing client at the leftmost blank
leaf. In groups with holes in the ratchet tree (after removals), this
broke resync in several places:

* client: encrypted user profile keys from the external commit info
  were paired with members positionally; with blank leaves, positions
  don't match leaf indices and the wrong keys were used. Look up keys
  by user id via the pre-commit ratchet tree instead.
* DS: validation only checked the first remove proposal, rejecting
  resync commits that also commit pending self-removes.
* DS: members removed via committed pending proposals kept their
  member profiles and room state roles, padding the profile key list
  for future external joiners.
* DS: the resynced client's member profile stayed keyed at its old
  leaf index, so fan-out exclusion missed it and the client received
  its own messages back (`CannotDecryptOwnMessage`).