### PR TITLE
fix(app): new message count could be wrong

### DIFF
--- a/app/lib/core/api/message_list_cubit.dart
+++ b/app/lib/core/api/message_list_cubit.dart
@@ -97,6 +97,7 @@ sealed class MessageListState with _$MessageListState {
     required bool hasNewer,
     required bool isAtBottom,
     int? firstUnreadIndex,
+    required int unreadCount,
     required int revision,
   }) = _MessageListState;
   static Future<MessageListState> default_() =>

--- a/app/lib/core/api/message_list_cubit.freezed.dart
+++ b/app/lib/core/api/message_list_cubit.freezed.dart
@@ -399,7 +399,7 @@ String toString() {
 /// @nodoc
 mixin _$MessageListState {
 
- bool? get isConnectionChat; bool get hasOlder; bool get hasNewer; bool get isAtBottom; int? get firstUnreadIndex; int get revision;
+ bool? get isConnectionChat; bool get hasOlder; bool get hasNewer; bool get isAtBottom; int? get firstUnreadIndex; int get unreadCount; int get revision;
 /// Create a copy of MessageListState
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -410,16 +410,16 @@ $MessageListStateCopyWith<MessageListState> get copyWith => _$MessageListStateCo
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is MessageListState&&(identical(other.isConnectionChat, isConnectionChat) || other.isConnectionChat == isConnectionChat)&&(identical(other.hasOlder, hasOlder) || other.hasOlder == hasOlder)&&(identical(other.hasNewer, hasNewer) || other.hasNewer == hasNewer)&&(identical(other.isAtBottom, isAtBottom) || other.isAtBottom == isAtBottom)&&(identical(other.firstUnreadIndex, firstUnreadIndex) || other.firstUnreadIndex == firstUnreadIndex)&&(identical(other.revision, revision) || other.revision == revision));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is MessageListState&&(identical(other.isConnectionChat, isConnectionChat) || other.isConnectionChat == isConnectionChat)&&(identical(other.hasOlder, hasOlder) || other.hasOlder == hasOlder)&&(identical(other.hasNewer, hasNewer) || other.hasNewer == hasNewer)&&(identical(other.isAtBottom, isAtBottom) || other.isAtBottom == isAtBottom)&&(identical(other.firstUnreadIndex, firstUnreadIndex) || other.firstUnreadIndex == firstUnreadIndex)&&(identical(other.unreadCount, unreadCount) || other.unreadCount == unreadCount)&&(identical(other.revision, revision) || other.revision == revision));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,isConnectionChat,hasOlder,hasNewer,isAtBottom,firstUnreadIndex,revision);
+int get hashCode => Object.hash(runtimeType,isConnectionChat,hasOlder,hasNewer,isAtBottom,firstUnreadIndex,unreadCount,revision);
 
 @override
 String toString() {
-  return 'MessageListState(isConnectionChat: $isConnectionChat, hasOlder: $hasOlder, hasNewer: $hasNewer, isAtBottom: $isAtBottom, firstUnreadIndex: $firstUnreadIndex, revision: $revision)';
+  return 'MessageListState(isConnectionChat: $isConnectionChat, hasOlder: $hasOlder, hasNewer: $hasNewer, isAtBottom: $isAtBottom, firstUnreadIndex: $firstUnreadIndex, unreadCount: $unreadCount, revision: $revision)';
 }
 
 
