### PR TITLE
fix(server): send QS client reference and encrypted user profile key out of band

### DIFF
--- a/apiclient/src/ds_api.rs
+++ b/apiclient/src/ds_api.rs
@@ -457,6 +457,8 @@ impl ApiClient {
         signing_key: &ClientSigningKey,
         group_state_ear_key: &GroupStateEarKey,
         own_leaf_index: LeafNodeIndex,
+        qs_client_reference: QsReference,
+        encrypted_user_profile_key: EncryptedUserProfileKey,
     ) -> Result<TimeStamp, DsRequestError> {
         let external_commit = AssistedMessageOut::new(commit, Some(group_info));
         let payload = ResyncPayload {
@@ -464,6 +466,8 @@ impl ApiClient {
             group_state_ear_key: Some(group_state_ear_key.ref_into()),
             external_commit: Some(external_commit.try_ref_into()?),
             sender: Some(own_leaf_index.into()),
+            qs_client_reference: Some(qs_client_reference.into()),
+            encrypted_user_profile_key: Some(encrypted_user_profile_key.into()),
         };
         let request = payload.sign(signing_key)?;
         let response = self.ds_grpc_client().resync(request).await?.into_inner();

--- a/apiclient/src/ds_api.rs
+++ b/apiclient/src/ds_api.rs
@@ -202,6 +202,8 @@ impl ApiClient {
         payload: GroupOperationParamsOut,
         signing_key: &ClientSigningKey,
         group_state_ear_key: &GroupStateEarKey,
+        qs_client_reference: QsReference,
+        encrypted_user_profile_key: EncryptedUserProfileKey,
     ) -> Result<TimeStamp, DsRequestError> {
         let add_users_info = payload
             .add_users_info_option
@@ -221,6 +223,8 @@ impl ApiClient {
             group_state_ear_key: Some(group_state_ear_key.ref_into()),
             commit: Some(payload.commit.try_ref_into()?),
             add_users_info,
+            qs_client_reference: Some(qs_client_reference.into()),
+            encrypted_user_profile_key: Some(encrypted_user_profile_key.into()),
         };
         let request = payload.sign(signing_key)?;
         let response = self
@@ -240,6 +244,8 @@ impl ApiClient {
         params: ApqGroupOperationParamsOut,
         signing_key: &ClientSigningKey,
         group_state_ear_key: &GroupStateEarKey,
+        qs_client_reference: QsReference,
+        encrypted_user_profile_key: EncryptedUserProfileKey,
     ) -> Result<TimeStamp, DsRequestError> {
         let ApqGroupOperationParamsOut {
             bundle:
@@ -276,6 +282,8 @@ impl ApiClient {
             group_state_ear_key: Some(group_state_ear_key.ref_into()),
             commit: Some(commit),
             add_users_info,
+            qs_client_reference: Some(qs_client_reference.into()),
+            encrypted_user_profile_key: Some(encrypted_user_profile_key.into()),
         };
         let request = payload.sign(signing_key)?;
         let response = self
@@ -457,8 +465,6 @@ impl ApiClient {
         signing_key: &ClientSigningKey,
         group_state_ear_key: &GroupStateEarKey,
         own_leaf_index: LeafNodeIndex,
-        qs_client_reference: QsReference,
-        encrypted_user_profile_key: EncryptedUserProfileKey,
     ) -> Result<TimeStamp, DsRequestError> {
         let external_commit = AssistedMessageOut::new(commit, Some(group_info));
         let payload = ResyncPayload {
@@ -466,8 +472,6 @@ impl ApiClient {
             group_state_ear_key: Some(group_state_ear_key.ref_into()),
             external_commit: Some(external_commit.try_ref_into()?),
             sender: Some(own_leaf_index.into()),
-            qs_client_reference: Some(qs_client_reference.into()),
-            encrypted_user_profile_key: Some(encrypted_user_profile_key.into()),
         };
         let request = payload.sign(signing_key)?;
         let response = self.ds_grpc_client().resync(request).await?.into_inner();

--- a/backend/src/ds/group_state/mod.rs
+++ b/backend/src/ds/group_state/mod.rs
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-use std::collections::{BTreeMap, btree_map::Entry};
+use std::collections::BTreeMap;
 
 use aircommon::{
     codec::PersistenceCodec,
@@ -205,37 +205,6 @@ impl DsGroupState {
         self.member_profiles
             .get(&member_index)
             .map(|cp| cp.client_queue_config.clone())
-    }
-
-    pub(crate) fn upsert_member_profile(
-        &mut self,
-        leaf_index: LeafNodeIndex,
-        qs_reference: QsReference,
-        encrypted_user_profile_key: EncryptedUserProfileKey,
-        activity_epoch: GroupEpoch,
-    ) {
-        match self.member_profiles.entry(leaf_index) {
-            Entry::Occupied(mut entry) => {
-                if entry.get().encrypted_user_profile_key != encrypted_user_profile_key {
-                    entry.insert(MemberProfile {
-                        leaf_index,
-                        client_queue_config: qs_reference,
-                        activity_time: TimeStamp::now(),
-                        activity_epoch,
-                        encrypted_user_profile_key,
-                    });
-                }
-            }
-            Entry::Vacant(vacant) => {
-                vacant.insert(MemberProfile {
-                    leaf_index,
-                    client_queue_config: qs_reference,
-                    activity_time: TimeStamp::now(),
-                    activity_epoch,
-                    encrypted_user_profile_key,
-                });
-            }
-        }
     }
 }
 

--- a/backend/src/ds/group_state/mod.rs
+++ b/backend/src/ds/group_state/mod.rs
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, btree_map::Entry};
 
 use aircommon::{
     codec::PersistenceCodec,
@@ -205,6 +205,37 @@ impl DsGroupState {
         self.member_profiles
             .get(&member_index)
             .map(|cp| cp.client_queue_config.clone())
+    }
+
+    pub(crate) fn upsert_member_profile(
+        &mut self,
+        leaf_index: LeafNodeIndex,
+        qs_reference: QsReference,
+        encrypted_user_profile_key: EncryptedUserProfileKey,
+        activity_epoch: GroupEpoch,
+    ) {
+        match self.member_profiles.entry(leaf_index) {
+            Entry::Occupied(mut entry) => {
+                if entry.get().encrypted_user_profile_key != encrypted_user_profile_key {
+                    entry.insert(MemberProfile {
+                        leaf_index,
+                        client_queue_config: qs_reference,
+                        activity_time: TimeStamp::now(),
+                        activity_epoch,
+                        encrypted_user_profile_key,
+                    });
+                }
+            }
+            Entry::Vacant(vacant) => {
+                vacant.insert(MemberProfile {
+                    leaf_index,
+                    client_queue_config: qs_reference,
+                    activity_time: TimeStamp::now(),
+                    activity_epoch,
+                    encrypted_user_profile_key,
+                });
+            }
+        }
     }
 }
 

--- a/backend/src/ds/grpc.rs
+++ b/backend/src/ds/grpc.rs
@@ -1122,6 +1122,20 @@ impl<Qep: QsConnector, As: AsConnector> DeliveryService for GrpcDs<Qep, As> {
                     .create_commit_response(sender_index, fan_out_payload.timestamp())?;
                 individual_fan_out_messages.push(commit_response);
 
+                // If specified by the client, we update our internal mapping of leaves to MemberProfile.
+                // This is used to recover groups where the OpenMLS leaves and its representation on the DS drifted.
+                if let Some((qs_client_reference, encrypted_user_profile_key)) = payload
+                    .qs_client_reference
+                    .zip(payload.encrypted_user_profile_key)
+                {
+                    group_state.upsert_member_profile(
+                        sender_index,
+                        qs_client_reference.try_into()?,
+                        encrypted_user_profile_key.try_into()?,
+                        group_state.group().epoch(),
+                    );
+                }
+
                 Ok((
                     destination_clients,
                     fan_out_payload,
@@ -1332,6 +1346,20 @@ impl<Qep: QsConnector, As: AsConnector> DeliveryService for GrpcDs<Qep, As> {
 
         let commit_response = t_group_state.create_commit_response(t_sender_index, timestamp)?;
         individual_fan_out_messages.push(commit_response);
+
+        // If specified by the client, we update our internal mapping of leaves to MemberProfile.
+        // This is used to recover groups where the OpenMLS leaves and its representation on the DS drifted.
+        if let Some((qs_client_reference, encrypted_user_profile_key)) = payload
+            .qs_client_reference
+            .zip(payload.encrypted_user_profile_key)
+        {
+            pq_group_state.upsert_member_profile(
+                pq_sender_index,
+                qs_client_reference.try_into()?,
+                encrypted_user_profile_key.try_into()?,
+                pq_group_state.group().epoch(),
+            );
+        }
 
         // Persist and commit the DS state *before* dispatching welcome bundles, so that joiners
         // fetching welcome info always observe the freshly stored past group state.

--- a/backend/src/ds/grpc.rs
+++ b/backend/src/ds/grpc.rs
@@ -45,7 +45,7 @@ use tracing::{error, warn};
 
 use crate::{
     auth_service::AsConnector,
-    ds::{attachments::ProvisionObjectError, process::Provider},
+    ds::{attachments::ProvisionObjectError, group_state::MemberProfile, process::Provider},
     messages::intra_backend::{DsFanOutMessage, DsFanOutPayload},
     qs::QsConnector,
     rate_limiter::{RateLimiter, RlConfig, RlKey, provider::RlPostgresStorage},
@@ -1128,11 +1128,15 @@ impl<Qep: QsConnector, As: AsConnector> DeliveryService for GrpcDs<Qep, As> {
                     .qs_client_reference
                     .zip(payload.encrypted_user_profile_key)
                 {
-                    group_state.upsert_member_profile(
+                    group_state.member_profiles.insert(
                         sender_index,
-                        qs_client_reference.try_into()?,
-                        encrypted_user_profile_key.try_into()?,
-                        group_state.group().epoch(),
+                        MemberProfile {
+                            leaf_index: sender_index,
+                            client_queue_config: qs_client_reference.try_into()?,
+                            activity_time: TimeStamp::now(),
+                            activity_epoch: group_state.group().epoch(),
+                            encrypted_user_profile_key: encrypted_user_profile_key.try_into()?,
+                        },
                     );
                 }
 
@@ -1353,11 +1357,15 @@ impl<Qep: QsConnector, As: AsConnector> DeliveryService for GrpcDs<Qep, As> {
             .qs_client_reference
             .zip(payload.encrypted_user_profile_key)
         {
-            pq_group_state.upsert_member_profile(
+            pq_group_state.member_profiles.insert(
                 pq_sender_index,
-                qs_client_reference.try_into()?,
-                encrypted_user_profile_key.try_into()?,
-                pq_group_state.group().epoch(),
+                MemberProfile {
+                    leaf_index: pq_sender_index,
+                    client_queue_config: qs_client_reference.try_into()?,
+                    activity_time: TimeStamp::now(),
+                    activity_epoch: pq_group_state.group().epoch(),
+                    encrypted_user_profile_key: encrypted_user_profile_key.try_into()?,
+                },
             );
         }
 

--- a/backend/src/ds/grpc.rs
+++ b/backend/src/ds/grpc.rs
@@ -1246,7 +1246,8 @@ impl<Qep: QsConnector, As: AsConnector> DeliveryService for GrpcDs<Qep, As> {
         let t_sender = t_group_state
             .group()
             .leaf(t_sender_index)
-            .ok_or(Status::invalid_argument("unknown sender"))?;
+            .ok_or(Status::invalid_argument("unknown sender"))?
+            .clone();
         let t_verifying_key: LeafVerifyingKeyRef = t_sender.signature_key().into();
         let payload: ApqGroupOperationPayload =
             request.verify(t_verifying_key).map_err(InvalidSignature)?;

--- a/backend/src/ds/grpc.rs
+++ b/backend/src/ds/grpc.rs
@@ -1251,6 +1251,24 @@ impl<Qep: QsConnector, As: AsConnector> DeliveryService for GrpcDs<Qep, As> {
         let payload: ApqGroupOperationPayload =
             request.verify(t_verifying_key).map_err(InvalidSignature)?;
 
+        // If specified by the client, we update our internal mapping of leaves to MemberProfile.
+        // This is used to recover groups where the OpenMLS leaves and its representation on the DS drifted.
+        if let Some((qs_client_reference, encrypted_user_profile_key)) = payload
+            .qs_client_reference
+            .zip(payload.encrypted_user_profile_key)
+        {
+            t_group_state.member_profiles.insert(
+                t_sender_index,
+                MemberProfile {
+                    leaf_index: t_sender_index,
+                    client_queue_config: qs_client_reference.try_into()?,
+                    activity_time: TimeStamp::now(),
+                    activity_epoch: t_group_state.group().epoch(),
+                    encrypted_user_profile_key: encrypted_user_profile_key.try_into()?,
+                },
+            );
+        }
+
         // Load the pq-group state
         let (mut pq_group_state, pq_group_data) = match self
             .load_group_state_for_update(&mut txn, &pq_qgid, &ear_key)
@@ -1291,24 +1309,6 @@ impl<Qep: QsConnector, As: AsConnector> DeliveryService for GrpcDs<Qep, As> {
             return Err(Status::invalid_argument(
                 "t and pq credentials do not match",
             ));
-        }
-
-        // If specified by the client, we update our internal mapping of leaves to MemberProfile.
-        // This is used to recover groups where the OpenMLS leaves and its representation on the DS drifted.
-        if let Some((qs_client_reference, encrypted_user_profile_key)) = payload
-            .qs_client_reference
-            .zip(payload.encrypted_user_profile_key)
-        {
-            pq_group_state.member_profiles.insert(
-                pq_sender_index,
-                MemberProfile {
-                    leaf_index: pq_sender_index,
-                    client_queue_config: qs_client_reference.try_into()?,
-                    activity_time: TimeStamp::now(),
-                    activity_epoch: pq_group_state.group().epoch(),
-                    encrypted_user_profile_key: encrypted_user_profile_key.try_into()?,
-                },
-            );
         }
 
         // Process group operation

--- a/backend/src/ds/grpc.rs
+++ b/backend/src/ds/grpc.rs
@@ -1099,6 +1099,24 @@ impl<Qep: QsConnector, As: AsConnector> DeliveryService for GrpcDs<Qep, As> {
                     ..
                 } = verification_data;
 
+                // If specified by the client, we update our internal mapping of leaves to MemberProfile.
+                // This is used to recover groups where the OpenMLS leaves and its representation on the DS drifted.
+                if let Some((qs_client_reference, encrypted_user_profile_key)) = payload
+                    .qs_client_reference
+                    .zip(payload.encrypted_user_profile_key)
+                {
+                    group_state.member_profiles.insert(
+                        sender_index,
+                        MemberProfile {
+                            leaf_index: sender_index,
+                            client_queue_config: qs_client_reference.try_into()?,
+                            activity_time: TimeStamp::now(),
+                            activity_epoch: group_state.group().epoch(),
+                            encrypted_user_profile_key: encrypted_user_profile_key.try_into()?,
+                        },
+                    );
+                }
+
                 let params = GroupOperationParams {
                     commit,
                     add_users_info_option: payload
@@ -1121,24 +1139,6 @@ impl<Qep: QsConnector, As: AsConnector> DeliveryService for GrpcDs<Qep, As> {
                 let commit_response = group_state
                     .create_commit_response(sender_index, fan_out_payload.timestamp())?;
                 individual_fan_out_messages.push(commit_response);
-
-                // If specified by the client, we update our internal mapping of leaves to MemberProfile.
-                // This is used to recover groups where the OpenMLS leaves and its representation on the DS drifted.
-                if let Some((qs_client_reference, encrypted_user_profile_key)) = payload
-                    .qs_client_reference
-                    .zip(payload.encrypted_user_profile_key)
-                {
-                    group_state.member_profiles.insert(
-                        sender_index,
-                        MemberProfile {
-                            leaf_index: sender_index,
-                            client_queue_config: qs_client_reference.try_into()?,
-                            activity_time: TimeStamp::now(),
-                            activity_epoch: group_state.group().epoch(),
-                            encrypted_user_profile_key: encrypted_user_profile_key.try_into()?,
-                        },
-                    );
-                }
 
                 Ok((
                     destination_clients,
@@ -1293,6 +1293,24 @@ impl<Qep: QsConnector, As: AsConnector> DeliveryService for GrpcDs<Qep, As> {
             ));
         }
 
+        // If specified by the client, we update our internal mapping of leaves to MemberProfile.
+        // This is used to recover groups where the OpenMLS leaves and its representation on the DS drifted.
+        if let Some((qs_client_reference, encrypted_user_profile_key)) = payload
+            .qs_client_reference
+            .zip(payload.encrypted_user_profile_key)
+        {
+            pq_group_state.member_profiles.insert(
+                pq_sender_index,
+                MemberProfile {
+                    leaf_index: pq_sender_index,
+                    client_queue_config: qs_client_reference.try_into()?,
+                    activity_time: TimeStamp::now(),
+                    activity_epoch: pq_group_state.group().epoch(),
+                    encrypted_user_profile_key: encrypted_user_profile_key.try_into()?,
+                },
+            );
+        }
+
         // Process group operation
         let add_users_info: Option<client_ds::ApqAddUsersInfo> = payload
             .add_users_info
@@ -1350,24 +1368,6 @@ impl<Qep: QsConnector, As: AsConnector> DeliveryService for GrpcDs<Qep, As> {
 
         let commit_response = t_group_state.create_commit_response(t_sender_index, timestamp)?;
         individual_fan_out_messages.push(commit_response);
-
-        // If specified by the client, we update our internal mapping of leaves to MemberProfile.
-        // This is used to recover groups where the OpenMLS leaves and its representation on the DS drifted.
-        if let Some((qs_client_reference, encrypted_user_profile_key)) = payload
-            .qs_client_reference
-            .zip(payload.encrypted_user_profile_key)
-        {
-            pq_group_state.member_profiles.insert(
-                pq_sender_index,
-                MemberProfile {
-                    leaf_index: pq_sender_index,
-                    client_queue_config: qs_client_reference.try_into()?,
-                    activity_time: TimeStamp::now(),
-                    activity_epoch: pq_group_state.group().epoch(),
-                    encrypted_user_profile_key: encrypted_user_profile_key.try_into()?,
-                },
-            );
-        }
 
         // Persist and commit the DS state *before* dispatching welcome bundles, so that joiners
         // fetching welcome info always observe the freshly stored past group state.

--- a/coreclient/src/clients/mod.rs
+++ b/coreclient/src/clients/mod.rs
@@ -818,6 +818,7 @@ impl CoreUser {
             db: JobContextDb::Db(self.inner.db.clone()),
             key_store: &self.inner.key_store,
             now: Utc::now(),
+            qs_client_id: &self.inner.qs_client_id,
         };
         job.execute(&mut context).await
     }

--- a/coreclient/src/clients/process/process_as.rs
+++ b/coreclient/src/clients/process/process_as.rs
@@ -155,6 +155,7 @@ impl CoreUser {
                     db: JobContextDb::Db(self.inner.db.clone()),
                     key_store: &self.inner.key_store,
                     now: Utc::now(),
+                    qs_client_id: &self.inner.qs_client_id,
                 };
                 let chat_id =
                     Self::process_connection_offer(&mut context, connection_info_source).await?;

--- a/coreclient/src/clients/process/process_qs.rs
+++ b/coreclient/src/clients/process/process_qs.rs
@@ -460,6 +460,7 @@ impl CoreUser {
             db: JobContextDb::Transaction(txn),
             key_store: &self.inner.key_store,
             now: Utc::now(),
+            qs_client_id: &self.inner.qs_client_id,
         };
 
         let chat_id =

--- a/coreclient/src/job/chat_operation.rs
+++ b/coreclient/src/job/chat_operation.rs
@@ -5,7 +5,7 @@
 use std::{borrow::Cow, collections::HashSet};
 
 use airapiclient::ds_api::DsAttachmentTarget;
-use aircommon::identifiers::UserId;
+use aircommon::{crypto::errors::EncryptionError, identifiers::UserId};
 use airprotos::{
     client::group::{EncryptedGroupTitle, GroupData, GroupProfile},
     delivery_service::v1::StorageObjectType,
@@ -41,6 +41,8 @@ pub(crate) struct ChatOperation {
 pub(crate) enum ChatOperationError {
     #[error(transparent)]
     LeafNodeValidation(#[from] LeafNodeValidationError),
+    #[error("failed to encrypt user profile key")]
+    UserProfileKeyEncryptionError(EncryptionError),
 }
 
 impl Job for ChatOperation {

--- a/coreclient/src/job/mod.rs
+++ b/coreclient/src/job/mod.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 use airapiclient::{ApiClientInitError, as_api::AsRequestError, ds_api::DsRequestError};
-use aircommon::codec;
+use aircommon::{codec, identifiers::QsClientId};
 use chrono::{DateTime, Utc};
 use sqlx::SqliteConnection;
 use thiserror::Error;
@@ -33,6 +33,7 @@ pub(crate) struct JobContext<'a, 'c> {
     pub db: JobContextDb<'a, 'c>,
     pub key_store: &'a MemoryUserKeyStore,
     pub now: DateTime<Utc>,
+    pub qs_client_id: &'a QsClientId,
 }
 
 pub(crate) enum JobContextDb<'a, 'c> {

--- a/coreclient/src/job/pending_chat_operation.rs
+++ b/coreclient/src/job/pending_chat_operation.rs
@@ -5,6 +5,7 @@
 use airapiclient::ds_api::DsRequestError;
 use aircommon::{
     credentials::{ClientCredential, keys::ClientSigningKey},
+    crypto::indexed_aead::keys::UserProfileKey,
     identifiers::{QualifiedGroupId, UserId},
     messages::client_ds_out::{
         ApqGroupOperationParamsOut, DeleteGroupParamsOut, GroupOperationParamsOut,
@@ -30,7 +31,10 @@ use crate::{
         Group, GroupDataBytes, PreparedInvitee, VerifiedGroup,
         client_auth_info::StorableClientCredential, handle_group_not_found_on_ds,
     },
-    job::{Job, JobContext, JobError, chat_operation::ChatOperationError},
+    job::{
+        Job, JobContext, JobContextReadConnection, JobError, chat_operation::ChatOperationError,
+    },
+    key_stores::indexed_keys::StorableIndexedKey,
 };
 
 // Having separate retry intervals for test and non-test is a hack until we can
@@ -238,6 +242,7 @@ impl PendingChatOperation {
             db,
             key_store,
             now,
+            qs_client_id,
             ..
         } = context;
         let signer = &key_store.signing_key;
@@ -267,6 +272,18 @@ impl PendingChatOperation {
                 .stage_leave_group(db.write().await?, signer)?;
         }
 
+        let encrypt_user_profile_key =
+            async |connection: JobContextReadConnection| -> Result<_, JobError<ChatOperationError>> {
+                let own_user_id = key_store.signing_key.credential().user_id();
+                let own_user_profile_key = UserProfileKey::load_own(connection).await?;
+                let own_encrypted_user_profile_key = own_user_profile_key
+                    .encrypt(self.group.identity_link_wrapper_key(), own_user_id)
+                    .map_err(|e| {
+                        JobError::domain(ChatOperationError::UserProfileKeyEncryptionError(e))
+                    })?;
+                Ok(own_encrypted_user_profile_key)
+            };
+
         let mut new_chat_picture = None;
         // TODO: Can we avoid cloning here?
         let res = match self.operation.clone() {
@@ -285,8 +302,18 @@ impl PendingChatOperation {
                 new_chat_picture: chat_picture,
             } => {
                 new_chat_picture = chat_picture;
+                let own_qs_client_reference = key_store.create_own_client_reference(qs_client_id);
+                let own_encrypted_user_profile_key =
+                    encrypt_user_profile_key(db.read().await?).await?;
+
                 api_client
-                    .ds_group_operation(*params, signer, self.group.group_state_ear_key())
+                    .ds_group_operation(
+                        *params,
+                        signer,
+                        self.group.group_state_ear_key(),
+                        own_qs_client_reference,
+                        own_encrypted_user_profile_key,
+                    )
                     .await
             }
             OperationType::ApqOther {
@@ -294,8 +321,19 @@ impl PendingChatOperation {
                 new_chat_picture: chat_picture,
             } => {
                 new_chat_picture = chat_picture;
+
+                let own_qs_client_reference = key_store.create_own_client_reference(qs_client_id);
+                let own_encrypted_user_profile_key =
+                    encrypt_user_profile_key(db.read().await?).await?;
+
                 api_client
-                    .ds_apq_group_operation(*params, signer, self.group.group_state_ear_key())
+                    .ds_apq_group_operation(
+                        *params,
+                        signer,
+                        self.group.group_state_ear_key(),
+                        own_qs_client_reference,
+                        own_encrypted_user_profile_key,
+                    )
                     .await
             }
         };

--- a/coreclient/src/outbound_service/mod.rs
+++ b/coreclient/src/outbound_service/mod.rs
@@ -10,7 +10,6 @@ use std::{
 
 use aircommon::{
     credentials::keys::ClientSigningKey,
-    crypto::{aead::keys::PushTokenEarKey, hpke::ClientIdEncryptionKey},
     identifiers::{QsClientId, UserId},
 };
 use chrono::Utc;
@@ -226,6 +225,7 @@ impl OutboundServiceContext {
             db: JobContextDb::Db(self.db.clone()),
             key_store: &self.key_store,
             now: Utc::now(),
+            qs_client_id: &self.qs_client_id,
         };
         let value = job.execute(&mut context).await?;
         Ok(value)
@@ -270,14 +270,6 @@ impl OutboundServiceContext {
 
     fn user_id(&self) -> &UserId {
         self.signing_key().credential().user_id()
-    }
-
-    fn push_token_ear_key(&self) -> &PushTokenEarKey {
-        &self.key_store.push_token_ear_key
-    }
-
-    fn qs_client_id_encryption_key(&self) -> &ClientIdEncryptionKey {
-        &self.key_store.qs_client_id_encryption_key
     }
 }
 

--- a/coreclient/src/outbound_service/mod.rs
+++ b/coreclient/src/outbound_service/mod.rs
@@ -10,6 +10,7 @@ use std::{
 
 use aircommon::{
     credentials::keys::ClientSigningKey,
+    crypto::{aead::keys::PushTokenEarKey, hpke::ClientIdEncryptionKey},
     identifiers::{QsClientId, UserId},
 };
 use chrono::Utc;
@@ -269,6 +270,14 @@ impl OutboundServiceContext {
 
     fn user_id(&self) -> &UserId {
         self.signing_key().credential().user_id()
+    }
+
+    fn push_token_ear_key(&self) -> &PushTokenEarKey {
+        &self.key_store.push_token_ear_key
+    }
+
+    fn qs_client_id_encryption_key(&self) -> &ClientIdEncryptionKey {
+        &self.key_store.qs_client_id_encryption_key
     }
 }
 

--- a/coreclient/src/outbound_service/resync.rs
+++ b/coreclient/src/outbound_service/resync.rs
@@ -4,8 +4,12 @@
 
 use aircommon::{
     credentials::keys::ClientSigningKey,
-    crypto::aead::keys::{GroupStateEarKey, IdentityLinkWrapperKey},
-    identifiers::QualifiedGroupId,
+    crypto::{
+        aead::keys::{EncryptedUserProfileKey, GroupStateEarKey, IdentityLinkWrapperKey},
+        hpke::HpkeEncryptable,
+        indexed_aead::keys::UserProfileKey,
+    },
+    identifiers::{ClientConfig, QsReference, QualifiedGroupId},
     messages::{client_ds::AadPayload, client_ds_out::ExternalCommitInfoIn},
 };
 use anyhow::{Context, Result};
@@ -23,6 +27,7 @@ use crate::{
     db::access::{WriteConnection, WriteDbTransaction},
     groups::{DecryptedProfileInfos, Group, ProfileInfo, handle_group_not_found_on_ds},
     job::{operation::OperationData, profile::FetchUserProfileOperation},
+    key_stores::indexed_keys::StorableIndexedKey,
     outbound_service::{
         OutboundServiceContext,
         error::{OutboundServiceError, classify_ds_error, is_ds_not_found_error},
@@ -84,8 +89,32 @@ impl OutboundServiceContext {
 
             let result = {
                 let mut connection = self.db.write().await?;
+
+                let group = Group::load(&mut connection, &group_id)
+                    .await?
+                    .context("group not found")?;
+                let own_user_profile_key = UserProfileKey::load_own(&mut connection).await?;
+                let own_encrypted_user_profile_key = own_user_profile_key
+                    .encrypt(group.identity_link_wrapper_key(), self.user_id())?;
+
+                let sealed_reference = ClientConfig {
+                    client_id: self.qs_client_id.clone(),
+                    push_token_ear_key: Some(self.push_token_ear_key().clone()),
+                }
+                .encrypt(self.qs_client_id_encryption_key(), &[], &[]);
+                let own_qs_client_reference = QsReference {
+                    client_homeserver_domain: self.user_id().domain().clone(),
+                    sealed_reference,
+                };
+
                 let result = resync
-                    .create_and_send_commit(&mut connection, &self.api_clients, self.signing_key())
+                    .create_and_send_commit(
+                        &mut connection,
+                        &self.api_clients,
+                        self.signing_key(),
+                        own_qs_client_reference,
+                        own_encrypted_user_profile_key,
+                    )
                     .await;
                 if result.is_ok() {
                     info!("Got profiles infos");
@@ -145,6 +174,8 @@ impl Resync {
         mut connection: impl WriteConnection,
         api_clients: &ApiClients,
         signer: &ClientSigningKey,
+        qs_client_reference: QsReference,
+        encrypted_user_profile_key: EncryptedUserProfileKey,
     ) -> Result<DecryptedProfileInfos, OutboundServiceError> {
         // TODO: We should somehow mark the chat as "resyncing" in the DB and
         // reflect that in the UI.
@@ -172,6 +203,8 @@ impl Resync {
             commit,
             group_info,
             original_leaf_index,
+            qs_client_reference,
+            encrypted_user_profile_key,
         )
         .await?;
 
@@ -233,6 +266,8 @@ impl Resync {
         commit: MlsMessageOut,
         group_info: MlsMessageOut,
         original_leaf_index: LeafNodeIndex,
+        qs_client_reference: QsReference,
+        encrypted_user_profile_key: EncryptedUserProfileKey,
     ) -> Result<(), OutboundServiceError> {
         let qgid: QualifiedGroupId = group
             .group_id()
@@ -249,6 +284,8 @@ impl Resync {
                 signer,
                 group.group_state_ear_key(),
                 original_leaf_index,
+                qs_client_reference,
+                encrypted_user_profile_key,
             )
             .await
             .map_err(classify_ds_error)?;

--- a/coreclient/src/outbound_service/resync.rs
+++ b/coreclient/src/outbound_service/resync.rs
@@ -4,12 +4,8 @@
 
 use aircommon::{
     credentials::keys::ClientSigningKey,
-    crypto::{
-        aead::keys::{EncryptedUserProfileKey, GroupStateEarKey, IdentityLinkWrapperKey},
-        hpke::HpkeEncryptable,
-        indexed_aead::keys::UserProfileKey,
-    },
-    identifiers::{ClientConfig, QsReference, QualifiedGroupId},
+    crypto::aead::keys::{GroupStateEarKey, IdentityLinkWrapperKey},
+    identifiers::QualifiedGroupId,
     messages::{client_ds::AadPayload, client_ds_out::ExternalCommitInfoIn},
 };
 use anyhow::{Context, Result};
@@ -27,7 +23,6 @@ use crate::{
     db::access::{WriteConnection, WriteDbTransaction},
     groups::{DecryptedProfileInfos, Group, ProfileInfo, handle_group_not_found_on_ds},
     job::{operation::OperationData, profile::FetchUserProfileOperation},
-    key_stores::indexed_keys::StorableIndexedKey,
     outbound_service::{
         OutboundServiceContext,
         error::{OutboundServiceError, classify_ds_error, is_ds_not_found_error},
@@ -90,31 +85,8 @@ impl OutboundServiceContext {
             let result = {
                 let mut connection = self.db.write().await?;
 
-                let group = Group::load(&mut connection, &group_id)
-                    .await?
-                    .context("group not found")?;
-                let own_user_profile_key = UserProfileKey::load_own(&mut connection).await?;
-                let own_encrypted_user_profile_key = own_user_profile_key
-                    .encrypt(group.identity_link_wrapper_key(), self.user_id())?;
-
-                let sealed_reference = ClientConfig {
-                    client_id: self.qs_client_id.clone(),
-                    push_token_ear_key: Some(self.push_token_ear_key().clone()),
-                }
-                .encrypt(self.qs_client_id_encryption_key(), &[], &[]);
-                let own_qs_client_reference = QsReference {
-                    client_homeserver_domain: self.user_id().domain().clone(),
-                    sealed_reference,
-                };
-
                 let result = resync
-                    .create_and_send_commit(
-                        &mut connection,
-                        &self.api_clients,
-                        self.signing_key(),
-                        own_qs_client_reference,
-                        own_encrypted_user_profile_key,
-                    )
+                    .create_and_send_commit(&mut connection, &self.api_clients, self.signing_key())
                     .await;
                 if result.is_ok() {
                     info!("Got profiles infos");
@@ -174,8 +146,6 @@ impl Resync {
         mut connection: impl WriteConnection,
         api_clients: &ApiClients,
         signer: &ClientSigningKey,
-        qs_client_reference: QsReference,
-        encrypted_user_profile_key: EncryptedUserProfileKey,
     ) -> Result<DecryptedProfileInfos, OutboundServiceError> {
         // TODO: We should somehow mark the chat as "resyncing" in the DB and
         // reflect that in the UI.
@@ -203,8 +173,6 @@ impl Resync {
             commit,
             group_info,
             original_leaf_index,
-            qs_client_reference,
-            encrypted_user_profile_key,
         )
         .await?;
 
@@ -266,8 +234,6 @@ impl Resync {
         commit: MlsMessageOut,
         group_info: MlsMessageOut,
         original_leaf_index: LeafNodeIndex,
-        qs_client_reference: QsReference,
-        encrypted_user_profile_key: EncryptedUserProfileKey,
     ) -> Result<(), OutboundServiceError> {
         let qgid: QualifiedGroupId = group
             .group_id()
@@ -284,8 +250,6 @@ impl Resync {
                 signer,
                 group.group_state_ear_key(),
                 original_leaf_index,
-                qs_client_reference,
-                encrypted_user_profile_key,
             )
             .await
             .map_err(classify_ds_error)?;

--- a/protos/api/delivery_service/v1/delivery_service.proto
+++ b/protos/api/delivery_service/v1/delivery_service.proto
@@ -278,8 +278,6 @@ message ResyncPayload {
   GroupStateEarKey group_state_ear_key = 1;
   AssistedMessage external_commit = 2;
   LeafNodeIndex sender = 3;
-  QsReference qs_client_reference = 5;
-  EncryptedUserProfileKey encrypted_user_profile_key = 6;
 }
 
 message ResyncResponse {
@@ -351,6 +349,8 @@ message GroupOperationPayload {
   GroupStateEarKey group_state_ear_key = 1;
   AssistedMessage commit = 2;
   optional AddUsersInfo add_users_info = 3;
+  optional QsReference qs_client_reference = 5;
+  optional EncryptedUserProfileKey encrypted_user_profile_key = 6;
 }
 
 message AddUsersInfo {
@@ -378,6 +378,8 @@ message ApqGroupOperationPayload {
   GroupStateEarKey group_state_ear_key = 2;
   ApqAssistedMlsMessage commit = 3;
   optional ApqAddUsersInfo add_users_info = 4;
+  optional QsReference qs_client_reference = 5;
+  optional EncryptedUserProfileKey encrypted_user_profile_key = 6;
 }
 
 message ApqGroupOperationResponse {

--- a/protos/api/delivery_service/v1/delivery_service.proto
+++ b/protos/api/delivery_service/v1/delivery_service.proto
@@ -278,6 +278,8 @@ message ResyncPayload {
   GroupStateEarKey group_state_ear_key = 1;
   AssistedMessage external_commit = 2;
   LeafNodeIndex sender = 3;
+  QsReference qs_client_reference = 5;
+  EncryptedUserProfileKey encrypted_user_profile_key = 6;
 }
 
 message ResyncResponse {


### PR DESCRIPTION
This means the server will get a chance to heal its local state (specifically the `member_profiles` map) if there was a leaf node index discrepancy.

Relates to #1281 and #1282