### PR TITLE
fix(app, server): pair user profile keys by leaf index instead of position

### DIFF
--- a/apiclient/src/ds_api.rs
+++ b/apiclient/src/ds_api.rs
@@ -4,10 +4,15 @@
 
 //! Client API for the delivery service (DS)
 
+use std::collections::HashMap;
+
 use aircommon::{
     LibraryError,
     credentials::keys::ClientSigningKey,
-    crypto::{aead::keys::GroupStateEarKey, signatures::signable::Signable},
+    crypto::{
+        aead::keys::{EncryptedUserProfileKey, GroupStateEarKey},
+        signatures::signable::Signable,
+    },
     identifiers::{AttachmentId, QsReference, QualifiedGroupId, UserId},
     messages::{
         client_ds::UserProfileKeyUpdateParams,
@@ -29,9 +34,10 @@ use airprotos::{
         AddUsersInfo, ApqAddUsersInfo, ApqAssistedMlsMessage, ApqGroupOperationPayload,
         ConnectionGroupInfoRequest, CreateApqGroupPayload, CreateGroupPayload, DeleteGroupPayload,
         ExternalCommitInfoRequest, GetAttachmentUrlPayload, GroupOperationPayload,
-        GroupSessionData, JoinConnectionGroupRequest, ProvisionAttachmentPayload,
-        RequestGroupIdRequest, ResyncPayload, SelfRemovePayload, SendMessagePayload,
-        StorageObjectType, TargetedMessagePayload, UpdateProfileKeyPayload, WelcomeInfoPayload,
+        GroupSessionData, IndexedEncryptedUserProfileKey, JoinConnectionGroupRequest,
+        ProvisionAttachmentPayload, RequestGroupIdRequest, ResyncPayload, SelfRemovePayload,
+        SendMessagePayload, StorageObjectType, TargetedMessagePayload, UpdateProfileKeyPayload,
+        WelcomeInfoPayload,
     },
     validation::MissingFieldExt,
 };
@@ -305,17 +311,17 @@ impl ApiClient {
             .welcome_info(request)
             .await?
             .into_inner();
+        let (encrypted_user_profile_keys, indexed_encrypted_user_profile_keys) =
+            extract_encrypted_user_profile_keys(
+                response.encrypted_user_profile_keys,
+                response.indexed_encrypted_user_profile_keys,
+            )?;
         Ok(WelcomeInfoIn {
             ratchet_tree: response
                 .ratchet_tree
                 .ok_or(DsRequestError::UnexpectedResponse)?
                 .try_ref_into()?,
-            encrypted_user_profile_keys: response
-                .encrypted_user_profile_keys
-                .into_iter()
-                .map(TryFrom::try_from)
-                .collect::<Result<Vec<_>, _>>()
-                .map_err(|_| DsRequestError::UnexpectedResponse)?,
+            encrypted_user_profile_keys,
             room_state: VerifiedRoomState::verify(
                 response
                     .room_state
@@ -323,6 +329,7 @@ impl ApiClient {
                     .try_ref_into()?,
             )
             .map_err(|_| DsRequestError::UnexpectedResponse)?,
+            indexed_encrypted_user_profile_keys,
         })
     }
 
@@ -343,6 +350,13 @@ impl ApiClient {
             .external_commit_info(request)
             .await?
             .into_inner();
+
+        let (encrypted_user_profile_keys, indexed_encrypted_user_profile_keys) =
+            extract_encrypted_user_profile_keys(
+                response.encrypted_user_profile_keys,
+                response.indexed_encrypted_user_profile_keys,
+            )?;
+
         Ok(ExternalCommitInfoIn {
             verifiable_group_info: response
                 .group_info
@@ -352,12 +366,7 @@ impl ApiClient {
                 .ratchet_tree
                 .ok_or(DsRequestError::UnexpectedResponse)?
                 .try_ref_into()?,
-            encrypted_user_profile_keys: response
-                .encrypted_user_profile_keys
-                .into_iter()
-                .map(TryFrom::try_from)
-                .collect::<Result<Vec<_>, _>>()
-                .map_err(|_| DsRequestError::UnexpectedResponse)?,
+            encrypted_user_profile_keys,
             room_state: VerifiedRoomState::verify(
                 response
                     .room_state
@@ -366,6 +375,7 @@ impl ApiClient {
             )
             .map_err(|_| DsRequestError::UnexpectedResponse)?,
             proposals: response.proposals.into_iter().map(|m| m.tls).collect(),
+            indexed_encrypted_user_profile_keys,
         })
     }
 
@@ -386,6 +396,11 @@ impl ApiClient {
             .connection_group_info(request)
             .await?
             .into_inner();
+        let (encrypted_user_profile_keys, indexed_encrypted_user_profile_keys) =
+            extract_encrypted_user_profile_keys(
+                response.encrypted_user_profile_keys,
+                response.indexed_encrypted_user_profile_keys,
+            )?;
         Ok(ExternalCommitInfoIn {
             verifiable_group_info: response
                 .group_info
@@ -395,12 +410,7 @@ impl ApiClient {
                 .ratchet_tree
                 .ok_or(DsRequestError::UnexpectedResponse)?
                 .try_ref_into()?,
-            encrypted_user_profile_keys: response
-                .encrypted_user_profile_keys
-                .into_iter()
-                .map(TryFrom::try_from)
-                .collect::<Result<Vec<_>, _>>()
-                .map_err(|_| DsRequestError::UnexpectedResponse)?,
+            encrypted_user_profile_keys,
             room_state: VerifiedRoomState::verify(
                 response
                     .room_state
@@ -409,6 +419,7 @@ impl ApiClient {
             )
             .map_err(|_| DsRequestError::UnexpectedResponse)?,
             proposals: response.proposals.into_iter().map(|m| m.tls).collect(),
+            indexed_encrypted_user_profile_keys,
         })
     }
 
@@ -741,4 +752,45 @@ impl ApiClient {
             .into_inner();
         Ok(response.download_url)
     }
+}
+
+fn extract_encrypted_user_profile_keys(
+    encrypted_user_profile_keys: Vec<airprotos::delivery_service::v1::EncryptedUserProfileKey>,
+    indexed_encrypted_user_profile_keys: Vec<IndexedEncryptedUserProfileKey>,
+) -> Result<
+    (
+        Vec<EncryptedUserProfileKey>,
+        HashMap<LeafNodeIndex, EncryptedUserProfileKey>,
+    ),
+    DsRequestError,
+> {
+    let (encrypted_user_profile_keys, indexed_encrypted_user_profile_keys) =
+        if !indexed_encrypted_user_profile_keys.is_empty() {
+            let indexed_encrypted_user_profile_keys = indexed_encrypted_user_profile_keys
+                .into_iter()
+                .filter_map(
+                    |IndexedEncryptedUserProfileKey {
+                         leaf_index,
+                         encrypted_user_profile_key,
+                     }| {
+                        Some((
+                            LeafNodeIndex::new(leaf_index),
+                            encrypted_user_profile_key?.try_into().ok()?,
+                        ))
+                    },
+                )
+                .collect();
+            (Default::default(), indexed_encrypted_user_profile_keys)
+        } else {
+            let encrypted_user_profile_keys = encrypted_user_profile_keys
+                .into_iter()
+                .map(TryFrom::try_from)
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|_| DsRequestError::UnexpectedResponse)?;
+            (encrypted_user_profile_keys, Default::default())
+        };
+    Ok((
+        encrypted_user_profile_keys,
+        indexed_encrypted_user_profile_keys,
+    ))
 }

--- a/backend/src/ds/grpc.rs
+++ b/backend/src/ds/grpc.rs
@@ -716,6 +716,14 @@ impl<Qep: QsConnector, As: AsConnector> DeliveryService for GrpcDs<Qep, As> {
                     .try_ref_into()
                     .invalid_tls("room_state")?,
             ),
+            indexed_encrypted_user_profile_keys: group_state
+                .member_profiles
+                .into_iter()
+                .map(|(index, profile)| IndexedEncryptedUserProfileKey {
+                    leaf_index: index.u32(),
+                    encrypted_user_profile_key: Some(profile.encrypted_user_profile_key.into()),
+                })
+                .collect(),
         }))
     }
 