@@ -430,7 +430,7 @@ abstract mixin class $MessageListStateCopyWith<$Res>  {
   factory $MessageListStateCopyWith(MessageListState value, $Res Function(MessageListState) _then) = _$MessageListStateCopyWithImpl;
 @useResult
 $Res call({
- bool? isConnectionChat, bool hasOlder, bool hasNewer, bool isAtBottom, int? firstUnreadIndex, int revision
+ bool? isConnectionChat, bool hasOlder, bool hasNewer, bool isAtBottom, int? firstUnreadIndex, int unreadCount, int revision
 });
 
 
@@ -447,14 +447,15 @@ class _$MessageListStateCopyWithImpl<$Res>
 
 /// Create a copy of MessageListState
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? isConnectionChat = freezed,Object? hasOlder = null,Object? hasNewer = null,Object? isAtBottom = null,Object? firstUnreadIndex = freezed,Object? revision = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? isConnectionChat = freezed,Object? hasOlder = null,Object? hasNewer = null,Object? isAtBottom = null,Object? firstUnreadIndex = freezed,Object? unreadCount = null,Object? revision = null,}) {
   return _then(_self.copyWith(
 isConnectionChat: freezed == isConnectionChat ? _self.isConnectionChat : isConnectionChat // ignore: cast_nullable_to_non_nullable
 as bool?,hasOlder: null == hasOlder ? _self.hasOlder : hasOlder // ignore: cast_nullable_to_non_nullable
 as bool,hasNewer: null == hasNewer ? _self.hasNewer : hasNewer // ignore: cast_nullable_to_non_nullable
 as bool,isAtBottom: null == isAtBottom ? _self.isAtBottom : isAtBottom // ignore: cast_nullable_to_non_nullable
 as bool,firstUnreadIndex: freezed == firstUnreadIndex ? _self.firstUnreadIndex : firstUnreadIndex // ignore: cast_nullable_to_non_nullable
-as int?,revision: null == revision ? _self.revision : revision // ignore: cast_nullable_to_non_nullable
+as int?,unreadCount: null == unreadCount ? _self.unreadCount : unreadCount // ignore: cast_nullable_to_non_nullable
+as int,revision: null == revision ? _self.revision : revision // ignore: cast_nullable_to_non_nullable
 as int,
   ));
 }
@@ -467,7 +468,7 @@ as int,
 
 
 class _MessageListState extends MessageListState {
-  const _MessageListState({this.isConnectionChat, required this.hasOlder, required this.hasNewer, required this.isAtBottom, this.firstUnreadIndex, required this.revision}): super._();
+  const _MessageListState({this.isConnectionChat, required this.hasOlder, required this.hasNewer, required this.isAtBottom, this.firstUnreadIndex, required this.unreadCount, required this.revision}): super._();
   
 
 @override final  bool? isConnectionChat;
@@ -475,6 +476,7 @@ class _MessageListState extends MessageListState {
 @override final  bool hasNewer;
 @override final  bool isAtBottom;
 @override final  int? firstUnreadIndex;
+@override final  int unreadCount;
 @override final  int revision;
 
 /// Create a copy of MessageListState
@@ -487,16 +489,16 @@ _$MessageListStateCopyWith<_MessageListState> get copyWith => __$MessageListStat
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _MessageListState&&(identical(other.isConnectionChat, isConnectionChat) || other.isConnectionChat == isConnectionChat)&&(identical(other.hasOlder, hasOlder) || other.hasOlder == hasOlder)&&(identical(other.hasNewer, hasNewer) || other.hasNewer == hasNewer)&&(identical(other.isAtBottom, isAtBottom) || other.isAtBottom == isAtBottom)&&(identical(other.firstUnreadIndex, firstUnreadIndex) || other.firstUnreadIndex == firstUnreadIndex)&&(identical(other.revision, revision) || other.revision == revision));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _MessageListState&&(identical(other.isConnectionChat, isConnectionChat) || other.isConnectionChat == isConnectionChat)&&(identical(other.hasOlder, hasOlder) || other.hasOlder == hasOlder)&&(identical(other.hasNewer, hasNewer) || other.hasNewer == hasNewer)&&(identical(other.isAtBottom, isAtBottom) || other.isAtBottom == isAtBottom)&&(identical(other.firstUnreadIndex, firstUnreadIndex) || other.firstUnreadIndex == firstUnreadIndex)&&(identical(other.unreadCount, unreadCount) || other.unreadCount == unreadCount)&&(identical(other.revision, revision) || other.revision == revision));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,isConnectionChat,hasOlder,hasNewer,isAtBottom,firstUnreadIndex,revision);
+int get hashCode => Object.hash(runtimeType,isConnectionChat,hasOlder,hasNewer,isAtBottom,firstUnreadIndex,unreadCount,revision);
 
 @override
 String toString() {
-  return 'MessageListState(isConnectionChat: $isConnectionChat, hasOlder: $hasOlder, hasNewer: $hasNewer, isAtBottom: $isAtBottom, firstUnreadIndex: $firstUnreadIndex, revision: $revision)';
+  return 'MessageListState(isConnectionChat: $isConnectionChat, hasOlder: $hasOlder, hasNewer: $hasNewer, isAtBottom: $isAtBottom, firstUnreadIndex: $firstUnreadIndex, unreadCount: $unreadCount, revision: $revision)';
 }
 
 
