### PR TITLE
fix(app): suppress spurious title/picture system messages

### DIFF
--- a/coreclient/src/clients/process/process_qs.rs
+++ b/coreclient/src/clients/process/process_qs.rs
@@ -340,6 +340,7 @@ impl CoreUser {
                     sender_user_id.clone(),
                     ds_timestamp,
                     external_group_profile,
+                    true,
                 )
                 .await?;
             }
@@ -912,6 +913,7 @@ impl CoreUser {
                         sender_client_credential.user_id().clone(),
                         ds_timestamp,
                         external_group_profile,
+                        false,
                     )
                     .await?;
                     None

--- a/coreclient/src/clients/update_key.rs
+++ b/coreclient/src/clients/update_key.rs
@@ -101,6 +101,9 @@ pub(crate) async fn update_chat_title(
 ) -> anyhow::Result<()> {
     match &chat.chat_type {
         ChatType::Group(attrs) => {
+            if attrs.title == new_title {
+                return Ok(());
+            }
             let old_title = attrs.title.clone();
             chat.set_title(connection, new_title.clone()).await?;
             let system_message = SystemMessage::ChangeTitle {

--- a/coreclient/src/job/profile.rs
+++ b/coreclient/src/job/profile.rs
@@ -79,12 +79,14 @@ impl CoreUser {
         sender_id: UserId,
         uploaded_at: TimeStamp,
         external_group_profile: ExternalGroupProfile,
+        is_initial_fetch: bool,
     ) -> sqlx::Result<()> {
         FetchGroupProfileOperation {
             group_id,
             sender_id,
             uploaded_at,
             external_group_profile,
+            is_initial_fetch,
         }
         .into_operation()
         .enqueue(connection)
@@ -189,6 +191,12 @@ pub(crate) struct FetchGroupProfileOperation {
     sender_id: UserId,
     uploaded_at: TimeStamp,
     external_group_profile: ExternalGroupProfile,
+    /// Set when the operation is enqueued from the welcome flow.
+    ///
+    /// When set the fetch represents the initial download of the group profile and must not produce
+    /// "title changed" / "picture changed" system messages.
+    #[serde(default)]
+    is_initial_fetch: bool,
 }
 
 impl OperationData for FetchGroupProfileOperation {
@@ -218,6 +226,7 @@ impl Job for FetchGroupProfileOperation {
             sender_id,
             uploaded_at,
             external_group_profile,
+            is_initial_fetch,
         } = self;
 
         info!(
@@ -293,23 +302,26 @@ impl Job for FetchGroupProfileOperation {
             .write()
             .await?
             .with_transaction(async |txn| -> anyhow::Result<()> {
-                let mut messages = Vec::new();
+                let new_picture = group_profile.picture.map(|p| p.into());
 
-                let chat_attributes = ChatAttributes::new(
-                    group_profile.title,
-                    group_profile.picture.map(|p| p.into()),
-                );
-                update_chat_attributes(
-                    &mut *txn,
-                    &mut chat,
-                    &sender_id,
-                    chat_attributes,
-                    uploaded_at,
-                    &mut messages,
-                )
-                .await?;
-
-                CoreUser::store_new_messages(txn, chat.id(), messages).await?;
+                if is_initial_fetch {
+                    // => no system messages
+                    chat.set_title(&mut *txn, group_profile.title).await?;
+                    chat.set_picture(&mut *txn, new_picture).await?;
+                } else {
+                    let mut messages = Vec::new();
+                    let chat_attributes = ChatAttributes::new(group_profile.title, new_picture);
+                    update_chat_attributes(
+                        &mut *txn,
+                        &mut chat,
+                        &sender_id,
+                        chat_attributes,
+                        uploaded_at,
+                        &mut messages,
+                    )
+                    .await?;
+                    CoreUser::store_new_messages(txn, chat.id(), messages).await?;
+                }
 
                 debug!(?group_id, chat_id = %chat.id(), "Updated chat attributes");
 

--- a/server/tests/tests/group.rs
+++ b/server/tests/tests/group.rs
@@ -5,7 +5,7 @@
 use std::slice;
 
 use aircoreclient::{
-    DisplayName, UserProfile,
+    DisplayName, EventMessage, Message, SystemMessage, UserProfile,
     clients::{
         listen_response,
         process::process_qs::{QsProcessEventResult, QsStreamProcessor},
@@ -449,8 +449,13 @@ async fn fetch_group_profile_on_invite() {
 
     let chat_id = setup.create_group(&alice).await;
 
-    // Record Alice's group attributes (title and resized picture set during create_group)
     let alice_user = &setup.get_user(&alice).user;
+    alice_user
+        .set_chat_picture(chat_id, Some(test_picture_bytes()))
+        .await
+        .unwrap();
+
+    // Record Alice's group attributes (title and resized picture)
     let alice_chat = alice_user.chat(&chat_id).await.unwrap();
     let attributes = alice_chat.attributes().unwrap().clone();
     let expected_title = attributes.title;
@@ -485,6 +490,24 @@ async fn fetch_group_profile_on_invite() {
     let bob_chat = bob_user.chat(&chat_id).await.unwrap();
     assert_eq!(bob_chat.attributes().unwrap().title(), &expected_title);
     assert_eq!(bob_chat.attributes().unwrap().picture, expected_picture);
+
+    // Regression: joining the group should not surface spurious "title changed" or "picture
+    // changed" system messages: the title is unchanged and the picture is just the initial
+    // download.
+    let mut bob_messages = bob_user.messages(chat_id, 1024).await.unwrap();
+    // Only keep system messages about the title or picture change
+    bob_messages.retain(|message| {
+        matches!(
+            message.message(),
+            Message::Event(EventMessage::System(
+                SystemMessage::ChangeTitle { .. } | SystemMessage::ChangePicture(_),
+            ))
+        )
+    });
+    assert!(
+        bob_messages.is_empty(),
+        "unexpected system messages on initial join: {bob_messages:#?}"
+    );
 }
 
 /// Tests that after a group title and picture update, other members fetch the new encrypted group


### PR DESCRIPTION
After joining a group via welcome, two stale system messages appeared in
the chat: "changed the group name from X to X" and "changed the group
picture".

* `update_chat_title` now skips the `ChangeTitle` message when the title
  is unchanged. This also fixes the same message firing on remote
  commits whose group data is carried alongside an unrelated change
  (e.g. a picture-only update).
* `FetchGroupProfileOperation` gains an `is_initial_fetch` flag. When
  set, the downloaded title and picture are written silently; the
  welcome flow passes `true`, the commit handler passes `false`.