@@ -765,6 +773,14 @@ impl<Qep: QsConnector, As: AsConnector> DeliveryService for GrpcDs<Qep, As> {
                     .invalid_tls("room_state")?,
             ),
             proposals: commit_info.proposals.into_iter().map(From::from).collect(),
+            indexed_encrypted_user_profile_keys: group_state
+                .member_profiles
+                .into_iter()
+                .map(|(index, profile)| IndexedEncryptedUserProfileKey {
+                    leaf_index: index.u32(),
+                    encrypted_user_profile_key: Some(profile.encrypted_user_profile_key.into()),
+                })
+                .collect(),
         }))
     }
 
@@ -814,6 +830,14 @@ impl<Qep: QsConnector, As: AsConnector> DeliveryService for GrpcDs<Qep, As> {
                     .invalid_tls("room_state")?,
             ),
             proposals: commit_info.proposals.into_iter().map(From::from).collect(),
+            indexed_encrypted_user_profile_keys: group_state
+                .member_profiles
+                .into_iter()
+                .map(|(index, profile)| IndexedEncryptedUserProfileKey {
+                    leaf_index: index.u32(),
+                    encrypted_user_profile_key: Some(profile.encrypted_user_profile_key.into()),
+                })
+                .collect(),
         }))
     }
 