@@ -507,7 +509,7 @@ abstract mixin class _$MessageListStateCopyWith<$Res> implements $MessageListSta
   factory _$MessageListStateCopyWith(_MessageListState value, $Res Function(_MessageListState) _then) = __$MessageListStateCopyWithImpl;
 @override @useResult
 $Res call({
- bool? isConnectionChat, bool hasOlder, bool hasNewer, bool isAtBottom, int? firstUnreadIndex, int revision
+ bool? isConnectionChat, bool hasOlder, bool hasNewer, bool isAtBottom, int? firstUnreadIndex, int unreadCount, int revision
 });
 
 
@@ -524,14 +526,15 @@ class __$MessageListStateCopyWithImpl<$Res>
 
 /// Create a copy of MessageListState
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? isConnectionChat = freezed,Object? hasOlder = null,Object? hasNewer = null,Object? isAtBottom = null,Object? firstUnreadIndex = freezed,Object? revision = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? isConnectionChat = freezed,Object? hasOlder = null,Object? hasNewer = null,Object? isAtBottom = null,Object? firstUnreadIndex = freezed,Object? unreadCount = null,Object? revision = null,}) {
   return _then(_MessageListState(
 isConnectionChat: freezed == isConnectionChat ? _self.isConnectionChat : isConnectionChat // ignore: cast_nullable_to_non_nullable
 as bool?,hasOlder: null == hasOlder ? _self.hasOlder : hasOlder // ignore: cast_nullable_to_non_nullable
 as bool,hasNewer: null == hasNewer ? _self.hasNewer : hasNewer // ignore: cast_nullable_to_non_nullable
 as bool,isAtBottom: null == isAtBottom ? _self.isAtBottom : isAtBottom // ignore: cast_nullable_to_non_nullable
 as bool,firstUnreadIndex: freezed == firstUnreadIndex ? _self.firstUnreadIndex : firstUnreadIndex // ignore: cast_nullable_to_non_nullable
-as int?,revision: null == revision ? _self.revision : revision // ignore: cast_nullable_to_non_nullable
+as int?,unreadCount: null == unreadCount ? _self.unreadCount : unreadCount // ignore: cast_nullable_to_non_nullable
+as int,revision: null == revision ? _self.revision : revision // ignore: cast_nullable_to_non_nullable
 as int,
   ));
 }

--- a/app/lib/core/frb_generated.dart
+++ b/app/lib/core/frb_generated.dart
@@ -9393,15 +9393,16 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   MessageListState dco_decode_message_list_state(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
-    if (arr.length != 6)
-      throw Exception('unexpected arr length: expect 6 but see ${arr.length}');
+    if (arr.length != 7)
+      throw Exception('unexpected arr length: expect 7 but see ${arr.length}');
     return MessageListState(
       isConnectionChat: dco_decode_opt_box_autoadd_bool(arr[0]),
       hasOlder: dco_decode_bool(arr[1]),
       hasNewer: dco_decode_bool(arr[2]),
       isAtBottom: dco_decode_bool(arr[3]),
       firstUnreadIndex: dco_decode_opt_CastedPrimitive_usize(arr[4]),
-      revision: dco_decode_CastedPrimitive_usize(arr[5]),
+      unreadCount: dco_decode_CastedPrimitive_usize(arr[5]),
+      revision: dco_decode_CastedPrimitive_usize(arr[6]),
     );
   }
 
@@ -12569,6 +12570,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     var var_firstUnreadIndex = sse_decode_opt_CastedPrimitive_usize(
       deserializer,
     );
+    var var_unreadCount = sse_decode_CastedPrimitive_usize(deserializer);
     var var_revision = sse_decode_CastedPrimitive_usize(deserializer);
     return MessageListState(
       isConnectionChat: var_isConnectionChat,
@@ -12576,6 +12578,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       hasNewer: var_hasNewer,
       isAtBottom: var_isAtBottom,
       firstUnreadIndex: var_firstUnreadIndex,
+      unreadCount: var_unreadCount,
       revision: var_revision,
     );
   }
@@ -16213,6 +16216,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     sse_encode_bool(self.hasNewer, serializer);
     sse_encode_bool(self.isAtBottom, serializer);
     sse_encode_opt_CastedPrimitive_usize(self.firstUnreadIndex, serializer);
