### PR TITLE
fix(app): correct APQ pending-commit discard and resync handling

### DIFF
--- a/coreclient/src/groups/mod.rs
+++ b/coreclient/src/groups/mod.rs
@@ -1346,7 +1346,12 @@ impl Group {
         self.clear_commit_failed(&mut *txn).await?;
         let provider = AirOpenMlsProvider::new(txn.as_mut());
         self.pending_diff = None;
+        // Clear the pending commit in the T group...
         self.mls_group.clear_pending_commit(provider.storage())?;
+        // ... and in the PQ group if it exists.
+        if let Some(pq) = &mut self.pq {
+            pq.mls_group.clear_pending_commit(provider.storage())?;
+        }
         Ok(())
     }
 

--- a/coreclient/src/groups/process.rs
+++ b/coreclient/src/groups/process.rs
@@ -642,6 +642,9 @@ impl Group {
         api_clients: &ApiClients,
         message: impl Into<ApqProtocolMessage>,
     ) -> Result<Option<ProcessMessageResult>> {
+        let message: ApqProtocolMessage = message.into();
+        let message_t_epoch = message.t_epoch();
+        let current_t_epoch = self.mls_group.epoch();
         let (t_mls_group, pq_mls_group) = self.apq_mls_groups_mut()?;
 
         let ApqProcessedMessage {
@@ -656,8 +659,18 @@ impl Group {
             Err(ApqProcessMessageError::Processing(ProcessMessageError::ValidationError(
                 ValidationError::WrongEpoch,
             ))) => {
-                // TODO: We need to handle epoch in the future gracefully and indicate a resync.
-                bail!("Wrong epoch");
+                // A past-epoch message is one we already moved past, so we
+                // ignore it.
+                if current_t_epoch > message_t_epoch {
+                    bail!(
+                        "Message epoch is in the past: message t-epoch {} < current t-epoch {}",
+                        message_t_epoch,
+                        current_t_epoch
+                    );
+                }
+                // A future-epoch message means we are behind and the caller
+                // must trigger a resync.
+                return Ok(None);
             }
             Err(e) => {
                 return Err(e).context("Failed to process APQ message");

--- a/coreclient/src/outbound_service/resync.rs
+++ b/coreclient/src/outbound_service/resync.rs
@@ -43,6 +43,11 @@ impl CoreUser {
             .await?
             .context("group not found")?;
 
+        // Resync is disabled for APQ groups for now.
+        if group.is_apq() {
+            anyhow::bail!("Resync is not supported for APQ groups");
+        }
+
         let resync = Resync {
             chat_id,
             group_id: group.group_id().clone(),

--- a/server/tests/tests/jobs.rs
+++ b/server/tests/tests/jobs.rs
@@ -211,6 +211,102 @@ async fn wrong_epoch_marks_pending_waiting_and_commit_clears_it() {
     alice_user.update_key(chat_id).await.unwrap();
 }
 
+async fn setup_apq_group_with_charlie_member() -> (TestBackend, UserId, UserId, UserId, ChatId) {
+    let mut setup = TestBackend::single().await;
+    let alice = setup.add_user().await;
+    let bob = setup.add_user().await;
+    let charlie = setup.add_user().await;
+
+    setup.connect_users(&alice, &bob).await;
+    setup.connect_users(&alice, &charlie).await;
+
+    let chat_id = setup.create_apq_group(&alice).await;
+    setup.invite_to_group(chat_id, &alice, vec![&bob]).await;
+    setup.invite_to_group(chat_id, &alice, vec![&charlie]).await;
+
+    (setup, alice, bob, charlie, chat_id)
+}
+
+// Make sure that the rosters of T and PQ groups in an APQ group remain
+// identical in the context of pending commits.
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn apq_wrong_epoch_recovery_keeps_t_and_pq_rosters_consistent() {
+    let (setup, alice, bob, charlie, chat_id) = setup_apq_group_with_charlie_member().await;
+    let alice_user = &setup.get_user(&alice).user;
+    let bob_user = &setup.get_user(&bob).user;
+
+    setup.listener_control_handle().set_drop_next_request();
+    let _ = alice_user
+        .remove_users(chat_id, vec![charlie.clone()])
+        .await
+        .expect_err("expected remove to fail due to network error");
+
+    // Bob commits first so Alice's pending commit is out of date.
+    bob_user.update_key(chat_id).await.unwrap();
+
+    let _ = alice_user
+        .update_key(chat_id)
+        .await
+        .expect_err("expected wrong epoch when retrying pending commit");
+
+    let pending = alice_user
+        .pending_chat_operation_info(chat_id)
+        .await
+        .unwrap()
+        .expect("pending operation should exist");
+    assert_eq!(pending.request_status, "waiting_for_queue_response");
+
+    // Alice processes Bob's winning commit, which must discard her stale pending
+    // commit on both the T and the PQ group.
+    let qs_messages = alice_user.qs_fetch_messages().await.unwrap();
+    let result = alice_user.fully_process_qs_messages(qs_messages).await;
+    assert!(
+        result.errors.is_empty(),
+        "processing incoming commit should succeed"
+    );
+
+    let pending_after = alice_user
+        .pending_chat_operation_info(chat_id)
+        .await
+        .unwrap();
+    assert!(
+        pending_after.is_none(),
+        "pending operation should be deleted"
+    );
+
+    // The discard must clear the pending commit on both groups, including the
+    // PQ group whose pending commit otherwise leaks.
+    let debug_info = alice_user.chat_debug_info(chat_id).await.unwrap();
+    let pq = debug_info
+        .pq
+        .clone()
+        .expect("APQ group must have a PQ group");
+    assert!(
+        !debug_info.has_pending_commit,
+        "T pending commit not cleared"
+    );
+    assert!(!pq.has_pending_commit, "PQ pending commit not cleared");
+    // Bob's winning commit was a T-only update, so it advances the T epoch but
+    // not the PQ epoch.
+    assert!(
+        pq.epoch < debug_info.epoch,
+        "PQ epoch must stay behind T after a T-only update, got T={} PQ={}",
+        debug_info.epoch,
+        pq.epoch
+    );
+
+    // Charlie is still a member, so removing him must succeed.
+    let participants = alice_user.chat_participants(chat_id).await.unwrap();
+    assert!(
+        participants.contains(&charlie),
+        "Charlie should still be a member"
+    );
+    alice_user
+        .remove_users(chat_id, vec![charlie.clone()])
+        .await
+        .expect("follow-up joint APQ remove should succeed");
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn network_errors_eventually_delete_pending_operation() {
     let (setup, alice, bob, _charlie, chat_id) = setup_group_with_contacts().await;

--- a/server/tests/tests/server.rs
+++ b/server/tests/tests/server.rs
@@ -675,6 +675,30 @@ async fn resync_valid_group_succeeds() {
     setup.send_message(chat_id, &bob, vec![&alice], None).await;
 }
 
+// Make sure that resync is refused for APQ groups for now.
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[tracing::instrument(name = "Resync is refused for APQ groups", skip_all)]
+async fn resync_refused_for_apq_group() {
+    let mut setup = TestBackend::single().await;
+
+    let alice = setup.add_user().await;
+    let bob = setup.add_user().await;
+    setup.connect_users(&alice, &bob).await;
+
+    let chat_id = setup.create_apq_group(&alice).await;
+    setup.invite_to_group(chat_id, &alice, vec![&bob]).await;
+
+    let bob_user = &setup.get_user(&bob).user;
+    bob_user
+        .enqueue_group_resync(chat_id)
+        .await
+        .expect_err("resync must be refused for APQ groups");
+    assert!(
+        !bob_user.is_resync_pending(chat_id).await.unwrap(),
+        "no resync should be queued for an APQ group"
+    );
+}
+
 /// Resync with holes in the leaf nodes: Alice creates a group with Bob,
 /// Charlie and Dave (leaf indices 0, 1, 2, 3), and then removes Bob. This
 /// blanks Bob's leaf, leaving a hole in the leaf nodes, so that leaf indices

--- a/server/tests/tests/server.rs
+++ b/server/tests/tests/server.rs
@@ -639,6 +639,12 @@ async fn resync_group_not_found_cleans_up_local_state() {
 async fn resync_valid_group_succeeds() {
     let mut setup = TestBackend::single().await;
 
+    // Skip resyncs for APQ groups.
+    if setup.apq_groups {
+        warn!("Skipping test: resync is not supported for APQ groups");
+        return;
+    }
+
     let alice = setup.add_user().await;
     let bob = setup.add_user().await;
     setup.connect_users(&alice, &bob).await;
@@ -709,6 +715,12 @@ async fn resync_refused_for_apq_group() {
 #[tracing::instrument(name = "Resync with blank leaf", skip_all)]
 async fn resync_with_blank_leaf_succeeds() {
     let mut setup = TestBackend::single().await;
+
+    // Skip resyncs for APQ groups.
+    if setup.apq_groups {
+        warn!("Skipping test: resync is not supported for APQ groups");
+        return;
+    }
 
     let alice = setup.add_user().await;
     let bob = setup.add_user().await;


### PR DESCRIPTION
Disables resyns for APQ groups (we need apqmls support for that) and irons out two bugs in APQ group processing:
 - pending commits were not cleared for the PQ group
 - commits from the past were wrongly classified as an error requiring a resync