--- a/common/src/messages/client_ds_out.rs
+++ b/common/src/messages/client_ds_out.rs
@@ -7,6 +7,8 @@
 //! TODO: We should eventually factor this module out, together with the crypto
 //! module, to allow re-use by the client implementation.
 
+use std::collections::HashMap;
+
 use apqmls::commit_builder::ApqCommitMessageBundle;
 use mimi_room_policy::VerifiedRoomState;
 use mls_assist::{
@@ -30,6 +32,7 @@ pub struct ExternalCommitInfoIn {
     pub encrypted_user_profile_keys: Vec<EncryptedUserProfileKey>,
     pub room_state: VerifiedRoomState,
     pub proposals: Vec<Vec<u8>>,
+    pub indexed_encrypted_user_profile_keys: HashMap<LeafNodeIndex, EncryptedUserProfileKey>,
 }
 
 #[derive(Debug)]
@@ -37,6 +40,7 @@ pub struct WelcomeInfoIn {
     pub ratchet_tree: RatchetTreeIn,
     pub encrypted_user_profile_keys: Vec<EncryptedUserProfileKey>,
     pub room_state: VerifiedRoomState,
+    pub indexed_encrypted_user_profile_keys: HashMap<LeafNodeIndex, EncryptedUserProfileKey>,
 }
 
 #[derive(Debug)]

--- a/coreclient/src/chats/pending.rs
+++ b/coreclient/src/chats/pending.rs
@@ -164,11 +164,12 @@ impl CoreUser {
 
                 // There should be only one user profile
                 let contact_profile_info = member_profile_info
+                    .members
                     .pop()
                     .context("No user profile returned when joining connection group")?;
 
                 debug_assert!(
-                    member_profile_info.is_empty(),
+                    member_profile_info.members.is_empty(),
                     "More than one user profile returned when joining connection group"
                 );
 

--- a/coreclient/src/clients/process/process_as.rs
+++ b/coreclient/src/clients/process/process_as.rs
@@ -236,13 +236,25 @@ impl CoreUser {
                     &connection_info.connection_group_ear_key,
                 )
                 .await?;
-            ensure!(
-                eci.encrypted_user_profile_keys.len() == 1,
-                "Unjoined connection group must have exactly one user profile key"
-            );
+            let encrypted_user_profile_key = if !eci.indexed_encrypted_user_profile_keys.is_empty()
+            {
+                ensure!(
+                    eci.indexed_encrypted_user_profile_keys.len() == 1,
+                    "Unjoined connection group must have exactly one user profile key"
+                );
+                eci.indexed_encrypted_user_profile_keys
+                    .values()
+                    .next()
+                    .expect("logic error: len == 1")
+            } else {
+                ensure!(
+                    eci.encrypted_user_profile_keys.len() == 1,
+                    "Unjoined connection group must have exactly one user profile key"
+                );
+                &eci.encrypted_user_profile_keys[0]
+            };
 
             // Decrypt user profile key
-            let encrypted_user_profile_key = &eci.encrypted_user_profile_keys[0];
             let user_profile_key = UserProfileKey::decrypt(
                 &connection_info.connection_group_identity_link_wrapper_key,
                 encrypted_user_profile_key,

--- a/coreclient/src/clients/process/process_qs.rs
+++ b/coreclient/src/clients/process/process_qs.rs
@@ -54,7 +54,7 @@ use crate::{
     contacts::{PartialContact, PartialContactType},
     db::access::{WriteConnection, WriteDbTransaction},
     groups::{
-        Group, ProfileInfo, VerifiedGroup, client_auth_info::StorableClientCredential,
+        DecryptedProfileInfos, Group, VerifiedGroup, client_auth_info::StorableClientCredential,
         process::ProcessMessageResult,
     },
     job::{JobContext, JobContextDb, pending_chat_operation::PendingChatOperation},
@@ -305,7 +305,7 @@ impl CoreUser {
         ds_timestamp: TimeStamp,
         group: Group,
         sender_user_id: UserId,
-        member_profile_info: Vec<ProfileInfo>,
+        member_profile_info: DecryptedProfileInfos,
     ) -> anyhow::Result<ProcessQsMessageResult> {
         let group_id = group.group_id().clone();
 
@@ -314,20 +314,9 @@ impl CoreUser {
 
         // TODO: This can fail in some cases. If it does, we should fetch and
         // process messages and then try again.
-        let mut own_profile_key_in_group = None;
-        for profile_info in member_profile_info {
-            // TODO: Don't fetch while holding a transaction!
-            if profile_info.client_credential.user_id() == self.user_id() {
-                // We already have our own profile info.
-                own_profile_key_in_group = Some(profile_info.user_profile_key);
-                continue;
-            }
+        for profile_info in member_profile_info.members {
             Self::schedule_fetch_user_profile(&mut *txn, profile_info).await?;
         }
-
-        let Some(own_profile_key_in_group) = own_profile_key_in_group else {
-            bail!("No profile info for our user found");
-        };
 
         // WelcomeBundle Phase 3: Store the user profiles of the group
         // members if they don't exist yet and store the group and the
@@ -377,7 +366,7 @@ impl CoreUser {
 
         // WelcomeBundle Phase 4: Check whether our user profile key is up to
         // date and if not, update it.
-        if own_profile_key_in_group != own_profile_key {
+        if member_profile_info.own_profile_key.as_ref() != Some(&own_profile_key) {
             let qualified_group_id = QualifiedGroupId::try_from(group.group_id().clone())?;
             let api_client = self
                 .inner

--- a/coreclient/src/groups/mod.rs
+++ b/coreclient/src/groups/mod.rs
@@ -72,7 +72,7 @@ use openmls_provider::AirOpenMlsProvider;
 use openmls_traits::storage::StorageProvider;
 use serde::Serialize;
 use tls_codec::DeserializeBytes;
-use tracing::{Level, debug, enabled, error};
+use tracing::{Level, debug, enabled, error, warn};
 
 use crate::{
     SystemMessage,
@@ -145,6 +145,14 @@ impl PartialCreateGroupParams {
             pq,
         }
     }
+}
+
+#[derive(Debug)]
+pub(super) struct DecryptedProfileInfos {
+    /// Profile infos of *other* members
+    pub(super) members: Vec<ProfileInfo>,
+    /// None = DS entry missing or undecryptable
+    pub(super) own_profile_key: Option<UserProfileKey>,
 }
 
 #[derive(Debug)]
@@ -390,7 +398,7 @@ impl Group {
         txn: &mut WriteDbTransaction<'_>,
         api_clients: &ApiClients,
         signer: &ClientSigningKey,
-    ) -> Result<(Self, UserId, Vec<ProfileInfo>)> {
+    ) -> Result<(Self, UserId, DecryptedProfileInfos)> {
         let serialized_welcome = welcome_bundle.welcome.tls_serialize_detached()?;
 
         let mls_group_config = default_mls_group_join_config();
@@ -464,6 +472,7 @@ impl Group {
             ratchet_tree,
             encrypted_user_profile_keys,
             room_state,
+            indexed_encrypted_user_profile_keys,
         } = welcome_info;
 
         let (mls_group, joiner_info, welcome_attribution_info, sender_user_id) = {
@@ -526,21 +535,22 @@ impl Group {
         }
 
         // Phase 8: Decrypt profile keys
-        let member_profile_info = encrypted_user_profile_keys
-            .into_iter()
-            .zip(credentials)
-            .map(|(eupk, ci)| {
-                UserProfileKey::decrypt(
-                    welcome_attribution_info.identity_link_wrapper_key(),
-                    &eupk,
-                    ci.user_id(),
-                )
-                .map(|user_profile_key| ProfileInfo {
-                    user_profile_key,
-                    client_credential: ci.into(),
-                })
-            })
-            .collect::<Result<Vec<_>, _>>()?;
+        let encrypted_user_profile_keys_fallback = if indexed_encrypted_user_profile_keys.is_empty()
+        {
+            credentials
+                .iter()
+                .map(|c| c.user_id().clone())
+                .zip(encrypted_user_profile_keys)
+                .collect()
+        } else {
+            Default::default()
+        };
+        let member_profile_info = group.decrypt_member_profile_keys(
+            credentials,
+            indexed_encrypted_user_profile_keys,
+            encrypted_user_profile_keys_fallback,
+            signer.credential().user_id(),
+        );
 
         Ok((group, sender_user_id, member_profile_info))
     }
@@ -554,7 +564,7 @@ impl Group {
         txn: &mut WriteDbTransaction<'_>,
         api_clients: &ApiClients,
         signer: &ClientSigningKey,
-    ) -> Result<(Self, UserId, Vec<ProfileInfo>)> {
+    ) -> Result<(Self, UserId, DecryptedProfileInfos)> {
         // Phase 1: Serialize welcome and split
         let serialized_welcome = welcome_bundle.welcome.tls_serialize_detached()?;
         let (t_welcome, pq_welcome) = welcome_bundle.welcome.split();
@@ -597,6 +607,7 @@ impl Group {
             ratchet_tree: pq_ratchet_tree,
             encrypted_user_profile_keys: _,
             room_state: _,
+            indexed_encrypted_user_profile_keys: _,
         } = api_client
             .ds_welcome_info(
                 pq_group_id.clone(),
@@ -649,6 +660,7 @@ impl Group {
             ratchet_tree: t_ratchet_tree,
             encrypted_user_profile_keys,
             room_state,
+            indexed_encrypted_user_profile_keys,
         } = api_client
             .ds_welcome_info(
                 t_group_id.clone(),
@@ -704,23 +716,88 @@ impl Group {
         }
 
         // Phase 7: Decrypt profile keys
-        let member_profile_info = encrypted_user_profile_keys
-            .into_iter()
-            .zip(credentials)
-            .map(|(eupk, ci)| {
-                UserProfileKey::decrypt(
-                    welcome_attribution_info.identity_link_wrapper_key(),
-                    &eupk,
-                    ci.user_id(),
-                )
-                .map(|user_profile_key| ProfileInfo {
-                    user_profile_key,
-                    client_credential: ci.into(),
-                })
-            })
-            .collect::<Result<Vec<_>, _>>()?;
+        let encrypted_user_profiles_keys_fallback =
+            if indexed_encrypted_user_profile_keys.is_empty() {
+                credentials
+                    .iter()
+                    .map(|c| c.user_id().clone())
+                    .zip(encrypted_user_profile_keys)
+                    .collect()
+            } else {
+                Default::default()
+            };
+        let member_profile_info = group.decrypt_member_profile_keys(
+            credentials,
+            indexed_encrypted_user_profile_keys,
+            encrypted_user_profiles_keys_fallback,
+            signer.credential().user_id(),
+        );
 
         Ok((group, sender_user_id, member_profile_info))
+    }
+
+    /// Pair the encrypted user profile keys with the group members and decrypt them.
+    ///
+    /// Keys that are missing or fail to decrypt are skipped with a warning: a stale DS entry must
+    /// not fail the join/resync.
+    fn decrypt_member_profile_keys(
+        &self,
+        credentials: Vec<StorableClientCredential>,
+        indexed_keys: HashMap<LeafNodeIndex, EncryptedUserProfileKey>,
+        // Positional fallback for servers that don't send indexed keys yet
+        fallback_keys: HashMap<UserId, EncryptedUserProfileKey>,
+        own_user_id: &UserId,
+    ) -> DecryptedProfileInfos {
+        let indices = self.mls_group().members().map(|m| m.index);
+
+        let mut members = Vec::with_capacity(credentials.len());
+        let mut own_profile_key = None;
+
+        for (index, credential) in indices.zip(credentials) {
+            let eupk = if !indexed_keys.is_empty() {
+                indexed_keys.get(&index)
+            } else {
+                fallback_keys.get(credential.user_id())
+            };
+            let Some(eupk) = eupk else {
+                if credential.user_id() != own_user_id {
+                    // Own key is sometimes expected to be missing
+                    warn!(
+                        user_id =? credential.user_id(),
+                        "No user profile key for member; skipping"
+                    );
+                }
+                continue;
+            };
+            match UserProfileKey::decrypt(
+                &self.identity_link_wrapper_key,
+                eupk,
+                credential.user_id(),
+            ) {
+                Ok(user_profile_key) => {
+                    if credential.user_id() == own_user_id {
+                        own_profile_key = Some(user_profile_key);
+                    } else {
+                        members.push(ProfileInfo {
+                            user_profile_key,
+                            client_credential: credential.into(),
+                        });
+                    }
+                }
+                Err(error) => {
+                    warn!(
+                        %error,
+                        user_id =? credential.user_id(),
+                        "Failed to decrypt user profile key; skipping"
+                    );
+                    continue;
+                }
+            }
+        }
+        DecryptedProfileInfos {
+            members,
+            own_profile_key,
+        }
     }
 
     /// Join a group using an external commit.
@@ -736,7 +813,10 @@ impl Group {
         // Should be Some if this join is in response to a connection offer.
         connection_offer_hash: Option<ConnectionOfferHash>,
     ) -> anyhow::Result<
-        Result<(Self, MlsMessageOut, MlsMessageOut, Vec<ProfileInfo>), LeafNodeValidationError>,
+        Result<
+            (Self, MlsMessageOut, MlsMessageOut, DecryptedProfileInfos),
+            LeafNodeValidationError,
+        >,
     > {
         let mls_group_config = default_mls_group_join_config();
         let credential_with_key = CredentialWithKey {
@@ -747,6 +827,7 @@ impl Group {
             verifiable_group_info,
             ratchet_tree_in,
             encrypted_user_profile_keys,
+            indexed_encrypted_user_profile_keys,
             room_state,
             proposals,
         } = external_commit_info;
@@ -764,7 +845,7 @@ impl Group {
 
         // Let's create the group first so that we can access the GroupId.
         // Phase 1: Create and store the group
-        let (mls_group, commit, group_info, encrypted_profile_keys) = {
+        let (mls_group, commit, group_info, encrypted_profile_keys_fallback) = {
             let provider = AirOpenMlsProvider::new(txn.as_mut());
             // Prepare PSK proposal if we have a connection offer hash.
             let psk_proposal = match connection_offer_hash {
@@ -786,17 +867,23 @@ impl Group {
                 .with_extensions(default_leaf_node_extensions::<AirComponent>())
                 .build();
 
-            let encrypted_profile_keys: HashMap<UserId, EncryptedUserProfileKey> = ratchet_tree_in
-                .leaves()
-                .zip(encrypted_user_profile_keys)
-                .filter_map(|(leaf_node, profile_key)| {
-                    let cred =
-                        VerifiableClientCredential::from_basic_credential(leaf_node.credential())
-                            .ok()?;
-                    // Credentials will be verified below
-                    Some((cred.user_id().clone(), profile_key))
-                })
-                .collect();
+            let encrypted_profile_keys_fallback = if indexed_encrypted_user_profile_keys.is_empty()
+            {
+                ratchet_tree_in
+                    .leaves()
+                    .zip(encrypted_user_profile_keys)
+                    .filter_map(|(leaf_node, profile_key)| {
+                        let cred = VerifiableClientCredential::from_basic_credential(
+                            leaf_node.credential(),
+                        )
+                        .ok()?;
+                        // Credentials will be verified below
+                        Some((cred.user_id().clone(), profile_key))
+                    })
+                    .collect()
+            } else {
+                Default::default()
+            };
 
             let mut builder = ExternalCommitBuilder::new()
                 .with_proposals(proposals)
@@ -827,7 +914,7 @@ impl Group {
                 mls_group,
                 commit,
                 group_info.context("No group info found")?,
-                encrypted_profile_keys,
+                encrypted_profile_keys_fallback,
             )
         };
 
@@ -849,30 +936,16 @@ impl Group {
         Group::delete_from_db(txn, group.group_id()).await?;
         group.store(&mut *txn).await?;
 
-        // Store credentials and accumulate member profile keys (excl. own member)
-        let mut member_profile_info = Vec::with_capacity(credentials.len());
-        for credential in credentials {
-            credential.store(&mut *txn).await?; // store everyone incl. self
-
-            // Decrypt the user profile key
-            if credential.user_id() == signer.credential().user_id() {
-                continue; // skip profile-key lookup for self
-            }
-            let eupk = encrypted_profile_keys
-                .get(credential.user_id())
-                .context("Missing user profile key")?;
-            let profile_info = UserProfileKey::decrypt(
-                &group.identity_link_wrapper_key,
-                eupk,
-                credential.user_id(),
-            )
-            .map(|user_profile_key| ProfileInfo {
-                user_profile_key,
-                client_credential: credential.into(),
-            })
-            .context("Failed to decrypt user profile key")?;
-            member_profile_info.push(profile_info);
+        for credential in &credentials {
+            credential.store(&mut *txn).await?;
         }
+
+        let member_profile_info = group.decrypt_member_profile_keys(
+            credentials,
+            indexed_encrypted_user_profile_keys,
+            encrypted_profile_keys_fallback,
+            signer.credential().user_id(),
+        );
 
         Ok(Ok((group, commit, group_info.into(), member_profile_info)))
     }

--- a/coreclient/src/outbound_service/resync.rs
+++ b/coreclient/src/outbound_service/resync.rs
@@ -21,7 +21,7 @@ use crate::{
     ChatId,
     clients::{CoreUser, api_clients::ApiClients},
     db::access::{WriteConnection, WriteDbTransaction},
-    groups::{Group, ProfileInfo, handle_group_not_found_on_ds},
+    groups::{DecryptedProfileInfos, Group, ProfileInfo, handle_group_not_found_on_ds},
     job::{operation::OperationData, profile::FetchUserProfileOperation},
     outbound_service::{
         OutboundServiceContext,
@@ -123,7 +123,7 @@ impl OutboundServiceContext {
             for ProfileInfo {
                 client_credential,
                 user_profile_key,
-            } in profile_infos
+            } in profile_infos.members
             {
                 if let Err(error) =
                     FetchUserProfileOperation::new(client_credential, user_profile_key)
@@ -145,7 +145,7 @@ impl Resync {
         mut connection: impl WriteConnection,
         api_clients: &ApiClients,
         signer: &ClientSigningKey,
-    ) -> Result<Vec<ProfileInfo>, OutboundServiceError> {
+    ) -> Result<DecryptedProfileInfos, OutboundServiceError> {
         // TODO: We should somehow mark the chat as "resyncing" in the DB and
         // reflect that in the UI.
 
@@ -205,7 +205,7 @@ impl Resync {
         api_clients: &ApiClients,
         signer: &ClientSigningKey,
         external_commit_info: ExternalCommitInfoIn,
-    ) -> Result<(Group, MlsMessageOut, MlsMessageOut, Vec<ProfileInfo>)> {
+    ) -> Result<(Group, MlsMessageOut, MlsMessageOut, DecryptedProfileInfos)> {
         // TODO: We should somehow mark the chat as "resyncing" in the DB and
         // reflect that in the UI.
 
@@ -213,7 +213,7 @@ impl Resync {
         Group::delete_from_db(txn, &self.group_id).await?;
 
         let aad = AadPayload::Resync.into();
-        let (new_group, commit, group_info, member_profile_info) = Group::join_group_externally(
+        Ok(Group::join_group_externally(
             txn,
             api_clients,
             external_commit_info,
@@ -223,9 +223,7 @@ impl Resync {
             aad,
             None, // This is not in response to a connection offer.
         )
-        .await??;
-
-        Ok((new_group, commit, group_info, member_profile_info))
+        .await??)
     }
 
     async fn send_commit(

--- a/protos/api/delivery_service/v1/delivery_service.proto
+++ b/protos/api/delivery_service/v1/delivery_service.proto
@@ -89,6 +89,11 @@ message RoomState {
   bytes tls = 1;
 }
 
+message IndexedEncryptedUserProfileKey {
+  uint32 leaf_index = 1;
+  EncryptedUserProfileKey encrypted_user_profile_key = 2;
+}
+
 // request group id
 
 message RequestGroupIdRequest {
@@ -205,6 +210,7 @@ message WelcomeInfoResponse {
   RatchetTree ratchet_tree = 1;
   repeated EncryptedUserProfileKey encrypted_user_profile_keys = 3;
   RoomState room_state = 4;
+  repeated IndexedEncryptedUserProfileKey indexed_encrypted_user_profile_keys = 5;
 }
 
 // external commit info
@@ -221,6 +227,7 @@ message ExternalCommitInfoResponse {
   repeated EncryptedUserProfileKey encrypted_user_profile_keys = 4;
   RoomState room_state = 5;
   repeated MlsMessage proposals = 6;
+  repeated IndexedEncryptedUserProfileKey indexed_encrypted_user_profile_keys = 7;
 }
 
 message GroupInfo {
@@ -241,6 +248,7 @@ message ConnectionGroupInfoResponse {
   repeated EncryptedUserProfileKey encrypted_user_profile_keys = 4;
   RoomState room_state = 5;
   repeated MlsMessage proposals = 6;
+  repeated IndexedEncryptedUserProfileKey indexed_encrypted_user_profile_keys = 7;
 }
 
 // join connection group


### PR DESCRIPTION
User profile keys in welcome info, external commit info and connection
group info were sent as a bare list and paired with group members by
position. The pairing breaks whenever DS member don't match the ratchet
tree 1:1: notably corrupted by pre-https://github.com/phnx-im/air/pull/1281 resync. This bricked every join
and resync of such groups with a profile key decryption error.

* DS: send profile keys keyed by leaf index
  (IndexedEncryptedUserProfileKey). The positional list is kept for
  backwards compatibility with old clients. It is also used by new
  clients as fallback for old servers.
* client: Pair profile keys with members by leaf index. Unify pairing of
  (apq) welcome and external commit joins.
* client: Skip profiles that are missing or failed to decrypt. A stale
  DS entry only costs the affected member's display name, which heals on
  their next profile key update.
* client: When joining via welcome, a missing own profile on the DS is
  now treated like an outdated one and triggers a republish, instead of
  failing the join.
* client: The connection offer fallacbk also uses indexed keys now.