+    sse_encode_CastedPrimitive_usize(self.unreadCount, serializer);
     sse_encode_CastedPrimitive_usize(self.revision, serializer);
   }
 

--- a/app/lib/l10n/app_de.arb
+++ b/app/lib/l10n/app_de.arb
@@ -339,5 +339,5 @@
   "memberSelectionList_client_not_supported": "Dieser Kontakt hat eine veraltete App, die aktualisiert werden muss.",
   "homeTab_chats": "Chats",
   "homeTab_profile": "Du",
-  "messageList_unreadMessages": "{count, plural, one {{count} ungelesene Nachricht} other {{count} ungelesene Nachrichten}}"
+  "messageList_newMessages": "{count, plural, one {{count} neue Nachricht} other {{count} neue Nachrichten}}"
 }

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -402,8 +402,8 @@
   "homeTab_chats": "Chats",
   "homeTab_profile": "You",
 
-  "messageList_unreadMessages": "{count, plural, one {{count} unread message} other {{count} unread messages}}",
-  "@messageList_unreadMessages": {
+  "messageList_newMessages": "{count, plural, one {{count} new message} other {{count} new messages}}",
+  "@messageList_newMessages": {
     "placeholders": {
       "count": {
         "type": "int"

--- a/app/lib/l10n/app_fr.arb
+++ b/app/lib/l10n/app_fr.arb
@@ -338,5 +338,5 @@
   "memberSelectionList_client_not_supported": "Ce contact a une application obsolète qui doit être mise à jour.",
   "homeTab_chats": "Discussions",
   "homeTab_profile": "Profil",
-  "messageList_unreadMessages": "{count, plural, one {{count} message non lu} other {{count} messages non lus}}"
+  "messageList_newMessages": "{count, plural, one {{count} nouveau message} other {{count} nouveaux messages}}"
 }

--- a/app/lib/l10n/app_localizations.dart
+++ b/app/lib/l10n/app_localizations.dart
@@ -1923,11 +1923,11 @@ abstract class AppLocalizations {
   /// **'You'**
   String get homeTab_profile;
 
-  /// No description provided for @messageList_unreadMessages.
+  /// No description provided for @messageList_newMessages.
   ///
   /// In en, this message translates to:
-  /// **'{count, plural, one {{count} unread message} other {{count} unread messages}}'**
-  String messageList_unreadMessages(int count);
+  /// **'{count, plural, one {{count} new message} other {{count} new messages}}'**
+  String messageList_newMessages(int count);
 }
 
 class _AppLocalizationsDelegate

--- a/app/lib/l10n/app_localizations_de.dart
+++ b/app/lib/l10n/app_localizations_de.dart
@@ -1099,12 +1099,12 @@ class AppLocalizationsDe extends AppLocalizations {
   String get homeTab_profile => 'Du';
 
   @override
-  String messageList_unreadMessages(int count) {
+  String messageList_newMessages(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count ungelesene Nachrichten',
-      one: '$count ungelesene Nachricht',
+      other: '$count neue Nachrichten',
+      one: '$count neue Nachricht',
     );
     return '$_temp0';
   }

--- a/app/lib/l10n/app_localizations_en.dart
+++ b/app/lib/l10n/app_localizations_en.dart
@@ -1082,12 +1082,12 @@ class AppLocalizationsEn extends AppLocalizations {
   String get homeTab_profile => 'You';
 
   @override
-  String messageList_unreadMessages(int count) {
+  String messageList_newMessages(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count unread messages',
-      one: '$count unread message',
+      other: '$count new messages',
+      one: '$count new message',
     );
     return '$_temp0';
   }

--- a/app/lib/l10n/app_localizations_fr.dart
+++ b/app/lib/l10n/app_localizations_fr.dart
@@ -1109,12 +1109,12 @@ class AppLocalizationsFr extends AppLocalizations {
   String get homeTab_profile => 'Profil';
 
   @override
-  String messageList_unreadMessages(int count) {
+  String messageList_newMessages(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count messages non lus',
-      one: '$count message non lu',
+      other: '$count nouveaux messages',
+      one: '$count nouveau message',
     );
     return '$_temp0';
   }

--- a/app/lib/l10n/app_localizations_sv.dart
+++ b/app/lib/l10n/app_localizations_sv.dart
@@ -1091,12 +1091,12 @@ class AppLocalizationsSv extends AppLocalizations {
   String get homeTab_profile => 'Du';
 
   @override
-  String messageList_unreadMessages(int count) {
+  String messageList_newMessages(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count olästa meddelanden',
-      one: '$count oläst meddelande',
+      other: '$count nya meddelanden',
+      one: '$count nytt meddelande',
     );
     return '$_temp0';
   }

--- a/app/lib/l10n/app_sv.arb
+++ b/app/lib/l10n/app_sv.arb
@@ -337,5 +337,5 @@
   "memberSelectionList_client_not_supported": "Den här kontakten har en föråldrad app som behöver uppdateras.",
   "homeTab_chats": "Chattar",
   "homeTab_profile": "Du",
-  "messageList_unreadMessages": "{count, plural, one {{count} oläst meddelande} other {{count} olästa meddelanden}}"
+  "messageList_newMessages": "{count, plural, one {{count} nytt meddelande} other {{count} nya meddelanden}}"
 }

--- a/app/lib/message_list/message_list_cubit.dart
+++ b/app/lib/message_list/message_list_cubit.dart
@@ -41,6 +41,7 @@ class MessageListStateWrapper {
   bool get isAtBottom => state.isAtBottom;
   bool? get isConnectionChat => state.isConnectionChat;
   int? get firstUnreadIndex => state.firstUnreadIndex;
+  int get unreadCount => state.unreadCount;
 
   UiChatMessage? messageAt(int oldestFirstIndex) {
     final idx = messageData.length - oldestFirstIndex - 1;

--- a/app/lib/message_list/message_list_view.dart
+++ b/app/lib/message_list/message_list_view.dart
@@ -542,9 +542,7 @@ class _MessageListViewState extends State<MessageListView>
 
     if (!showDateDivider && !isFirstUnread) return tile;
 
-    final unreadCount = isFirstUnread
-        ? state.messageData.length - state.firstUnreadIndex!
-        : 0;
+    final unreadCount = isFirstUnread ? state.unreadCount : 0;
     // The inline [DateDivider] is hidden (but keeps its layout space) only
     // once its pill has actually risen to the floating pill's slot — i.e.
     // when this message is the oldest visible *and* the controller reports

--- a/app/lib/message_list/unread_divider.dart
+++ b/app/lib/message_list/unread_divider.dart
@@ -14,9 +14,7 @@ class UnreadDivider extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final label = AppLocalizations.of(
-      context,
-    ).messageList_unreadMessages(count);
+    final label = AppLocalizations.of(context).messageList_newMessages(count);
     return Padding(
       padding: const EdgeInsets.symmetric(
         horizontal: Spacing.px24,

--- a/app/test/message_list/goldens/message_list_unread_divider.linux.png
+++ b/app/test/message_list/goldens/message_list_unread_divider.linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4eb03c26c81439823a4df30893b9e0159c57ab3e7f933b653f6dfe08aae03f7c
-size 217444
+oid sha256:2f873e88d82dceace8ed593667d9cbda75221d99c140b51b7c812c8853cd4f68
+size 217093

--- a/app/test/message_list/goldens/message_list_unread_divider.macos.png
+++ b/app/test/message_list/goldens/message_list_unread_divider.macos.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1064144554efcce35654ec11fc56082a3ab7964d49829b73e88653f7bdb3e4aa
-size 227229
+oid sha256:4011e47f56e80592f25ebf9e5606a0cd0e7cdaa1eca1d14cfb6e9f2f39ef2da6
+size 226388

--- a/app/test/message_list/goldens/message_list_unread_divider.windows.png
+++ b/app/test/message_list/goldens/message_list_unread_divider.windows.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1d61b872e0ba9470215ce61078897b870326c048bade16a6ad442399091a6fdd
-size 162941
+oid sha256:4c42e2c6235401d1ed23ba8e0f6b8faf821c83d0ac057ebab1d496927cbea848
+size 162921

--- a/app/test/message_list/message_list_test.dart
+++ b/app/test/message_list/message_list_test.dart
@@ -954,7 +954,11 @@ void main() {
           },
       ];
 
-      messageListCubit.setState(unreadMessages, firstUnreadIndex: 2);
+      messageListCubit.setState(
+        unreadMessages,
+        firstUnreadIndex: 2,
+        unreadCount: 4,
+      );
 
       await tester.pumpWidget(buildSubject());
 

--- a/app/test/mocks.dart
+++ b/app/test/mocks.dart
@@ -156,6 +156,7 @@ class MockMessageListCubit implements MessageListCubit {
     bool hasNewer = false,
     bool isAtBottom = false,
     int? firstUnreadIndex,
+    int unreadCount = 0,
     int revision = 0,
   }) {
     _syncMessageData(
@@ -165,6 +166,7 @@ class MockMessageListCubit implements MessageListCubit {
       hasNewer: hasNewer,
       isAtBottom: isAtBottom,
       firstUnreadIndex: firstUnreadIndex,
+      unreadCount: unreadCount,
       revision: revision,
     );
     if (!_controller.isClosed) {
@@ -186,6 +188,7 @@ class MockMessageListCubit implements MessageListCubit {
       isAtBottom: prev.isAtBottom,
       // Appending at the newest end leaves oldest-first indices unchanged.
       firstUnreadIndex: prev.firstUnreadIndex,
+      unreadCount: prev.unreadCount,
       revision: prev.revision + 1,
     );
     _state = MessageListStateWrapper.test(
@@ -211,6 +214,7 @@ class MockMessageListCubit implements MessageListCubit {
     bool hasNewer = false,
     bool isAtBottom = false,
     int? firstUnreadIndex,
+    int unreadCount = 0,
     int revision = 0,
   }) {
     // AnchoredListData: index 0 = newest; messages is oldest-first
@@ -222,6 +226,7 @@ class MockMessageListCubit implements MessageListCubit {
       hasNewer: hasNewer,
       isAtBottom: isAtBottom,
       firstUnreadIndex: firstUnreadIndex,
+      unreadCount: unreadCount,
       revision: revision,
     );
     _state = MessageListStateWrapper.test(

--- a/applogic/src/api/message_list_cubit.rs
+++ b/applogic/src/api/message_list_cubit.rs
@@ -30,7 +30,7 @@ use super::{
     user_cubit::UserCubitBase,
 };
 
-const PAGE_SIZE: usize = 50;
+const PAGE_SIZE: usize = 64;
 /// Maximum number of messages kept in the loaded window.
 /// When a prepend/append would exceed this, messages are dropped from the far
 /// end. With anchored rendering we can retain a larger buffer to make long
@@ -51,6 +51,8 @@ pub struct MessageListState {
     pub is_at_bottom: bool,
     /// Index of the first unread message (set on initial load only)
     pub first_unread_index: Option<usize>,
+    /// Number of unread messages shown in the unread divider.
+    pub unread_count: usize,
     /// Monotonic revision incremented for every emitted transition.
     pub revision: usize,
 }
@@ -115,6 +117,7 @@ enum LoadDirection {
         has_newer: bool,
         is_at_bottom: bool,
         first_unread_index: Option<usize>,
+        unread_count: usize,
         command: Option<MessageListCommand>,
     },
     /// Prepend older messages before the current window
@@ -239,6 +242,7 @@ impl MessageListData {
                 has_newer,
                 is_at_bottom,
                 first_unread_index,
+                unread_count,
                 command: next_command,
             } => {
                 let mut messages: Vec<UiChatMessage> = new_messages
@@ -261,6 +265,7 @@ impl MessageListData {
                 state.has_newer = has_newer;
                 state.is_at_bottom = is_at_bottom;
                 state.first_unread_index = first_unread_index;
+                state.unread_count = unread_count;
 
                 changes.push(MessageListChange::Reload {
                     messages: newest_first(&self.messages),
@@ -436,6 +441,7 @@ impl MessageListData {
         let end = (unread_idx + 1).min(self.messages.len());
         recompute_flight_positions_range(&mut self.messages, start, end, None);
         state.first_unread_index = None;
+        state.unread_count = 0;
 
         let mut changes = Vec::new();
         push_patch_changes(&mut changes, &self.messages, start..end);
@@ -752,6 +758,7 @@ impl MessageListContext {
                 };
 
             let first_unread_index = messages.iter().position(|m| m.id() == unread_id);
+            let unread_count = self.core_user.unread_messages_count(self.chat_id).await;
 
             let mut state = self.state_tx.borrow().clone();
             let transition = self.data.apply_messages(
@@ -764,6 +771,7 @@ impl MessageListContext {
                     has_newer,
                     is_at_bottom: !has_newer,
                     first_unread_index,
+                    unread_count,
                     command: None,
                 },
             );
@@ -814,6 +822,7 @@ impl MessageListContext {
                 has_newer: false,
                 is_at_bottom: true,
                 first_unread_index: None,
+                unread_count: 0,
                 command: scroll_to_bottom.then_some(MessageListCommand::ScrollToBottom),
             },
         );
@@ -1038,6 +1047,7 @@ impl MessageListContext {
                 has_newer,
                 is_at_bottom: !has_newer,
                 first_unread_index: None,
+                unread_count: 0,
                 command: Some(MessageListCommand::ScrollToId { message_id }),
             },
         );
@@ -1208,6 +1218,7 @@ mod tests {
                 has_newer: false,
                 is_at_bottom: true,
                 first_unread_index: None,
+                unread_count: 0,
                 command: None,
             },
         );
@@ -1249,6 +1260,7 @@ mod tests {
                 has_newer: false,
                 is_at_bottom: true,
                 first_unread_index: Some(2),
+                unread_count: 2,
                 command: None,
             },
         );
@@ -1276,6 +1288,7 @@ mod tests {
                 has_newer: false,
                 is_at_bottom: true,
                 first_unread_index: None,
+                unread_count: 0,
                 command: Some(MessageListCommand::ScrollToBottom),
             },
         );
@@ -1315,6 +1328,7 @@ mod tests {
                 has_newer: false,
                 is_at_bottom: true,
                 first_unread_index: None,
+                unread_count: 0,
                 command: None,
             },
         );
@@ -1381,6 +1395,7 @@ mod tests {
                 has_newer: false,
                 is_at_bottom: true,
                 first_unread_index: None,
+                unread_count: 0,
                 command: None,
             },
         );
@@ -1447,6 +1462,7 @@ mod tests {
                 has_newer: false,
                 is_at_bottom: true,
                 first_unread_index: None,
+                unread_count: 0,
                 command: None,
             },
         );

--- a/applogic/src/frb_generated.rs
+++ b/applogic/src/frb_generated.rs
@@ -10519,6 +10519,7 @@ impl SseDecode for crate::api::message_list_cubit::MessageListState {
         let mut var_hasNewer = <bool>::sse_decode(deserializer);
         let mut var_isAtBottom = <bool>::sse_decode(deserializer);
         let mut var_firstUnreadIndex = <Option<usize>>::sse_decode(deserializer);
+        let mut var_unreadCount = <usize>::sse_decode(deserializer);
         let mut var_revision = <usize>::sse_decode(deserializer);
         return crate::api::message_list_cubit::MessageListState {
             is_connection_chat: var_isConnectionChat,
@@ -10526,6 +10527,7 @@ impl SseDecode for crate::api::message_list_cubit::MessageListState {
             has_newer: var_hasNewer,
             is_at_bottom: var_isAtBottom,
             first_unread_index: var_firstUnreadIndex,
+            unread_count: var_unreadCount,
             revision: var_revision,
         };
     }
@@ -13495,6 +13497,7 @@ impl flutter_rust_bridge::IntoDart for crate::api::message_list_cubit::MessageLi
             self.has_newer.into_into_dart().into_dart(),
             self.is_at_bottom.into_into_dart().into_dart(),
             self.first_unread_index.into_into_dart().into_dart(),
+            self.unread_count.into_into_dart().into_dart(),
             self.revision.into_into_dart().into_dart(),
         ]
         .into_dart()
@@ -16095,6 +16098,7 @@ impl SseEncode for crate::api::message_list_cubit::MessageListState {
         <bool>::sse_encode(self.has_newer, serializer);
         <bool>::sse_encode(self.is_at_bottom, serializer);
         <Option<usize>>::sse_encode(self.first_unread_index, serializer);
+        <usize>::sse_encode(self.unread_count, serializer);
         <usize>::sse_encode(self.revision, serializer);
     }
 }


### PR DESCRIPTION
The unread divider would never show more than 51 unread messages, because it only looked at the loaded message window. Now it gets the number from the db instead.
This PR also renames the label of the unread divider to make it less confusing.