### PR TITLE
chore: upgrade openmls to the latest commit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -541,7 +541,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -553,10 +553,12 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 [[package]]
 name = "apqmls"
 version = "0.1.0"
-source = "git+https://github.com/phnx-im/apqmls?rev=021ba62bbe2d319f614c5be2888993fb1055d0a0#021ba62bbe2d319f614c5be2888993fb1055d0a0"
 dependencies = [
  "openmls",
  "openmls_basic_credential",
+ "openmls_memory_storage",
+ "openmls_rust_crypto",
+ "openmls_sqlite_storage",
  "openmls_traits",
  "serde",
  "tap",
@@ -1805,7 +1807,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2656,7 +2658,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3235,9 +3237,6 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash",
-]
 
 [[package]]
 name = "hashbrown"
@@ -3259,15 +3258,6 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.2.0",
-]
-
-[[package]]
-name = "hashlink"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
-dependencies = [
- "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -4327,9 +4317,9 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.30.1"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+checksum = "133c182a6a2c87864fe97778797e46c7e999672690dc9fa3ee8e241aa4a9c13f"
 dependencies = [
  "cc",
  "pkg-config",
@@ -4600,6 +4590,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "minicov"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4869b6a491569605d66d3952bcdf03df789e5b536e5f0cf7758a7f08a55ae24d"
+dependencies = [
+ "cc",
+ "walkdir",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4821,7 +4821,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5060,27 +5060,35 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 [[package]]
 name = "openmls"
 version = "0.8.1"
-source = "git+https://github.com/boxdot/openmls?rev=ac45b95dde09c024bbf3876e4b71d754bf49368c#ac45b95dde09c024bbf3876e4b71d754bf49368c"
+source = "git+https://github.com/openmls/openmls?rev=26fadc3e49f92361d895598ffaa0f4c548446776#26fadc3e49f92361d895598ffaa0f4c548446776"
 dependencies = [
+ "backtrace",
+ "itertools 0.14.0",
  "log",
+ "once_cell",
  "openmls_basic_credential",
  "openmls_libcrux_crypto",
  "openmls_memory_storage",
  "openmls_rust_crypto",
+ "openmls_serialization_helpers",
  "openmls_sqlite_storage",
+ "openmls_test",
  "openmls_traits",
+ "rand 0.10.1",
  "rayon",
  "serde",
  "serde_bytes",
+ "serde_json",
  "thiserror 2.0.18",
  "tls_codec",
+ "wasm-bindgen-test",
  "zeroize",
 ]
 
 [[package]]
 name = "openmls_basic_credential"
 version = "0.5.0"
-source = "git+https://github.com/boxdot/openmls?rev=ac45b95dde09c024bbf3876e4b71d754bf49368c#ac45b95dde09c024bbf3876e4b71d754bf49368c"
+source = "git+https://github.com/openmls/openmls?rev=26fadc3e49f92361d895598ffaa0f4c548446776#26fadc3e49f92361d895598ffaa0f4c548446776"
 dependencies = [
  "ed25519-dalek",
  "ml-dsa",
@@ -5096,7 +5104,7 @@ dependencies = [
 [[package]]
 name = "openmls_libcrux_crypto"
 version = "0.3.1"
-source = "git+https://github.com/boxdot/openmls?rev=ac45b95dde09c024bbf3876e4b71d754bf49368c#ac45b95dde09c024bbf3876e4b71d754bf49368c"
+source = "git+https://github.com/openmls/openmls?rev=26fadc3e49f92361d895598ffaa0f4c548446776#26fadc3e49f92361d895598ffaa0f4c548446776"
 dependencies = [
  "hpke-rs",
  "hpke-rs-crypto",
@@ -5117,7 +5125,7 @@ dependencies = [
 [[package]]
 name = "openmls_memory_storage"
 version = "0.5.0"
-source = "git+https://github.com/boxdot/openmls?rev=ac45b95dde09c024bbf3876e4b71d754bf49368c#ac45b95dde09c024bbf3876e4b71d754bf49368c"
+source = "git+https://github.com/openmls/openmls?rev=26fadc3e49f92361d895598ffaa0f4c548446776#26fadc3e49f92361d895598ffaa0f4c548446776"
 dependencies = [
  "hex",
  "log",
@@ -5130,7 +5138,7 @@ dependencies = [
 [[package]]
 name = "openmls_rust_crypto"
 version = "0.5.1"
-source = "git+https://github.com/boxdot/openmls?rev=ac45b95dde09c024bbf3876e4b71d754bf49368c#ac45b95dde09c024bbf3876e4b71d754bf49368c"
+source = "git+https://github.com/openmls/openmls?rev=26fadc3e49f92361d895598ffaa0f4c548446776#26fadc3e49f92361d895598ffaa0f4c548446776"
 dependencies = [
  "aes-gcm",
  "chacha20poly1305",
@@ -5148,29 +5156,50 @@ dependencies = [
  "rand_chacha 0.3.1",
  "rand_core 0.10.1",
  "rand_core 0.6.4",
- "serde",
  "sha2 0.11.0",
  "thiserror 2.0.18",
  "tls_codec",
 ]
 
 [[package]]
+name = "openmls_serialization_helpers"
+version = "0.1.0"
+source = "git+https://github.com/openmls/openmls?rev=26fadc3e49f92361d895598ffaa0f4c548446776#26fadc3e49f92361d895598ffaa0f4c548446776"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "openmls_sqlite_storage"
 version = "0.2.0"
-source = "git+https://github.com/boxdot/openmls?rev=ac45b95dde09c024bbf3876e4b71d754bf49368c#ac45b95dde09c024bbf3876e4b71d754bf49368c"
+source = "git+https://github.com/openmls/openmls?rev=26fadc3e49f92361d895598ffaa0f4c548446776#26fadc3e49f92361d895598ffaa0f4c548446776"
 dependencies = [
- "log",
  "openmls_traits",
  "refinery",
  "rusqlite",
  "serde",
- "thiserror 2.0.18",
+]
+
+[[package]]
+name = "openmls_test"
+version = "0.2.1"
+source = "git+https://github.com/openmls/openmls?rev=26fadc3e49f92361d895598ffaa0f4c548446776#26fadc3e49f92361d895598ffaa0f4c548446776"
+dependencies = [
+ "openmls_libcrux_crypto",
+ "openmls_rust_crypto",
+ "openmls_sqlite_storage",
+ "openmls_traits",
+ "quote",
+ "syn",
 ]
 
 [[package]]
 name = "openmls_traits"
 version = "0.5.0"
-source = "git+https://github.com/boxdot/openmls?rev=ac45b95dde09c024bbf3876e4b71d754bf49368c#ac45b95dde09c024bbf3876e4b71d754bf49368c"
+source = "git+https://github.com/openmls/openmls?rev=26fadc3e49f92361d895598ffaa0f4c548446776#26fadc3e49f92361d895598ffaa0f4c548446776"
 dependencies = [
  "serde",
  "tls_codec",
@@ -5193,7 +5222,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.45.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6379,14 +6408,14 @@ dependencies = [
 
 [[package]]
 name = "rusqlite"
-version = "0.32.1"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+checksum = "165ca6e57b20e1351573e3729b958bc62f0e48025386970b6e4d29e7a7e71f3f"
 dependencies = [
  "bitflags 2.11.0",
  "fallible-iterator",
  "fallible-streaming-iterator",
- "hashlink 0.9.1",
+ "hashlink 0.10.0",
  "libsqlite3-sys",
  "smallvec",
 ]
@@ -6422,7 +6451,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6823,7 +6852,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7176,7 +7205,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7796,7 +7825,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8066,6 +8095,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-test"
+version = "0.3.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6311c867385cc7d5602463b31825d454d0837a3aba7cdb5e56d5201792a3f7fe"
+dependencies = [
+ "async-trait",
+ "cast",
+ "js-sys",
+ "libm",
+ "minicov",
+ "nu-ansi-term",
+ "num-traits",
+ "oorandom",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test-macro",
+ "wasm-bindgen-test-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-test-macro"
+version = "0.3.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67008cdde4769831958536b0f11b3bdd0380bde882be17fff9c2f34bb4549abd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "wasm-bindgen-test-shared"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe29135b180b72b04c74aa97b2b4a2ef275161eff9a6c7955ea9eaedc7e1d4e"
+
+[[package]]
 name = "wasm-encoder"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8264,7 +8332,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ members = [
     "server",
     "test_harness",
     "xtask",
+    "apqmls",
 ]
 
 [workspace.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,11 +28,11 @@ airmacros = { path = "macros" }
 airprotos = { path = "protos" }
 airserver = { path = "server" }
 airserver_test_harness = { path = "test_harness" }
+apqmls = { path = "apqmls" }
 mls-assist = { path = "mls-assist" }
 
 aes-gcm = "0.10"
 anyhow = { version = "1.0.98", features = ["backtrace"] }
-apqmls = { git = "https://github.com/phnx-im/apqmls", rev = "021ba62bbe2d319f614c5be2888993fb1055d0a0" }
 arboard = "3"
 argon2 = "0.5.3"
 async-trait = "0.1.53"
@@ -80,10 +80,11 @@ minicbor = { version = "2.2.1", features = ["std"] }
 minicbor-serde = { version = "0.6", features = ["std"] }
 mockall = "0.13.1"
 mockito = "1.7.0"
-openmls = { version = "0.8.1", features = ["extensions-draft-08", "draft-ietf-mls-pq-ciphersuites"] }
-openmls_basic_credential = { version = "0.5.0" }
+openmls = { version = "0.8.1", features = ["extensions-draft-08", "draft-ietf-mls-pq-ciphersuites", "unchecked-conversions", "0-8-1-storage-format"] }
+openmls_basic_credential = { version = "0.5.0", features = ["clonable"] }
 openmls_memory_storage = { version = "0.5.0", features = ["extensions-draft-08", "draft-ietf-mls-pq-ciphersuites"] }
 openmls_rust_crypto = { version = "0.5.1", features = ["draft-ietf-mls-pq-ciphersuites"] }
+openmls_sqlite_storage = { version = "0.2.0", features = ["extensions-draft-08", "draft-ietf-mls-pq-ciphersuites"] }
 openmls_traits = { version = "0.5.0", features = ["draft-ietf-mls-pq-ciphersuites"] }
 parking_lot = "0.12"
 pin-project = "1.1.10"
@@ -107,6 +108,7 @@ sha2 = "0.10.9"
 shadow-rs = { version = "1.4.0", default-features = false }
 sqlx = { version = "0.9.0", default-features = false, features = ["macros", "uuid", "chrono", "migrate", "bigdecimal", "runtime-tokio", "sqlx-toml"] }
 strum = { version = "0.28", features = ["derive"] }
+tap = "1.0.1"
 tar = "0.4.44"
 tempfile = "3.23.0"
 thiserror = "2.0"
@@ -133,16 +135,13 @@ zeroize = "1.8.2"
 
 
 [patch.crates-io]
-# Use the several commits after the 0.8.1 release exposing methods as public APIs, in particular:
-# <https://github.com/openmls/openmls/commit/04c50d7fb12d52f4f9aee26de5f5234f3df29fa8>
-# <https://github.com/openmls/openmls/commit/b73621ba14ead6b32636a4e910f2cbfabb0d1ee9>
-#
-# Also, use the post-quantum-support branch of openmls.
-openmls = { git = "https://github.com/boxdot/openmls", rev = "ac45b95dde09c024bbf3876e4b71d754bf49368c" }
-openmls_rust_crypto = { git = "https://github.com/boxdot/openmls", rev = "ac45b95dde09c024bbf3876e4b71d754bf49368c" }
-openmls_traits = { git = "https://github.com/boxdot/openmls", rev = "ac45b95dde09c024bbf3876e4b71d754bf49368c" }
-openmls_memory_storage = { git = "https://github.com/boxdot/openmls", rev = "ac45b95dde09c024bbf3876e4b71d754bf49368c" }
-openmls_basic_credential = { git = "https://github.com/boxdot/openmls", rev = "ac45b95dde09c024bbf3876e4b71d754bf49368c" }
+# Use unreleased post-quantum and virtual-clients features of openmls after the 0.8.1 release
+openmls = { git = "https://github.com/openmls/openmls", rev = "26fadc3e49f92361d895598ffaa0f4c548446776" }
+openmls_rust_crypto = { git = "https://github.com/openmls/openmls", rev = "26fadc3e49f92361d895598ffaa0f4c548446776" }
+openmls_traits = { git = "https://github.com/openmls/openmls", rev = "26fadc3e49f92361d895598ffaa0f4c548446776" }
+openmls_memory_storage = { git = "https://github.com/openmls/openmls", rev = "26fadc3e49f92361d895598ffaa0f4c548446776" }
+openmls_basic_credential = { git = "https://github.com/openmls/openmls", rev = "26fadc3e49f92361d895598ffaa0f4c548446776" }
+openmls_sqlite_storage = { git = "https://github.com/openmls/openmls", rev = "26fadc3e49f92361d895598ffaa0f4c548446776" }
 # openmls = { path = "../openmls/openmls" }
 # openmls_rust_crypto = { path = "../openmls/openmls_rust_crypto" }
 # openmls_traits = { path = "../openmls/traits" }
@@ -162,9 +161,6 @@ hpke-rs-rust-crypto = { git = "https://github.com/cryspen/hpke-rs", rev = "42f9b
 # v0.10.0-rc.18 with additional unreleased commit using `signature@0.3` instead of `3.0.0-rc.10`
 # This patch is needed to be compatible with dsa 0.1 which uses `signature@0.3`.
 rsa = { git = "https://github.com/RustCrypto/RSA", rev = "99f80888cdc838da78a48ad14f6e1f5c01be5c30" }
-
-# [patch."https://github.com/phnx-im/apqmls"]
-# apqmls = { path = "../apqmls" }
 
 
 [profile.release]

--- a/apqmls/Cargo.toml
+++ b/apqmls/Cargo.toml
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: 2025 Phoenix R&D GmbH <hello@phnx.im>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+[package]
+name = "apqmls"
+description = "Amortized Post-Quantum MLS Combiner"
+authors = ["Phoenix R&D GmbH <hello@phnx.im>"]
+version = "0.1.0"
+edition = "2024"
+license = "AGPL-3.0-or-later"
+
+[dependencies]
+openmls.workspace = true
+openmls_basic_credential.workspace = true
+openmls_traits.workspace = true
+serde.workspace = true
+tap.workspace = true
+thiserror.workspace = true
+tls_codec.workspace = true
+
+[dev-dependencies]
+# `test-utils` exposes `MlsGroup::export_group_context` for the group context tests
+openmls = { workspace = true, features = ["test-utils"] }
+openmls_memory_storage.workspace = true
+openmls_rust_crypto.workspace = true
+openmls_sqlite_storage.workspace = true

--- a/apqmls/README.md
+++ b/apqmls/README.md
@@ -1,0 +1,21 @@
+<!--
+SPDX-FileCopyrightText: 2026 Phoenix R&D GmbH <hello@phnx.im>
+
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
+# APQMLS - Amortized Post-Quantum MLS Combiner
+
+Implementation of the [MLS
+Combiner](https://www.ietf.org/archive/id/draft-ietf-mls-combiner-02.html)
+(draft-ietf-mls-combiner-02) -- an amortized post-quantum MLS combiner built on
+top of [OpenMLS](https://github.com/openmls/openmls).
+
+MLS is a secure group messaging protocol. The MLS Combiner runs a classical and
+a post-quantum MLS group in parallel and combines their key material to provide
+post-quantum security. The "amortized" aspect batches the post-quantum
+operations across multiple epochs, reducing per-message overhead.
+
+## License
+
+AGPL-3.0-or-later

--- a/apqmls/src/authentication.rs
+++ b/apqmls/src/authentication.rs
@@ -1,0 +1,142 @@
+// SPDX-FileCopyrightText: 2025 Phoenix R&D GmbH <hello@phnx.im>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! This module defines types and traits for handling authentication in APQMLS.
+
+use openmls::prelude::{
+    BasicCredential, CredentialWithKey, CryptoError, SignaturePublicKey, SignatureScheme,
+};
+use openmls_basic_credential::SignatureKeyPair;
+use openmls_traits::{
+    signatures::Signer,
+    storage::{self, CURRENT_VERSION},
+};
+use serde::{Deserialize, Serialize};
+use tap::Pipe;
+use tls_codec::{Serialize as _, TlsDeserialize, TlsSerialize, TlsSize};
+
+use crate::ApqCiphersuite;
+
+/// The combined verifying key of a [`ApqSigner`].
+#[derive(Debug, Clone, PartialEq, Eq, TlsSize, TlsSerialize, TlsDeserialize)]
+pub struct ApqVerifyingKey {
+    pub t_verifying_key: SignaturePublicKey,
+    pub pq_verifying_key: SignaturePublicKey,
+}
+
+impl ApqVerifyingKey {
+    pub fn to_bytes(&self) -> Vec<u8> {
+        // We unwrap here, because we know that public keys are not going to be
+        // too long for the TLS codec to handle.
+        self.tls_serialize_detached().unwrap()
+    }
+}
+
+/// A combined credential with key for use in APQMLS.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ApqCredentialWithKey {
+    pub t_credential: CredentialWithKey,
+    pub pq_credential: CredentialWithKey,
+}
+
+impl ApqCredentialWithKey {
+    pub fn new(identity: &[u8], keypair: &ApqSignatureKeyPair) -> Self {
+        let t_credential = BasicCredential::new(identity.to_vec());
+        let pq_credential = BasicCredential::new(identity.to_vec());
+
+        Self {
+            t_credential: CredentialWithKey {
+                credential: t_credential.into(),
+                signature_key: keypair.t_signer.public().into(),
+            },
+            pq_credential: CredentialWithKey {
+                credential: pq_credential.into(),
+                signature_key: keypair.pq_signer.public().into(),
+            },
+        }
+    }
+}
+
+/// A trait for types that can sign messages in APQMLS.
+pub trait ApqSigner {
+    type TSigner: Signer;
+    type PqSigner: Signer;
+
+    fn t_signer(&self) -> &Self::TSigner;
+    fn pq_signer(&self) -> &Self::PqSigner;
+}
+
+/// The signature scheme of a [`ApqSigner`].
+#[derive(Debug, Clone, Copy)]
+pub struct ApqSignatureScheme {
+    pub t_signature_scheme: SignatureScheme,
+    pub pq_signature_scheme: SignatureScheme,
+}
+
+impl From<ApqCiphersuite> for ApqSignatureScheme {
+    fn from(ciphersuite: ApqCiphersuite) -> Self {
+        Self {
+            t_signature_scheme: ciphersuite.t_ciphersuite.signature_algorithm(),
+            pq_signature_scheme: ciphersuite.pq_ciphersuite.signature_algorithm(),
+        }
+    }
+}
+
+/// A combined signature key pair for use in APQMLS.
+#[derive(Debug, Clone, TlsSize, TlsSerialize, TlsDeserialize, Serialize, Deserialize)]
+pub struct ApqSignatureKeyPair {
+    t_signer: SignatureKeyPair,
+    pq_signer: SignatureKeyPair,
+}
+
+impl ApqSignatureKeyPair {
+    pub fn new(signature_scheme: ApqSignatureScheme) -> Result<Self, CryptoError> {
+        let t_signer = SignatureKeyPair::new(signature_scheme.t_signature_scheme)?;
+        let pq_signer = SignatureKeyPair::new(signature_scheme.pq_signature_scheme)?;
+        Self {
+            t_signer,
+            pq_signer,
+        }
+        .pipe(Ok)
+    }
+
+    pub fn id(&self) -> ApqStorageId {
+        ApqStorageId {
+            t_signature_scheme: self.t_signer.signature_scheme(),
+            t_verifying_key: self.t_signer.public().to_vec(),
+            pq_signature_scheme: self.pq_signer.signature_scheme(),
+            pq_verifying_key: self.pq_signer.public().to_vec(),
+        }
+    }
+}
+
+impl ApqSigner for ApqSignatureKeyPair {
+    type TSigner = SignatureKeyPair;
+    type PqSigner = SignatureKeyPair;
+
+    fn t_signer(&self) -> &SignatureKeyPair {
+        &self.t_signer
+    }
+
+    fn pq_signer(&self) -> &SignatureKeyPair {
+        &self.pq_signer
+    }
+}
+
+/// The storage ID for a [`ApqSignatureKeyPair`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ApqStorageId {
+    t_signature_scheme: SignatureScheme,
+    t_verifying_key: Vec<u8>,
+    pq_signature_scheme: SignatureScheme,
+    pq_verifying_key: Vec<u8>,
+}
+
+// Implement key traits for the storage id
+impl storage::Key<CURRENT_VERSION> for ApqStorageId {}
+impl storage::traits::SignaturePublicKey<CURRENT_VERSION> for ApqStorageId {}
+
+// Implement entity trait for the signature key pair
+impl storage::Entity<CURRENT_VERSION> for ApqSignatureKeyPair {}
+impl storage::traits::SignatureKeyPair<CURRENT_VERSION> for ApqSignatureKeyPair {}

--- a/apqmls/src/commit_builder.rs
+++ b/apqmls/src/commit_builder.rs
@@ -1,0 +1,322 @@
+// SPDX-FileCopyrightText: 2025 Phoenix R&D GmbH <hello@phnx.im>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+use openmls::{
+    group::{
+        CommitBuilder as MlsGroupCommitBuilder, CommitBuilderStageError, CommitMessageBundle,
+        CreateCommitError as OpenMlsCreateCommitError, GroupEpoch, Initial, MlsGroup,
+        QueuedProposal,
+    },
+    prelude::{
+        AppDataUpdateProposal, InvalidExtensionError, LeafNodeIndex, LeafNodeParameters,
+        PreSharedKeyProposal, Proposal, ProposalType,
+    },
+    storage::OpenMlsProvider,
+};
+use serde::{Deserialize, Serialize};
+use tap::Pipe as _;
+use thiserror::Error;
+
+use crate::{
+    ApqMlsGroup, ApqMlsGroupMut,
+    authentication::ApqSigner,
+    extension::APQMLS_COMPONENT_ID,
+    messages::{ApqGroupInfo, ApqKeyPackage, ApqMlsMessageOut, ApqWelcome},
+    psk::{ApqPskError, derive_and_store_psk},
+};
+
+/// Error while creating a commit in APQMLS.
+#[derive(Debug, Error)]
+pub enum CreateCommitError<StorageError> {
+    #[error("Failed to build commit: {0}")]
+    BuildCommit(#[from] OpenMlsCreateCommitError),
+    #[error("Failed to stage commit: {0}")]
+    StageCommit(#[from] CommitBuilderStageError<StorageError>),
+    #[error("Missing APQInfo extension")]
+    MissingApqInfo,
+    #[error("Malformed extension: {0}")]
+    MalformedExtension(#[from] tls_codec::Error),
+    #[error(transparent)]
+    Psk(#[from] ApqPskError<StorageError>),
+    #[error(transparent)]
+    Extension(#[from] InvalidExtensionError),
+}
+
+/// A message bundle resulting from a commit operation in APQMLS.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ApqCommitMessageBundle {
+    pub commit: ApqMlsMessageOut,
+    pub welcome: Option<ApqWelcome>,
+    pub group_info: Option<ApqGroupInfo>,
+}
+
+impl ApqCommitMessageBundle {
+    fn from_bundles(t_bundle: CommitMessageBundle, pq_bundle: CommitMessageBundle) -> Self {
+        let (t_commit, t_welcome, t_group_info) = t_bundle.into_contents();
+        let (pq_commit, pq_welcome, pq_group_info) = pq_bundle.into_contents();
+
+        let commit = ApqMlsMessageOut {
+            t_message: t_commit,
+            pq_message: pq_commit,
+        };
+
+        let welcome = match (t_welcome, pq_welcome) {
+            (Some(t), Some(pq)) => Some(ApqWelcome {
+                t_welcome: t,
+                pq_welcome: pq,
+            }),
+            (None, None) => None,
+            _ => {
+                debug_assert!(false, "Inconsistent welcome messages");
+                None
+            }
+        };
+
+        let group_info = t_group_info
+            .zip(pq_group_info)
+            .map(|(t_group_info, pq_group_info)| ApqGroupInfo {
+                t_group_info,
+                pq_group_info,
+            });
+
+        Self {
+            commit,
+            welcome,
+            group_info,
+        }
+    }
+
+    /// Consumes the bundle and returns the commit message.
+    pub fn into_message_out(self) -> ApqMlsMessageOut {
+        self.commit
+    }
+
+    /// Consumes the bundle and returns the welcome message, if any.
+    pub fn into_welcome(self) -> Option<ApqWelcome> {
+        self.welcome
+    }
+
+    /// Consumes the bundle and returns the group info, if any.
+    pub fn into_group_info(self) -> Option<ApqGroupInfo> {
+        self.group_info
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+struct ConfigValues {
+    consume_proposal_store: Option<bool>,
+    force_self_update: Option<bool>,
+    t_proposals: Vec<Proposal>,
+    t_leaf_node_parameters: Option<LeafNodeParameters>,
+    pq_leaf_node_parameters: Option<LeafNodeParameters>,
+    proposed_adds: Vec<ApqKeyPackage>,
+    proposed_removals: Vec<LeafNodeIndex>,
+    create_group_info: bool,
+}
+
+impl ConfigValues {
+    fn apply<'b, const IS_TRADITIONAL: bool>(
+        &self,
+        mut builder: MlsGroupCommitBuilder<'b, Initial>,
+    ) -> MlsGroupCommitBuilder<'b, Initial> {
+        if let Some(consume) = self.consume_proposal_store {
+            builder = builder.consume_proposal_store(consume);
+        }
+        if let Some(force) = self.force_self_update {
+            builder = builder.force_self_update(force);
+        }
+        if let Some(t_leaf_node_parameters) = &self.t_leaf_node_parameters {
+            builder = builder.leaf_node_parameters(t_leaf_node_parameters.clone());
+        }
+        if let Some(pq_leaf_node_parameters) = &self.pq_leaf_node_parameters {
+            builder = builder.leaf_node_parameters(pq_leaf_node_parameters.clone());
+        }
+        let (t_kps, pq_kps): (Vec<_>, Vec<_>) = self
+            .proposed_adds
+            .iter()
+            .map(|kp| (kp.t_key_package.clone(), kp.pq_key_package.clone()))
+            .unzip();
+        if IS_TRADITIONAL {
+            builder = builder.add_proposals(self.t_proposals.clone());
+            builder = builder.propose_adds(t_kps);
+        } else {
+            builder = builder.propose_adds(pq_kps);
+        }
+        builder = builder.propose_removals(self.proposed_removals.clone());
+
+        builder
+    }
+}
+
+/// A builder for creating commits in an APQMLS group. This builder can be used
+/// to affect membership changes and issue full updates.
+pub struct CommitBuilder<'a> {
+    group: ApqMlsGroupMut<'a>,
+    values: ConfigValues,
+}
+
+impl<'a> CommitBuilder<'a> {
+    /// Creates a new [`CommitBuilder`] for the given [`ApqMlsGroup`] group.
+    pub fn new(group: &'a mut ApqMlsGroup) -> Self {
+        Self::from_groups(&mut group.t_group, &mut group.pq_group)
+    }
+
+    /// Creates a new [`CommitBuilder`] from the given mutable [`openmls::group::MlsGroup`]s.
+    pub fn from_groups(t_group: &'a mut MlsGroup, pq_group: &'a mut MlsGroup) -> Self {
+        Self {
+            group: ApqMlsGroupMut::from_groups(t_group, pq_group),
+            values: ConfigValues::default(),
+        }
+    }
+
+    /// Sets whether or not the proposals in the proposal store of the group should be included in
+    /// the commit. Defaults to `true`.
+    pub fn consume_proposal_store(mut self, consume_proposal_store: bool) -> Self {
+        self.values.consume_proposal_store = Some(consume_proposal_store);
+        self
+    }
+
+    /// Sets whether or not the commit should force a self-update. Defaults to `false`.
+    pub fn force_self_update(mut self, force_self_update: bool) -> Self {
+        self.values.force_self_update = Some(force_self_update);
+        self
+    }
+
+    /// Adds a proposal to the proposals to be committed in the traditional
+    /// group. This must not be used with add or remove proposals.
+    ///
+    /// If this is used with add or remove proposals, the
+    /// builder will return unchanged.
+    pub fn add_t_proposal(mut self, t_proposal: Proposal) -> Self {
+        if t_proposal.proposal_type() == ProposalType::Add
+            || t_proposal.proposal_type() == ProposalType::Remove
+        {
+            return self;
+        }
+        self.values.t_proposals.push(t_proposal);
+        self
+    }
+
+    /// Adds the proposals in the iterator to the proposals to be committed.
+    /// None of the proposals may be of type Add or Remove.
+    ///
+    /// Any add or remove proposals are filtered out.
+    pub fn add_t_proposals(mut self, t_proposals: impl IntoIterator<Item = Proposal>) -> Self {
+        let iter = t_proposals.into_iter().filter(|p| {
+            p.proposal_type() != ProposalType::Add && p.proposal_type() != ProposalType::Remove
+        });
+        self.values.t_proposals.extend(iter);
+        self
+    }
+
+    /// Sets the leaf node parameters for the new leaf node in a self-update. Implies that a
+    /// self-update takes place.
+    pub fn leaf_node_parameters(
+        mut self,
+        t_leaf_node_parameters: LeafNodeParameters,
+        pq_leaf_node_parameters: LeafNodeParameters,
+    ) -> Self {
+        self.values.t_leaf_node_parameters = Some(t_leaf_node_parameters);
+        self.values.pq_leaf_node_parameters = Some(pq_leaf_node_parameters);
+        self
+    }
+
+    /// Adds an Add proposal for each of the provided [`openmls::key_packages::KeyPackage`] tuples
+    /// to the list of proposals to be committed. The first KeyPackage in each tuple must be the
+    /// traditional one and the second the post-quantum one.
+    pub fn propose_adds(mut self, key_packages: impl IntoIterator<Item = ApqKeyPackage>) -> Self {
+        self.values.proposed_adds.extend(key_packages);
+        self
+    }
+
+    /// Adds a Remove proposal for the provided [`LeafNodeIndex`]es to the list of proposals to be
+    /// committed.
+    pub fn propose_removals(mut self, removed: impl IntoIterator<Item = LeafNodeIndex>) -> Self {
+        let removed = removed.into_iter().collect::<Vec<_>>();
+        self.values.proposed_removals.extend(removed);
+        self
+    }
+
+    /// Sets whether or not a [`GroupInfo`] should be created when the commit is staged.
+    pub fn create_group_info(mut self, create_group_info: bool) -> Self {
+        self.values.create_group_info = create_group_info;
+        self
+    }
+
+    /// Perform all steps to finish the builder.
+    /// - load the PSKs for the PskProposals marked for inclusion
+    /// - build the commit
+    /// - stage the commit
+    ///
+    /// TODO: Split this up to enable sans-io usage.
+    pub fn finalize<S: ApqSigner, Provider: OpenMlsProvider>(
+        self,
+        provider: &Provider,
+        signer: &S,
+        t_f: impl FnMut(&QueuedProposal) -> bool,
+        pq_f: impl FnMut(&QueuedProposal) -> bool,
+    ) -> Result<ApqCommitMessageBundle, CreateCommitError<Provider::StorageError>> {
+        let mut apq_info = self
+            .group
+            .apq_info()
+            .ok_or_else(|| CreateCommitError::MissingApqInfo)?;
+        let new_t_epoch = self.group.t_group.epoch().as_u64() + 1;
+        let new_pq_epoch = self.group.pq_group.epoch().as_u64() + 1;
+        apq_info.set_epoch(
+            GroupEpoch::from(new_t_epoch),
+            GroupEpoch::from(new_pq_epoch),
+        );
+
+        let apq_info_component_data = apq_info.to_component_data()?;
+        let app_data_update_proposal =
+            AppDataUpdateProposal::update(APQMLS_COMPONENT_ID, apq_info_component_data.data());
+
+        // Create the PQ commit first s.t. we can export the PSK for the T group.
+        let mut pq_builder = self
+            .group
+            .pq_group
+            .commit_builder()
+            .pipe(|b| self.values.apply::<false>(b))
+            .add_proposal(Proposal::AppDataUpdate(Box::new(
+                app_data_update_proposal.clone(),
+            )))
+            .load_psks(provider.storage())?
+            .create_group_info(self.values.create_group_info);
+        let mut updater = pq_builder.app_data_dictionary_updater();
+        updater.set(apq_info_component_data.clone());
+        let changes = updater.changes();
+        pq_builder.with_app_data_dictionary_updates(changes);
+        let pq_result = pq_builder
+            .build(provider.rand(), provider.crypto(), signer.pq_signer(), pq_f)?
+            .stage_commit(provider)?;
+
+        // Prepare the PSK for the T group.
+        let psk_proposal = derive_and_store_psk::<_, true>(
+            provider,
+            self.group.pq_group,
+            self.group.t_group.ciphersuite(),
+        )?
+        .pipe(PreSharedKeyProposal::new)
+        .pipe(Box::new)
+        .pipe(Proposal::PreSharedKey);
+
+        let mut t_builder = self
+            .group
+            .t_group
+            .commit_builder()
+            .pipe(|b| self.values.apply::<true>(b))
+            .add_proposal(psk_proposal)
+            .add_proposal(Proposal::AppDataUpdate(Box::new(app_data_update_proposal)))
+            .load_psks(provider.storage())?
+            .create_group_info(self.values.create_group_info);
+        let mut updater = t_builder.app_data_dictionary_updater();
+        updater.set(apq_info_component_data);
+        let changes = updater.changes();
+        t_builder.with_app_data_dictionary_updates(changes);
+        let t_result = t_builder
+            .build(provider.rand(), provider.crypto(), signer.t_signer(), t_f)?
+            .stage_commit(provider)?;
+        Ok(ApqCommitMessageBundle::from_bundles(t_result, pq_result))
+    }
+}

--- a/apqmls/src/export.rs
+++ b/apqmls/src/export.rs
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: 2025 Phoenix R&D GmbH <hello@phnx.im>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+use openmls::{group::ExportGroupInfoError, prelude::OpenMlsCrypto};
+
+use crate::{
+    ApqMlsGroup,
+    authentication::ApqSigner,
+    messages::{ApqMlsMessageOut, ApqRatchetTree},
+};
+
+impl ApqMlsGroup {
+    /// Export the ratchet tree of the group.
+    pub fn export_ratchet_tree(&self) -> ApqRatchetTree {
+        let t_ratchet_tree = self.t_group.export_ratchet_tree();
+        let pq_ratchet_tree = self.pq_group.export_ratchet_tree();
+        ApqRatchetTree {
+            t_ratchet_tree,
+            pq_ratchet_tree,
+        }
+    }
+
+    /// Export the group info of the group.
+    pub fn export_group_info(
+        &self,
+        crypto: &impl OpenMlsCrypto,
+        signer: &impl ApqSigner,
+        with_ratchet_tree: bool,
+    ) -> Result<ApqMlsMessageOut, ExportGroupInfoError> {
+        let t_group_info =
+            self.t_group
+                .export_group_info(crypto, signer.t_signer(), with_ratchet_tree)?;
+        let pq_group_info =
+            self.pq_group
+                .export_group_info(crypto, signer.pq_signer(), with_ratchet_tree)?;
+        let group_info = ApqMlsMessageOut {
+            t_message: t_group_info,
+            pq_message: pq_group_info,
+        };
+        Ok(group_info)
+    }
+}

--- a/apqmls/src/extension.rs
+++ b/apqmls/src/extension.rs
@@ -1,0 +1,170 @@
+// SPDX-FileCopyrightText: 2025 Phoenix R&D GmbH <hello@phnx.im>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+use openmls::{
+    component::{ComponentData, ComponentId, ComponentType},
+    group::{GroupContext, GroupEpoch, GroupId},
+    prelude::{
+        AppDataDictionary, AppDataDictionaryExtension, Capabilities, Ciphersuite, Extension,
+        ExtensionType, Extensions, LeafNode, ProposalType,
+    },
+};
+use tap::Pipe;
+use tls_codec::{Deserialize as _, Serialize as _, TlsDeserialize, TlsSerialize, TlsSize};
+
+use crate::{ApqCiphersuite, ApqGroupId, ApqMlsGroup, ApqMlsGroupMut};
+
+/// The component ID of the APQMLS component.
+///
+/// The value is not yet finalized in the draft
+/// <https://datatracker.ietf.org/doc/html/draft-ietf-mls-combiner#name-key-schedule>.
+pub const APQMLS_COMPONENT_ID: ComponentId = 0x8001;
+
+/// The mode of an [`ApqMlsGroup`], which determines whether only confidentiality or both
+/// confidentiality and authentication is PQ secure.
+#[derive(Default, Debug, Clone, TlsSize, TlsSerialize, TlsDeserialize, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum PqtMode {
+    #[default]
+    ConfOnly,
+    ConfAndAuth,
+}
+
+impl From<PqtMode> for bool {
+    fn from(value: PqtMode) -> Self {
+        match value {
+            PqtMode::ConfOnly => false,
+            PqtMode::ConfAndAuth => true,
+        }
+    }
+}
+
+impl PqtMode {
+    /// Returns the default ciphersuite for the given mode.
+    pub fn default_ciphersuite(&self) -> ApqCiphersuite {
+        match self {
+            PqtMode::ConfOnly => ApqCiphersuite::default_pq_conf(),
+            PqtMode::ConfAndAuth => ApqCiphersuite::default_pq_conf_and_auth(),
+        }
+    }
+}
+
+/// The APQMLS extension, which is used to store APQMLS-specific information
+/// in the extensions of an [`openmls::group::MlsGroup`].
+#[derive(Debug, Clone, TlsSize, TlsSerialize, TlsDeserialize, PartialEq, Eq)]
+pub struct ApqInfo {
+    pub t_session_group_id: GroupId,
+    pub pq_session_group_id: GroupId,
+    pub mode: PqtMode,
+    pub t_cipher_suite: Ciphersuite,
+    pub pq_cipher_suite: Ciphersuite,
+    pub t_epoch: GroupEpoch,
+    pub pq_epoch: GroupEpoch,
+}
+
+impl ApqInfo {
+    pub(super) fn to_component_data(&self) -> Result<ComponentData, tls_codec::Error> {
+        let bytes = self.tls_serialize_detached()?;
+        Ok(ComponentData::from_parts(APQMLS_COMPONENT_ID, bytes.into()))
+    }
+
+    pub(super) fn set_epoch(&mut self, t_epoch: GroupEpoch, pq_epoch: GroupEpoch) {
+        self.t_epoch = t_epoch;
+        self.pq_epoch = pq_epoch;
+    }
+
+    pub fn from_extensions(
+        extensions: &Extensions<GroupContext>,
+    ) -> Result<Option<Self>, tls_codec::Error> {
+        extensions
+            .app_data_dictionary()
+            .and_then(|dict| dict.dictionary().get(&APQMLS_COMPONENT_ID))
+            .map(ApqInfo::tls_deserialize_exact)
+            .transpose()
+    }
+
+    pub fn group_id(&self) -> ApqGroupId {
+        ApqGroupId {
+            t_group_id: self.t_session_group_id.clone(),
+            pq_group_id: self.pq_session_group_id.clone(),
+        }
+    }
+}
+
+pub(super) fn ensure_extension_support(
+    capabilities: Capabilities,
+) -> Result<Capabilities, tls_codec::Error> {
+    let mut extensions = capabilities.extensions().to_vec();
+    if !extensions.contains(&ExtensionType::RequiredCapabilities) {
+        extensions.push(ExtensionType::RequiredCapabilities);
+    }
+    if !extensions.contains(&ExtensionType::AppDataDictionary) {
+        extensions.push(ExtensionType::AppDataDictionary);
+    }
+    let mut proposals: Vec<ProposalType> = capabilities.proposals().to_vec();
+    if !proposals.contains(&ProposalType::AppDataUpdate) {
+        proposals.push(ProposalType::AppDataUpdate);
+    }
+
+    let ciphersuites: Vec<Ciphersuite> = capabilities
+        .ciphersuites()
+        .iter()
+        .map(|&cs| cs.try_into())
+        .collect::<Result<_, _>>()?;
+    Capabilities::new(
+        Some(capabilities.versions()),
+        Some(&ciphersuites),
+        Some(extensions.as_slice()),
+        Some(proposals.as_slice()),
+        Some(capabilities.credentials()),
+    )
+    .pipe(Ok)
+}
+
+pub(super) fn ensure_component_support(
+    mut dictionary: AppDataDictionary,
+) -> Result<AppDataDictionary, tls_codec::Error> {
+    let mut app_components: Vec<ComponentId> = dictionary
+        .get(&ComponentId::from(ComponentType::AppComponents))
+        .map(Vec::tls_deserialize_exact)
+        .transpose()?
+        .unwrap_or_default();
+    if !app_components.contains(&APQMLS_COMPONENT_ID) {
+        app_components.push(APQMLS_COMPONENT_ID);
+        dictionary.insert(
+            ComponentId::from(ComponentType::AppComponents),
+            app_components.tls_serialize_detached()?,
+        );
+    }
+    Ok(dictionary)
+}
+
+pub(super) fn ensure_leaf_node_component_support(
+    mut extensions: Extensions<LeafNode>,
+) -> Result<Extensions<LeafNode>, tls_codec::Error> {
+    let dictionary = extensions
+        .app_data_dictionary()
+        .map(|extension| extension.dictionary().clone())
+        .unwrap_or_default();
+    let dictionary = ensure_component_support(dictionary)?;
+    let extension = Extension::AppDataDictionary(AppDataDictionaryExtension::new(dictionary));
+    extensions
+        .add_or_replace(extension)
+        .expect("logic error: extension is valid");
+    Ok(extensions)
+}
+
+impl ApqMlsGroup {
+    /// Get the APQMLS component from the group, if it exists.
+    pub fn apq_info(&self) -> Option<ApqInfo> {
+        ApqInfo::from_extensions(self.t_group.extensions()).ok()?
+    }
+}
+
+impl ApqMlsGroupMut<'_> {
+    /// Get the APQMLS component from the group, if it exists.
+    pub fn apq_info(&self) -> Option<ApqInfo> {
+        ApqInfo::from_extensions(self.t_group.extensions()).ok()?
+    }
+}

--- a/apqmls/src/group_builder.rs
+++ b/apqmls/src/group_builder.rs
@@ -281,8 +281,8 @@ fn ensure_group_context_component_support<StorageError>(
         .unwrap_or_default()
         .pipe(ensure_component_support)?;
     let mut dictionary = dictionary;
-    let (compoent_id, data) = apq_info.into_parts();
-    dictionary.insert(compoent_id, data.into());
+    let (component_id, data) = apq_info.into_parts();
+    dictionary.insert(component_id, data.into());
     extensions.add_or_replace(Extension::AppDataDictionary(
         AppDataDictionaryExtension::new(dictionary),
     ))?;

--- a/apqmls/src/group_builder.rs
+++ b/apqmls/src/group_builder.rs
@@ -1,0 +1,319 @@
+// SPDX-FileCopyrightText: 2025 Phoenix R&D GmbH <hello@phnx.im>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+use openmls::{
+    component::ComponentData,
+    group::{
+        GroupContext, GroupEpoch, GroupId, MlsGroupBuilder, NewGroupError as OpenMlsNewGroupError,
+        WireFormatPolicy,
+    },
+    prelude::{
+        AppDataDictionaryExtension, Capabilities, Extension, ExtensionType, Extensions,
+        InvalidExtensionError, LeafNode, Lifetime, ProposalType, RequiredCapabilitiesExtension,
+        SenderRatchetConfiguration,
+    },
+    storage::OpenMlsProvider,
+    treesync::errors::LeafNodeValidationError,
+};
+use tap::Pipe as _;
+use thiserror::Error;
+
+use crate::{
+    ApqCiphersuite, ApqGroupId, ApqMlsGroup,
+    authentication::{ApqCredentialWithKey, ApqSigner},
+    extension::{ApqInfo, PqtMode, ensure_component_support, ensure_extension_support},
+    key_package::ensure_ciphersuite_support,
+};
+
+/// Errors that can occur when creating a new [`ApqMlsGroup`].
+#[derive(Error, Debug)]
+pub enum NewGroupError<StorageError> {
+    #[error(transparent)]
+    NewGroup(#[from] OpenMlsNewGroupError<StorageError>),
+    #[error("Error serializing APQInfo extension: {0}")]
+    InvalidExtension(#[from] tls_codec::Error),
+}
+
+impl<StorageError> From<InvalidExtensionError> for NewGroupError<StorageError> {
+    fn from(err: InvalidExtensionError) -> Self {
+        OpenMlsNewGroupError::InvalidExtensions(err).into()
+    }
+}
+
+/// A builder for creating a new [`ApqMlsGroup`].
+#[derive(Debug, Default)]
+pub struct GroupBuilder {
+    t_group_builder: MlsGroupBuilder,
+    pq_group_builder: MlsGroupBuilder,
+    // We keep track of the values below so we can do some post-processing
+    // later.
+    group_ids: Option<ApqGroupId>,
+    mode: PqtMode,
+    ciphersuite: Option<ApqCiphersuite>,
+    capabilities: Capabilities,
+    t_extensions: Extensions<GroupContext>,
+    pq_extensions: Extensions<GroupContext>,
+}
+
+impl GroupBuilder {
+    pub(super) fn new() -> Self {
+        Self::default()
+    }
+
+    /// Sets the [`PqtMode`] mode of the [`ApqMlsGroup`].
+    pub fn set_mode(mut self, mode: PqtMode) -> Self {
+        self.mode = mode;
+        self
+    }
+
+    /// Overrides the ciphersuite used for both groups. If not set, the default
+    /// ciphersuite for the configured [`PqtMode`] is used.
+    pub fn with_ciphersuite(mut self, ciphersuite: ApqCiphersuite) -> Self {
+        self.ciphersuite = Some(ciphersuite);
+        self
+    }
+
+    /// Sets the group ID of the [`ApqMlsGroup`].
+    pub fn with_group_ids(mut self, t_group_id: GroupId, pq_group_id: GroupId) -> Self {
+        self.t_group_builder = self.t_group_builder.with_group_id(t_group_id.clone());
+        self.pq_group_builder = self.pq_group_builder.with_group_id(pq_group_id.clone());
+        self.group_ids = Some(ApqGroupId {
+            t_group_id,
+            pq_group_id,
+        });
+        self
+    }
+
+    /// Build a new group as configured by this builder.
+    pub fn build<Provider: OpenMlsProvider>(
+        mut self,
+        provider: &Provider,
+        signer: &impl ApqSigner,
+        credential_with_key: ApqCredentialWithKey,
+    ) -> Result<ApqMlsGroup, NewGroupError<Provider::StorageError>> {
+        let ciphersuite = self.ciphersuite.unwrap_or_else(|| match self.mode {
+            PqtMode::ConfOnly => ApqCiphersuite::default_pq_conf(),
+            PqtMode::ConfAndAuth => ApqCiphersuite::default_pq_conf_and_auth(),
+        });
+
+        // Add extension to capabilities.
+        let capabilities = self
+            .capabilities
+            .pipe(ensure_extension_support)?
+            .pipe(|c| ensure_ciphersuite_support(c, ciphersuite))?;
+
+        // Add extension to extensions
+        let apq_group_id = self
+            .group_ids
+            .unwrap_or_else(|| ApqGroupId::random(provider.rand()));
+
+        // Add required capabilities extension
+        let t_rc = merged_required_capabilities(self.t_extensions.required_capabilities())
+            .pipe(Extension::RequiredCapabilities);
+        let pq_rc = merged_required_capabilities(self.pq_extensions.required_capabilities())
+            .pipe(Extension::RequiredCapabilities);
+
+        self.t_extensions.add_or_replace(t_rc)?;
+        self.pq_extensions.add_or_replace(pq_rc)?;
+
+        let info = ApqInfo {
+            t_session_group_id: apq_group_id.t_group_id.clone(),
+            pq_session_group_id: apq_group_id.pq_group_id.clone(),
+            mode: self.mode,
+            t_cipher_suite: ciphersuite.t_ciphersuite,
+            pq_cipher_suite: ciphersuite.pq_ciphersuite,
+            t_epoch: GroupEpoch::from(0),
+            pq_epoch: GroupEpoch::from(0),
+        };
+
+        let info_component = info.to_component_data()?;
+        ensure_group_context_component_support(&mut self.t_extensions, info_component.clone())?;
+        ensure_group_context_component_support(&mut self.pq_extensions, info_component)?;
+
+        let t_group = self
+            .t_group_builder
+            .ciphersuite(ciphersuite.t_ciphersuite)
+            .with_group_context_extensions(self.t_extensions)
+            .with_group_id(apq_group_id.t_group_id.clone())
+            .with_capabilities(capabilities.clone())
+            .build(
+                provider,
+                signer.t_signer(),
+                credential_with_key.t_credential,
+            )?;
+        let pq_group = self
+            .pq_group_builder
+            .ciphersuite(ciphersuite.pq_ciphersuite)
+            .with_group_context_extensions(self.pq_extensions)
+            .with_group_id(apq_group_id.pq_group_id.clone())
+            .with_capabilities(capabilities)
+            .build(
+                provider,
+                signer.pq_signer(),
+                credential_with_key.pq_credential,
+            )?;
+
+        Ok(ApqMlsGroup { pq_group, t_group })
+    }
+
+    // Builder options
+
+    /// Sets the `wire_format` property of the ApqMlsGroup.
+    pub fn with_wire_format_policy(mut self, wire_format_policy: WireFormatPolicy) -> Self {
+        self.t_group_builder = self
+            .t_group_builder
+            .with_wire_format_policy(wire_format_policy);
+        self.pq_group_builder = self
+            .pq_group_builder
+            .with_wire_format_policy(wire_format_policy);
+        self
+    }
+
+    /// Sets the `padding_size` property of the ApqMlsGroup.
+    pub fn padding_size(mut self, padding_size: usize) -> Self {
+        self.t_group_builder = self.t_group_builder.padding_size(padding_size);
+        self.pq_group_builder = self.pq_group_builder.padding_size(padding_size);
+        self
+    }
+
+    /// Sets the `max_past_epochs` property of the traditional MlsGroup.
+    /// This allows application messages from previous epochs to be decrypted.
+    ///
+    /// **WARNING**
+    ///
+    /// This feature enables the storage of message secrets from past epochs.
+    /// It is a trade-off between functionality and forward secrecy and should only be enabled
+    /// if the Delivery Service cannot guarantee that application messages will be sent in
+    /// the same epoch in which they were generated. The number for `max_epochs` should be
+    /// as low as possible.
+    pub fn max_past_epochs(mut self, max_past_epochs: usize) -> Self {
+        self.t_group_builder = self.t_group_builder.max_past_epochs(max_past_epochs);
+        // pq group is not used for application messages, so we don't set it there
+        self
+    }
+
+    /// Sets the `number_of_resumption_psks` property of the ApqMlsGroup.
+    pub fn number_of_resumption_psks(mut self, number_of_resumption_psks: usize) -> Self {
+        self.t_group_builder = self
+            .t_group_builder
+            .number_of_resumption_psks(number_of_resumption_psks);
+        self.pq_group_builder = self
+            .pq_group_builder
+            .number_of_resumption_psks(number_of_resumption_psks);
+        self
+    }
+
+    /// Sets the `use_ratchet_tree_extension` property of the MlsGroup.
+    pub fn use_ratchet_tree_extension(mut self, use_ratchet_tree_extension: bool) -> Self {
+        self.t_group_builder = self
+            .t_group_builder
+            .use_ratchet_tree_extension(use_ratchet_tree_extension);
+        self.pq_group_builder = self
+            .pq_group_builder
+            .use_ratchet_tree_extension(use_ratchet_tree_extension);
+        self
+    }
+
+    /// Sets the `sender_ratchet_configuration` property of the traditional
+    /// MlsGroup. See [`SenderRatchetConfiguration`] for more information.
+    pub fn sender_ratchet_configuration(
+        mut self,
+        sender_ratchet_configuration: SenderRatchetConfiguration,
+    ) -> Self {
+        self.t_group_builder = self
+            .t_group_builder
+            .sender_ratchet_configuration(sender_ratchet_configuration);
+        // pq group does not use application messages, so we don't set the
+        // configuration there
+        self
+    }
+
+    /// Sets the `lifetime` of the group creator's leaf.
+    pub fn lifetime(mut self, lifetime: Lifetime) -> Self {
+        self.t_group_builder = self.t_group_builder.lifetime(lifetime);
+        self.pq_group_builder = self.pq_group_builder.lifetime(lifetime);
+        self
+    }
+
+    /// Sets the initial group context extensions
+    pub fn with_group_context_extensions(
+        mut self,
+        t_extensions: Extensions<GroupContext>,
+        pq_extensions: Extensions<GroupContext>,
+    ) -> Result<Self, InvalidExtensionError> {
+        self.t_extensions = t_extensions;
+        self.pq_extensions = pq_extensions;
+        // We set the extensions for both groups in `build`.
+        Ok(self)
+    }
+
+    /// Sets the initial leaf node extensions
+    pub fn with_leaf_node_extensions(
+        mut self,
+        t_extensions: Extensions<LeafNode>,
+        pq_extensions: Extensions<LeafNode>,
+    ) -> Result<Self, LeafNodeValidationError> {
+        self.t_group_builder = self
+            .t_group_builder
+            .with_leaf_node_extensions(t_extensions)?;
+        self.pq_group_builder = self
+            .pq_group_builder
+            .with_leaf_node_extensions(pq_extensions)?;
+        Ok(self)
+    }
+
+    /// Sets the group creator's [`Capabilities`]
+    pub fn with_capabilities(mut self, capabilities: Capabilities) -> Self {
+        self.capabilities = capabilities.clone();
+        // We set the capabilities for both groups in `build`.
+        self
+    }
+}
+
+fn ensure_group_context_component_support<StorageError>(
+    extensions: &mut Extensions<GroupContext>,
+    apq_info: ComponentData,
+) -> Result<(), NewGroupError<StorageError>> {
+    let dictionary = extensions
+        .app_data_dictionary()
+        .map(|extension| extension.dictionary().clone())
+        .unwrap_or_default()
+        .pipe(ensure_component_support)?;
+    let mut dictionary = dictionary;
+    let (compoent_id, data) = apq_info.into_parts();
+    dictionary.insert(compoent_id, data.into());
+    extensions.add_or_replace(Extension::AppDataDictionary(
+        AppDataDictionaryExtension::new(dictionary),
+    ))?;
+    Ok(())
+}
+
+fn merged_required_capabilities(
+    existing: Option<&RequiredCapabilitiesExtension>,
+) -> RequiredCapabilitiesExtension {
+    let mut extension_types = vec![
+        ExtensionType::RequiredCapabilities,
+        ExtensionType::AppDataDictionary,
+    ];
+    let mut proposal_types = vec![ProposalType::AppDataUpdate];
+    let mut credential_types = vec![];
+    if let Some(rq) = existing {
+        for &et in rq.extension_types() {
+            if !extension_types.contains(&et) {
+                extension_types.push(et);
+            }
+        }
+        for &pt in rq.proposal_types() {
+            if !proposal_types.contains(&pt) {
+                proposal_types.push(pt);
+            }
+        }
+        for &ct in rq.credential_types() {
+            if !credential_types.contains(&ct) {
+                credential_types.push(ct);
+            }
+        }
+    }
+    RequiredCapabilitiesExtension::new(&extension_types, &proposal_types, &credential_types)
+}

--- a/apqmls/src/key_package.rs
+++ b/apqmls/src/key_package.rs
@@ -1,0 +1,201 @@
+// SPDX-FileCopyrightText: 2025 Phoenix R&D GmbH <hello@phnx.im>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+use std::collections::HashSet;
+
+use openmls::{
+    prelude::{
+        Capabilities, Ciphersuite, Extensions, KeyPackage, KeyPackageBuilder, KeyPackageBundle,
+        KeyPackageNewError as OpenMlsKeyPackageNewError, KeyPackageVerifyError, LeafNode, Lifetime,
+        OpenMlsCrypto, ProtocolVersion,
+    },
+    storage::OpenMlsProvider,
+};
+use serde::{Deserialize, Serialize};
+use tap::Pipe as _;
+use thiserror::Error;
+
+use crate::{
+    ApqCiphersuite,
+    authentication::{ApqCredentialWithKey, ApqSigner},
+    extension::{ensure_extension_support, ensure_leaf_node_component_support},
+    messages::{ApqKeyPackage, ApqKeyPackageIn},
+};
+
+/// Errors that can occur when creating a new [`ApqKeyPackage`].
+#[derive(Error, Debug)]
+pub enum KeyPackageNewError {
+    #[error(transparent)]
+    OpenMls(#[from] OpenMlsKeyPackageNewError),
+    #[error("Unsupported ciphersuite")]
+    UnsupportedCiphersuite(#[from] tls_codec::Error),
+}
+
+/// A builder for creating a new [`ApqKeyPackage`].
+pub struct ApqKeyPackageBuilder {
+    capabilities: Capabilities,
+    t_kp_builder: KeyPackageBuilder,
+    pq_kp_builder: KeyPackageBuilder,
+    key_package_extensions: Extensions<KeyPackage>,
+    leaf_node_extensions: Extensions<LeafNode>,
+}
+
+/// A bundle consisting of an [`ApqKeyPackage`] and its corresponding
+/// private keys.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ApqKeyPackageBundle {
+    t_kp_bundle: KeyPackageBundle,
+    pq_kp_bundle: KeyPackageBundle,
+}
+
+impl ApqKeyPackageBundle {
+    pub fn into_key_package(self) -> ApqKeyPackage {
+        ApqKeyPackage {
+            t_key_package: self.t_kp_bundle.key_package().clone(),
+            pq_key_package: self.pq_kp_bundle.key_package().clone(),
+        }
+    }
+}
+
+impl Default for ApqKeyPackageBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ApqKeyPackageBuilder {
+    /// Create a key package builder.
+    pub fn new() -> Self {
+        Self {
+            capabilities: Capabilities::default(),
+            t_kp_builder: KeyPackageBuilder::new(),
+            pq_kp_builder: KeyPackageBuilder::new(),
+            key_package_extensions: Extensions::default(),
+            leaf_node_extensions: Extensions::default(),
+        }
+    }
+
+    /// Set the key package lifetime.
+    pub fn key_package_lifetime(mut self, lifetime: Lifetime) -> Self {
+        self.t_kp_builder = self.t_kp_builder.key_package_lifetime(lifetime);
+        self.pq_kp_builder = self.pq_kp_builder.key_package_lifetime(lifetime);
+        self
+    }
+
+    /// Set the key package extensions.
+    pub fn key_package_extensions(mut self, extensions: Extensions<KeyPackage>) -> Self {
+        self.key_package_extensions = extensions;
+        self
+    }
+
+    /// Mark the key package as a last-resort key package via a
+    /// [`openmls::extensions::LastResortExtension`].
+    pub fn mark_as_last_resort(mut self) -> Self {
+        self.t_kp_builder = self.t_kp_builder.mark_as_last_resort();
+        self.pq_kp_builder = self.pq_kp_builder.mark_as_last_resort();
+        self
+    }
+
+    /// Set the leaf node capabilities.
+    pub fn leaf_node_capabilities(mut self, capabilities: Capabilities) -> Self {
+        self.capabilities = capabilities;
+        // The capabilities are set in `build`, so we don't set them here.
+        self
+    }
+
+    /// Set the leaf node extensions.
+    pub fn leaf_node_extensions(mut self, extensions: Extensions<LeafNode>) -> Self {
+        self.leaf_node_extensions = extensions;
+        self
+    }
+
+    /// Finalize and build the key package.
+    pub fn build(
+        mut self,
+        provider: &impl OpenMlsProvider,
+        ciphersuite: ApqCiphersuite,
+        signer: &impl ApqSigner,
+        credential_with_key: ApqCredentialWithKey,
+    ) -> Result<ApqKeyPackageBundle, KeyPackageNewError> {
+        let capabilities = self
+            .capabilities
+            .pipe(ensure_extension_support)?
+            .pipe(|c| ensure_ciphersuite_support(c, ciphersuite))?;
+
+        let ln_extensions = self
+            .leaf_node_extensions
+            .pipe(ensure_leaf_node_component_support)?;
+        let pk_extensions = self.key_package_extensions;
+
+        self.t_kp_builder = self
+            .t_kp_builder
+            .leaf_node_capabilities(capabilities.clone())
+            .leaf_node_extensions(ln_extensions.clone())
+            .key_package_extensions(pk_extensions.clone());
+        self.pq_kp_builder = self
+            .pq_kp_builder
+            .leaf_node_capabilities(capabilities)
+            .leaf_node_extensions(ln_extensions)
+            .key_package_extensions(pk_extensions);
+        let t_kp_bundle = self.t_kp_builder.build(
+            ciphersuite.t_ciphersuite,
+            provider,
+            signer.t_signer(),
+            credential_with_key.t_credential,
+        )?;
+        let pq_kp_bundle = self.pq_kp_builder.build(
+            ciphersuite.pq_ciphersuite,
+            provider,
+            signer.pq_signer(),
+            credential_with_key.pq_credential,
+        )?;
+        Ok(ApqKeyPackageBundle {
+            t_kp_bundle,
+            pq_kp_bundle,
+        })
+    }
+}
+
+impl ApqKeyPackage {
+    pub fn builder() -> ApqKeyPackageBuilder {
+        ApqKeyPackageBuilder::new()
+    }
+}
+
+impl ApqKeyPackageIn {
+    pub fn validate(
+        self,
+        crypto: &impl OpenMlsCrypto,
+    ) -> Result<ApqKeyPackage, KeyPackageVerifyError> {
+        let protocol_version = ProtocolVersion::default();
+        let t_key_package = self.t_key_package.validate(crypto, protocol_version)?;
+        let pq_key_package = self.pq_key_package.validate(crypto, protocol_version)?;
+        Ok(ApqKeyPackage {
+            t_key_package,
+            pq_key_package,
+        })
+    }
+}
+
+pub(super) fn ensure_ciphersuite_support(
+    capabilities: Capabilities,
+    ciphersuite: ApqCiphersuite,
+) -> Result<Capabilities, tls_codec::Error> {
+    let mut ciphersuites: HashSet<Ciphersuite> = capabilities
+        .ciphersuites()
+        .iter()
+        .map(|&cs| cs.try_into())
+        .collect::<Result<_, _>>()?;
+    ciphersuites.insert(ciphersuite.t_ciphersuite);
+    ciphersuites.insert(ciphersuite.pq_ciphersuite);
+    let ciphersuites: Vec<Ciphersuite> = ciphersuites.into_iter().collect();
+    Capabilities::new(
+        Some(capabilities.versions()),
+        Some(&ciphersuites),
+        Some(capabilities.extensions()),
+        Some(capabilities.proposals()),
+        Some(capabilities.credentials()),
+    )
+    .pipe(Ok)
+}

--- a/apqmls/src/lib.rs
+++ b/apqmls/src/lib.rs
@@ -1,0 +1,209 @@
+// SPDX-FileCopyrightText: 2025 Phoenix R&D GmbH <hello@phnx.im>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! # APQMLS
+//!
+//! This crate provides an implementation of
+//! [APQMLS](https://datatracker.ietf.org/doc/draft-ietf-mls-combiner/), a
+//! mechanism that combines two MLS groups, one with a traditional ciphersuite
+//! and one with a post-quantum ciphersuite. An [APQMLS group](ApqMlsGroup)
+//! provides PQ security and "full" updates, as well as updates to group
+//! membership provide PQ FS and PCS. In addition, the traditional group can be
+//! used independently, except for membership updates, e.g. Independent use of
+//! the traditional group, for example, allows for cheaper non-PQ PCS updates.
+//!
+//! A APQMLS group can be run in one of two modes: "confidentiality and
+//! authentication" mode, where the post-quantum ciphersuite provides both both
+//! PQ confidentiality and PQ authentication, and "confidentiality-only" mode,
+//! where the post-quantum ciphersuite only provides PQ confidentiality with
+//! traditional authentication.
+
+use openmls::{
+    group::{GroupEpoch, GroupId, MlsGroup},
+    prelude::{Ciphersuite, LeafNodeIndex, OpenMlsRand},
+    storage::StorageProvider,
+};
+use serde::{Deserialize, Serialize};
+use tls_codec::{TlsSerialize, TlsSize};
+
+use crate::{authentication::ApqVerifyingKey, group_builder::GroupBuilder};
+
+pub mod authentication;
+pub mod commit_builder;
+mod export;
+pub mod extension;
+pub mod group_builder;
+pub mod key_package;
+mod merging;
+pub mod messages;
+pub mod processing;
+mod psk;
+pub mod public_group;
+mod secret;
+pub mod welcome;
+
+/// The combined ciphersuite of a [`ApqMlsGroup`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Copy)]
+pub struct ApqCiphersuite {
+    t_ciphersuite: Ciphersuite,
+    pq_ciphersuite: Ciphersuite,
+}
+
+impl ApqCiphersuite {
+    pub const fn new(t_ciphersuite: Ciphersuite, pq_ciphersuite: Ciphersuite) -> Self {
+        Self {
+            t_ciphersuite,
+            pq_ciphersuite,
+        }
+    }
+
+    pub const fn default_pq_conf_and_auth() -> Self {
+        Self {
+            t_ciphersuite: Ciphersuite::MLS_256_DHKEMP384_AES256GCM_SHA384_P384,
+            pq_ciphersuite: Ciphersuite::MLS_256_MLKEM1024_AES256GCM_SHA512_MLDSA87,
+        }
+    }
+
+    pub const fn default_pq_conf() -> Self {
+        Self {
+            t_ciphersuite: Ciphersuite::MLS_256_DHKEMP384_AES256GCM_SHA384_P384,
+            pq_ciphersuite: Ciphersuite::MLS_192_MLKEM1024_AES256GCM_SHA384_P384,
+        }
+    }
+}
+
+/// The group ID of a [`ApqMlsGroup`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TlsSize, TlsSerialize)]
+pub struct ApqGroupId {
+    t_group_id: GroupId,
+    pq_group_id: GroupId,
+}
+
+impl ApqGroupId {
+    pub fn random(rng: &impl OpenMlsRand) -> Self {
+        Self {
+            t_group_id: GroupId::random(rng),
+            pq_group_id: GroupId::random(rng),
+        }
+    }
+
+    pub fn t_group_id(&self) -> &GroupId {
+        &self.t_group_id
+    }
+
+    pub fn pq_group_id(&self) -> &GroupId {
+        &self.pq_group_id
+    }
+}
+
+/// An APQMLS group, consisting of a traditional MLS group and a post-quantum MLS group.
+///
+/// The two groups can be used independently, except for membership updates.
+#[derive(Debug)]
+pub struct ApqMlsGroup {
+    pq_group: MlsGroup,
+    pub t_group: MlsGroup,
+}
+
+/// Same as [`ApqMlsGroup`], but references MLS groups instead of owning them.
+pub struct ApqMlsGroupMut<'a> {
+    t_group: &'a mut MlsGroup,
+    pq_group: &'a mut MlsGroup,
+}
+
+impl<'a> ApqMlsGroupMut<'a> {
+    /// A non-owning version of [`ApqMlsGroupMut::from_groups`].
+    pub fn from_groups(t_group: &'a mut MlsGroup, pq_group: &'a mut MlsGroup) -> Self {
+        Self { t_group, pq_group }
+    }
+}
+
+impl ApqMlsGroup {
+    /// Create a new APQMLS group from the traditional and post-quantum MLS groups.
+    pub fn from_groups(t_group: MlsGroup, pq_group: MlsGroup) -> Self {
+        Self { t_group, pq_group }
+    }
+
+    pub fn as_mut(&mut self) -> ApqMlsGroupMut<'_> {
+        ApqMlsGroupMut::from_groups(&mut self.t_group, &mut self.pq_group)
+    }
+
+    pub fn into_groups(self) -> (MlsGroup, MlsGroup) {
+        (self.t_group, self.pq_group)
+    }
+
+    /// Returns a reference to the post-quantum group.
+    pub fn pq_group(&self) -> &MlsGroup {
+        &self.pq_group
+    }
+
+    /// Build a new APQMLS group.
+    pub fn builder() -> GroupBuilder {
+        GroupBuilder::new()
+    }
+
+    /// Creates a commit builder for the APQMLS group. This builder can be used
+    /// to affect membership changes and issue full updates.
+    pub fn commit_builder(&mut self) -> commit_builder::CommitBuilder<'_> {
+        commit_builder::CommitBuilder::new(self)
+    }
+
+    /// Returns the group ID of the APQMLS group.
+    pub fn group_id(&self) -> ApqGroupId {
+        ApqGroupId {
+            t_group_id: self.t_group.group_id().clone(),
+            pq_group_id: self.pq_group.group_id().clone(),
+        }
+    }
+
+    pub fn ciphersuite(&self) -> ApqCiphersuite {
+        ApqCiphersuite {
+            t_ciphersuite: self.t_group.ciphersuite(),
+            pq_ciphersuite: self.pq_group.ciphersuite(),
+        }
+    }
+
+    /// Returns the current epoch of the traditional group.
+    pub fn t_epoch(&self) -> GroupEpoch {
+        self.t_group.epoch()
+    }
+
+    /// Returns the current epoch of the post-quantum group.
+    pub fn pq_epoch(&self) -> GroupEpoch {
+        self.pq_group.epoch()
+    }
+
+    /// Returns the [`ApqVerifyingKey`] of the member at the given index.
+    pub fn verifying_key_at(&self, index: LeafNodeIndex) -> Option<ApqVerifyingKey> {
+        let t_member = self.t_group.member_at(index)?;
+        let pq_member = self.pq_group.member_at(index)?;
+        Some(ApqVerifyingKey {
+            t_verifying_key: t_member.signature_key.into(),
+            pq_verifying_key: pq_member.signature_key.into(),
+        })
+    }
+
+    /// Load an APQMLS group from storage.
+    pub fn load<Storage: StorageProvider>(
+        provider: &Storage,
+        group_id: &ApqGroupId,
+    ) -> Result<Option<Self>, Storage::Error> {
+        let t_group = MlsGroup::load(provider, &group_id.t_group_id)?;
+        let pq_group = MlsGroup::load(provider, &group_id.pq_group_id)?;
+
+        Ok(t_group
+            .zip(pq_group)
+            .map(|(t_group, pq_group)| Self { pq_group, t_group }))
+    }
+
+    /// Delete the APQMLS group from storage.
+    pub fn delete<Storage: StorageProvider>(
+        &mut self,
+        provider: &Storage,
+    ) -> Result<(), Storage::Error> {
+        self.t_group.delete(provider)?;
+        self.pq_group.delete(provider)?;
+        Ok(())
+    }
+}

--- a/apqmls/src/merging.rs
+++ b/apqmls/src/merging.rs
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: 2025 Phoenix R&D GmbH <hello@phnx.im>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+use openmls::{
+    group::{MergeCommitError, MergePendingCommitError},
+    storage::{OpenMlsProvider, PublicStorageProvider, StorageProvider},
+};
+
+use crate::{ApqMlsGroup, processing::ApqStagedCommit, public_group::ApqPublicGroupMut};
+
+impl ApqMlsGroup {
+    /// Merges the pending [`openmls::group::StagedCommit`] of the traditional group, as well as
+    /// that of the PQ group if there is one.
+    pub fn merge_pending_commit<Provider: OpenMlsProvider>(
+        &mut self,
+        provider: &Provider,
+    ) -> Result<(), MergePendingCommitError<Provider::StorageError>> {
+        self.t_group.merge_pending_commit(provider)?;
+        self.pq_group.merge_pending_commit(provider)?;
+        Ok(())
+    }
+
+    /// Merge a [`openmls::group::StagedCommit`] into the group after inspection. As this advances
+    /// the epoch of the group, it also clears any pending commits.
+    pub fn merge_staged_commit<Provider: OpenMlsProvider>(
+        &mut self,
+        provider: &Provider,
+        staged_commit: ApqStagedCommit,
+    ) -> Result<(), MergeCommitError<Provider::StorageError>> {
+        let ApqStagedCommit {
+            t_staged_commit,
+            pq_staged_commit,
+        } = staged_commit;
+        self.t_group
+            .merge_staged_commit(provider, t_staged_commit)?;
+        self.pq_group
+            .merge_staged_commit(provider, pq_staged_commit)?;
+        Ok(())
+    }
+
+    pub fn clear_pending_commits<Storage: StorageProvider>(
+        &mut self,
+        provider: &Storage,
+    ) -> Result<(), Storage::Error> {
+        self.t_group.clear_pending_commit(provider)?;
+        self.pq_group.clear_pending_commit(provider)?;
+        Ok(())
+    }
+}
+
+impl ApqPublicGroupMut<'_> {
+    /// Merge a [`openmls::group::StagedCommit`] into the public group.
+    pub fn merge_staged_commit<Storage: PublicStorageProvider>(
+        &mut self,
+        storage: &Storage,
+        staged_commit: ApqStagedCommit,
+    ) -> Result<(), MergeCommitError<Storage::Error>> {
+        let ApqStagedCommit {
+            t_staged_commit,
+            pq_staged_commit,
+        } = staged_commit;
+        self.pq_public_group
+            .merge_commit(storage, pq_staged_commit)?;
+        self.t_public_group.merge_commit(storage, t_staged_commit)?;
+        Ok(())
+    }
+}

--- a/apqmls/src/messages.rs
+++ b/apqmls/src/messages.rs
@@ -1,0 +1,328 @@
+// SPDX-FileCopyrightText: 2025 Phoenix R&D GmbH <hello@phnx.im>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+use openmls::{
+    group::GroupEpoch,
+    prelude::{
+        Ciphersuite, Credential, KeyPackage, KeyPackageIn, KeyPackageVerifyError, MlsMessageBodyIn,
+        MlsMessageIn, MlsMessageOut, OpenMlsCrypto, OpenMlsSignaturePublicKey, ProtocolMessage,
+        ProtocolVersion, RatchetTreeIn, SignatureError, Verifiable as _, Welcome,
+        group_info::{GroupInfo, VerifiableGroupInfo},
+    },
+    treesync::RatchetTree,
+};
+use serde::{Deserialize, Serialize};
+use tls_codec::{
+    Deserialize as _, Serialize as _, TlsDeserialize, TlsDeserializeBytes, TlsSerialize, TlsSize,
+};
+
+use crate::{ApqGroupId, authentication::ApqVerifyingKey, extension::PqtMode};
+
+/// An incoming message for processing by an [`crate::ApqMlsGroup`].
+#[derive(Debug, Clone, TlsDeserialize, TlsDeserializeBytes, TlsSize)]
+pub struct ApqMlsMessageIn {
+    pub(crate) t_message: MlsMessageIn,
+    pub(crate) pq_message: MlsMessageIn,
+}
+
+impl ApqMlsMessageIn {
+    pub fn t_message(&self) -> &MlsMessageIn {
+        &self.t_message
+    }
+
+    pub fn pq_message(&self) -> &MlsMessageIn {
+        &self.pq_message
+    }
+
+    pub fn into_welcome(self) -> Option<ApqWelcome> {
+        let MlsMessageBodyIn::Welcome(t_welcome) = self.t_message.extract() else {
+            return None;
+        };
+        let MlsMessageBodyIn::Welcome(pq_welcome) = self.pq_message.extract() else {
+            return None;
+        };
+        Some(ApqWelcome {
+            t_welcome,
+            pq_welcome,
+        })
+    }
+
+    pub fn into_key_package(self) -> Option<ApqKeyPackageIn> {
+        let MlsMessageBodyIn::KeyPackage(t_key_package) = self.t_message.extract() else {
+            return None;
+        };
+        let MlsMessageBodyIn::KeyPackage(pq_key_package) = self.pq_message.extract() else {
+            return None;
+        };
+        Some(ApqKeyPackageIn {
+            t_key_package,
+            pq_key_package,
+        })
+    }
+
+    pub fn into_protocol_message(self) -> Option<ApqProtocolMessage> {
+        let t_protocol_message = self.t_message.try_into_protocol_message().ok()?;
+        let pq_protocol_message = self.pq_message.try_into_protocol_message().ok()?;
+        Some(ApqProtocolMessage {
+            t_protocol_message,
+            pq_protocol_message,
+        })
+    }
+}
+
+pub struct ApqProtocolMessage {
+    pub(crate) t_protocol_message: ProtocolMessage,
+    pub(crate) pq_protocol_message: ProtocolMessage,
+}
+
+impl ApqProtocolMessage {
+    pub fn new(t_protocol_message: ProtocolMessage, pq_protocol_message: ProtocolMessage) -> Self {
+        Self {
+            t_protocol_message,
+            pq_protocol_message,
+        }
+    }
+
+    pub fn group_id(&self) -> ApqGroupId {
+        ApqGroupId {
+            t_group_id: self.t_protocol_message.group_id().clone(),
+            pq_group_id: self.pq_protocol_message.group_id().clone(),
+        }
+    }
+
+    pub fn t_epoch(&self) -> GroupEpoch {
+        self.t_protocol_message.epoch()
+    }
+
+    pub fn pq_epoch(&self) -> GroupEpoch {
+        self.pq_protocol_message.epoch()
+    }
+}
+
+/// An outgoing message from an [`crate::ApqMlsGroup`].
+#[derive(Debug, Clone, TlsSerialize, TlsSize, Serialize, Deserialize)]
+pub struct ApqMlsMessageOut {
+    pub(crate) t_message: MlsMessageOut,
+    pub(crate) pq_message: MlsMessageOut,
+}
+
+impl ApqMlsMessageOut {
+    pub fn split(self) -> (MlsMessageOut, MlsMessageOut) {
+        (self.t_message, self.pq_message)
+    }
+}
+
+impl TryFrom<ApqMlsMessageOut> for ApqMlsMessageIn {
+    type Error = tls_codec::Error;
+
+    fn try_from(value: ApqMlsMessageOut) -> Result<Self, Self::Error> {
+        let serialied_t_message = value.t_message.tls_serialize_detached()?;
+        let serialized_pq_message = value.pq_message.tls_serialize_detached()?;
+        let t_message_in = MlsMessageIn::tls_deserialize_exact(&serialied_t_message)?;
+        let pq_message_in = MlsMessageIn::tls_deserialize_exact(&serialized_pq_message)?;
+        Ok(ApqMlsMessageIn {
+            t_message: t_message_in,
+            pq_message: pq_message_in,
+        })
+    }
+}
+
+/// A welcome message for joining an [`crate::ApqMlsGroup`].
+#[derive(Debug, Clone, TlsSerialize, TlsDeserializeBytes, TlsSize, Serialize, Deserialize)]
+pub struct ApqWelcome {
+    pub(crate) t_welcome: Welcome,
+    pub(crate) pq_welcome: Welcome,
+}
+
+impl ApqWelcome {
+    pub fn new(t_welcome: Welcome, pq_welcome: Welcome) -> Self {
+        Self {
+            t_welcome,
+            pq_welcome,
+        }
+    }
+
+    pub fn split(self) -> (Welcome, Welcome) {
+        let Self {
+            t_welcome,
+            pq_welcome,
+        } = self;
+        (t_welcome, pq_welcome)
+    }
+}
+
+impl From<ApqWelcome> for ApqMlsMessageOut {
+    fn from(value: ApqWelcome) -> Self {
+        ApqMlsMessageOut {
+            t_message: MlsMessageOut::from_welcome(value.t_welcome, ProtocolVersion::default()),
+            pq_message: MlsMessageOut::from_welcome(value.pq_welcome, ProtocolVersion::default()),
+        }
+    }
+}
+
+/// A ratchet tree for an [`crate::ApqMlsGroup`].
+#[derive(Clone)]
+pub struct ApqRatchetTree {
+    pub(crate) t_ratchet_tree: RatchetTree,
+    pub(crate) pq_ratchet_tree: RatchetTree,
+}
+
+impl From<ApqRatchetTree> for ApqRatchetTreeIn {
+    fn from(value: ApqRatchetTree) -> Self {
+        ApqRatchetTreeIn {
+            t_ratchet_tree: value.t_ratchet_tree.into(),
+            pq_ratchet_tree: value.pq_ratchet_tree.into(),
+        }
+    }
+}
+
+/// An unverified ratchet tree for an [`crate::ApqMlsGroup`].
+pub struct ApqRatchetTreeIn {
+    pub(crate) t_ratchet_tree: RatchetTreeIn,
+    pub(crate) pq_ratchet_tree: RatchetTreeIn,
+}
+
+impl ApqRatchetTreeIn {
+    pub fn new(t_ratchet_tree: RatchetTreeIn, pq_ratchet_tree: RatchetTreeIn) -> Self {
+        Self {
+            t_ratchet_tree,
+            pq_ratchet_tree,
+        }
+    }
+
+    pub fn split(self) -> (RatchetTreeIn, RatchetTreeIn) {
+        (self.t_ratchet_tree, self.pq_ratchet_tree)
+    }
+}
+
+/// A key package to add members to an [`crate::ApqMlsGroup`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ApqKeyPackage {
+    pub(crate) t_key_package: KeyPackage,
+    pub(crate) pq_key_package: KeyPackage,
+}
+
+impl ApqKeyPackage {
+    pub fn new(t_key_package: KeyPackage, pq_key_package: KeyPackage) -> Self {
+        Self {
+            t_key_package,
+            pq_key_package,
+        }
+    }
+
+    pub fn t_key_package(&self) -> &KeyPackage {
+        &self.t_key_package
+    }
+
+    pub fn pq_key_package(&self) -> &KeyPackage {
+        &self.pq_key_package
+    }
+
+    pub fn mode(&self) -> PqtMode {
+        match self.pq_key_package.ciphersuite() {
+            Ciphersuite::MLS_256_MLKEM1024_AES256GCM_SHA512_MLDSA87
+            | Ciphersuite::MLS_256_MLKEM1024_AES256GCM_SHA384_MLDSA87
+            | Ciphersuite::MLS_192_MLKEM768_AES256GCM_SHA384_MLDSA65 => PqtMode::ConfAndAuth,
+            _ => PqtMode::ConfOnly,
+        }
+    }
+
+    /// Returns the credential of the T [`KeyPackage`].
+    pub fn t_credential(&self) -> &Credential {
+        self.t_key_package.leaf_node().credential()
+    }
+
+    /// Returns the credential of the PQ [`KeyPackage`].
+    pub fn pq_credential(&self) -> &Credential {
+        self.pq_key_package.leaf_node().credential()
+    }
+}
+
+impl From<ApqKeyPackage> for ApqMlsMessageOut {
+    fn from(value: ApqKeyPackage) -> Self {
+        ApqMlsMessageOut {
+            t_message: MlsMessageOut::from(value.t_key_package),
+            pq_message: MlsMessageOut::from(value.pq_key_package),
+        }
+    }
+}
+
+/// An unverified key package for adding members to an [`crate::ApqMlsGroup`].
+pub struct ApqKeyPackageIn {
+    pub(crate) t_key_package: KeyPackageIn,
+    pub(crate) pq_key_package: KeyPackageIn,
+}
+
+impl ApqKeyPackageIn {
+    pub fn new(t_key_package: KeyPackageIn, pq_key_package: KeyPackageIn) -> Self {
+        Self {
+            t_key_package,
+            pq_key_package,
+        }
+    }
+
+    pub fn unwrap_verified(self) -> Result<ApqKeyPackage, KeyPackageVerifyError> {
+        Ok(ApqKeyPackage {
+            t_key_package: self.t_key_package.into_unchecked()?,
+            pq_key_package: self.pq_key_package.into_unchecked()?,
+        })
+    }
+}
+
+/// The group info of an [`crate::ApqMlsGroup`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ApqGroupInfo {
+    pub(crate) t_group_info: GroupInfo,
+    pub(crate) pq_group_info: GroupInfo,
+}
+
+impl ApqGroupInfo {
+    pub fn new(t_group_info: GroupInfo, pq_group_info: GroupInfo) -> Self {
+        Self {
+            t_group_info,
+            pq_group_info,
+        }
+    }
+
+    pub fn into_parts(self) -> (GroupInfo, GroupInfo) {
+        (self.t_group_info, self.pq_group_info)
+    }
+}
+
+impl From<ApqGroupInfo> for ApqMlsMessageOut {
+    fn from(value: ApqGroupInfo) -> Self {
+        ApqMlsMessageOut {
+            t_message: MlsMessageOut::from(value.t_group_info),
+            pq_message: MlsMessageOut::from(value.pq_group_info),
+        }
+    }
+}
+
+/// A verifiable group info for an [`crate::ApqMlsGroup`].
+pub struct VerifiableApqGroupInfo {
+    pub(crate) t_group_info: VerifiableGroupInfo,
+    pub(crate) pq_group_info: VerifiableGroupInfo,
+}
+
+impl VerifiableApqGroupInfo {
+    /// Verifies the group info and returns the contained [`ApqGroupInfo`].
+    pub fn verify(
+        self,
+        provider: &impl OpenMlsCrypto,
+        verifying_key: &ApqVerifyingKey,
+    ) -> Result<ApqGroupInfo, SignatureError> {
+        let t_verifying_key = OpenMlsSignaturePublicKey::from_signature_key(
+            verifying_key.t_verifying_key.clone(),
+            self.t_group_info.ciphersuite().signature_algorithm(),
+        );
+        let pq_verifying_key = OpenMlsSignaturePublicKey::from_signature_key(
+            verifying_key.pq_verifying_key.clone(),
+            self.pq_group_info.ciphersuite().signature_algorithm(),
+        );
+        Ok(ApqGroupInfo {
+            t_group_info: self.t_group_info.verify(provider, &t_verifying_key)?,
+            pq_group_info: self.pq_group_info.verify(provider, &pq_verifying_key)?,
+        })
+    }
+}

--- a/apqmls/src/processing.rs
+++ b/apqmls/src/processing.rs
@@ -1,0 +1,564 @@
+// SPDX-FileCopyrightText: 2025 Phoenix R&D GmbH <hello@phnx.im>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+use std::fmt::Debug;
+
+use openmls::{
+    component::ComponentData,
+    group::{
+        AppDataUpdates, GroupEpoch, GroupId, MlsGroup, ProcessMessageError, PublicGroup,
+        PublicProcessMessageError, StagedCommit,
+    },
+    prelude::{
+        AppDataUpdateOperation, Ciphersuite, Credential, LeafNodeIndex, OpenMlsCrypto,
+        ProcessedMessage, ProcessedMessageContent, Proposal, ProposalIn, ProposalOrRefIn,
+        ProposalType, Sender, UnverifiedMessage,
+    },
+    schedule::{PreSharedKeyId, Psk, psk::ApplicationPsk},
+    storage::OpenMlsProvider,
+};
+use thiserror::Error;
+
+use crate::{
+    ApqMlsGroup, ApqMlsGroupMut,
+    extension::{APQMLS_COMPONENT_ID, ApqInfo},
+    messages::ApqProtocolMessage,
+    psk::{ApqPskError, store_psk},
+    public_group::ApqPublicGroupMut,
+    secret::Secret,
+};
+
+/// A bundle consisting of the processed messages of both the traditional and the PQ group.
+pub struct ApqProcessedMessage {
+    pub t_message: ProcessedMessage,
+    pub pq_message: ProcessedMessage,
+}
+
+/// A bundle consisting of the staged commits of both the traditional and the
+/// PQ group.
+pub struct ApqStagedCommit {
+    pub t_staged_commit: StagedCommit,
+    pub pq_staged_commit: StagedCommit,
+}
+
+impl ApqProcessedMessage {
+    pub fn into_staged_commit(self) -> Option<ApqStagedCommit> {
+        let t_staged_commit = match self.t_message.into_content() {
+            ProcessedMessageContent::StagedCommitMessage(staged_commit) => *staged_commit,
+            _ => return None,
+        };
+        let pq_staged_commit = match self.pq_message.into_content() {
+            ProcessedMessageContent::StagedCommitMessage(staged_commit) => *staged_commit,
+            _ => return None,
+        };
+        Some(ApqStagedCommit {
+            t_staged_commit,
+            pq_staged_commit,
+        })
+    }
+}
+
+/// Errors that can occur when processing a message with an [`ApqMlsGroup`].
+#[derive(Debug, Error)]
+pub enum ApqProcessMessageError<StorageError> {
+    #[error("Failed to process message: {0}")]
+    Processing(#[from] ProcessMessageError<StorageError>),
+    #[error(transparent)]
+    Psk(#[from] ApqPskError<StorageError>),
+    #[error(transparent)]
+    Validation(#[from] ApqProcessMessageValidationError),
+}
+
+#[derive(Debug, Error, PartialEq, Clone)]
+pub enum ApqProcessPublicMessageError {
+    #[error(transparent)]
+    Processing(#[from] PublicProcessMessageError),
+    #[error(transparent)]
+    Validation(#[from] ApqProcessMessageValidationError),
+}
+
+#[derive(Debug, Error, PartialEq, Eq, Clone, Copy)]
+pub enum ApqProcessMessageValidationError {
+    #[error("The message type is invalid for processing.")]
+    InvalidMessageType,
+    #[error("The MLS messages don't match.")]
+    MismatchedMessages,
+    #[error("APQInfo extension is missing or invalid in commit message.")]
+    MissingApqInfo,
+    #[error("APQInfo extension content is invalid.")]
+    InvalidApqInfo,
+}
+
+#[derive(Eq)]
+enum MessageType<F: Fn(&Credential, &Credential) -> bool> {
+    Proposal(ProposalContent<F>),
+    Commit(CommitContent<F>),
+}
+
+impl<F: Fn(&Credential, &Credential) -> bool> Debug for MessageType<F> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            MessageType::Proposal(proposal) => f
+                .debug_struct("Proposal")
+                .field("proposal_type", &proposal.proposal_type)
+                .field("credential", &proposal.credential)
+                .field("leaf_index", &proposal.leaf_index)
+                .finish(),
+            MessageType::Commit(commit) => f
+                .debug_struct("Commit")
+                .field("adds", &commit.adds)
+                .field("removes", &commit.removes)
+                .field("updates", &commit.updates)
+                .finish(),
+        }
+    }
+}
+
+impl<F: Fn(&Credential, &Credential) -> bool> MessageType<F> {
+    fn new(processed_message: &ProcessedMessageContent, compare: F) -> Option<Self> {
+        match processed_message {
+            ProcessedMessageContent::ApplicationMessage(_) => None,
+            ProcessedMessageContent::ProposalMessage(queued_proposal) => {
+                let proposal = queued_proposal.proposal();
+                let proposal_type = proposal.proposal_type();
+                let (credential, leaf_index) = match proposal {
+                    Proposal::Add(add_proposal) => (
+                        Some(add_proposal.key_package().leaf_node().credential().clone()),
+                        None,
+                    ),
+                    Proposal::Update(update_proposal) => {
+                        (Some(update_proposal.leaf_node().credential().clone()), None)
+                    }
+                    Proposal::Remove(remove_proposal) => (None, Some(remove_proposal.removed())),
+                    _ => (None, None),
+                };
+                Some(MessageType::Proposal(ProposalContent {
+                    proposal_type,
+                    credential,
+                    leaf_index,
+                    compare,
+                }))
+            }
+            ProcessedMessageContent::ExternalJoinProposalMessage(queued_proposal) => {
+                let proposal = queued_proposal.proposal();
+                let proposal_type = proposal.proposal_type();
+                let credential = if let Proposal::Add(add_proposal) = proposal {
+                    Some(add_proposal.key_package().leaf_node().credential().clone())
+                } else {
+                    None
+                };
+                Some(MessageType::Proposal(ProposalContent {
+                    proposal_type,
+                    credential,
+                    leaf_index: None,
+                    compare,
+                }))
+            }
+            ProcessedMessageContent::StagedCommitMessage(staged_commit) => {
+                let adds = staged_commit
+                    .add_proposals()
+                    .map(|p| {
+                        p.add_proposal()
+                            .key_package()
+                            .leaf_node()
+                            .credential()
+                            .clone()
+                    })
+                    .collect();
+                let removes = staged_commit
+                    .remove_proposals()
+                    .map(|p| p.remove_proposal().removed())
+                    .collect();
+                let updates = staged_commit
+                    .update_proposals()
+                    .map(|p| p.update_proposal().leaf_node().credential().clone())
+                    .collect();
+                let path_credential = staged_commit
+                    .update_path_leaf_node()
+                    .map(|node| node.credential().clone());
+                Some(MessageType::Commit(CommitContent {
+                    path_credential,
+                    adds,
+                    removes,
+                    updates,
+                    compare,
+                }))
+            }
+        }
+    }
+}
+
+#[derive(Debug, Eq)]
+struct ProposalContent<F: Fn(&Credential, &Credential) -> bool> {
+    proposal_type: ProposalType,
+    credential: Option<Credential>,
+    leaf_index: Option<LeafNodeIndex>,
+    compare: F,
+}
+
+impl<F: Fn(&Credential, &Credential) -> bool> PartialEq for ProposalContent<F> {
+    fn eq(&self, other: &Self) -> bool {
+        let same_credential = match (&self.credential, &other.credential) {
+            (Some(a), Some(b)) => (self.compare)(a, b),
+            (None, None) => true,
+            _ => false,
+        };
+        self.proposal_type == other.proposal_type
+            && self.leaf_index == other.leaf_index
+            && same_credential
+    }
+}
+
+impl<F: Fn(&Credential, &Credential) -> bool> PartialEq for MessageType<F> {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (MessageType::Proposal(a), MessageType::Proposal(b)) => a == b,
+            (MessageType::Commit(a), MessageType::Commit(b)) => a == b,
+            _ => false,
+        }
+    }
+}
+
+#[derive(Debug, Eq)]
+struct CommitContent<F: Fn(&Credential, &Credential) -> bool> {
+    path_credential: Option<Credential>,
+    adds: Vec<Credential>,
+    removes: Vec<LeafNodeIndex>,
+    updates: Vec<Credential>,
+    compare: F,
+}
+
+impl<F: Fn(&Credential, &Credential) -> bool> PartialEq for CommitContent<F> {
+    fn eq(&self, other: &Self) -> bool {
+        let same_path_credential = match (&self.path_credential, &other.path_credential) {
+            (Some(a), Some(b)) => (self.compare)(a, b),
+            (None, None) => true,
+            _ => false,
+        };
+        same_path_credential
+            && self.removes == other.removes
+            && self.adds.len() == other.adds.len()
+            && self.updates.len() == other.updates.len()
+            && self
+                .adds
+                .iter()
+                .zip(&other.adds)
+                .all(|(a, b)| (self.compare)(a, b))
+            && self
+                .updates
+                .iter()
+                .zip(&other.updates)
+                .all(|(a, b)| (self.compare)(a, b))
+    }
+}
+
+#[derive(Eq)]
+struct MessageInfo<F: Fn(&Credential, &Credential) -> bool> {
+    msg_type: MessageType<F>,
+    sender: Sender,
+}
+
+impl<F: Fn(&Credential, &Credential) -> bool> MessageInfo<F> {
+    fn new(
+        content: &ProcessedMessageContent,
+        sender: Sender,
+        sender_equivalence: F,
+    ) -> Result<Self, ApqProcessMessageValidationError>
+    where
+        F: Fn(&Credential, &Credential) -> bool,
+    {
+        let msg_type = MessageType::new(content, sender_equivalence)
+            .ok_or(ApqProcessMessageValidationError::InvalidMessageType)?;
+        Ok(Self { msg_type, sender })
+    }
+}
+
+impl<F: Fn(&Credential, &Credential) -> bool> Debug for MessageInfo<F> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MessageInfo")
+            .field("msg_type", &self.msg_type)
+            .field("sender", &self.sender)
+            .finish()
+    }
+}
+
+impl<F: Fn(&Credential, &Credential) -> bool> PartialEq for MessageInfo<F> {
+    fn eq(&self, other: &Self) -> bool {
+        self.msg_type == other.msg_type && self.sender == other.sender
+    }
+}
+
+impl ApqMlsGroup {
+    /// See [`ApqMlsGroupMut::process_message`].
+    pub fn process_message<F, Provider: OpenMlsProvider>(
+        &mut self,
+        provider: &Provider,
+        message: impl Into<ApqProtocolMessage>,
+        sender_equivalence: F,
+    ) -> Result<ApqProcessedMessage, ApqProcessMessageError<Provider::StorageError>>
+    where
+        F: Fn(&Credential, &Credential) -> bool,
+    {
+        self.as_mut()
+            .process_message(provider, message, sender_equivalence)
+    }
+}
+
+impl ApqMlsGroupMut<'_> {
+    /// Processes an incoming APQMLS message.
+    ///
+    /// Parses incoming messages from the DS. Checks for syntactic errors and makes some semantic checks
+    /// as well. If the input is an encrypted message, it will be decrypted. This processing function
+    /// does syntactic and semantic validation of the message. It returns a [`ProcessedMessage`] enum.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`ProcessMessageError`] when the validation checks fail with the exact reason of the
+    /// failure.
+    pub fn process_message<F, Provider: OpenMlsProvider>(
+        &mut self,
+        provider: &Provider,
+        message: impl Into<ApqProtocolMessage>,
+        sender_equivalence: F,
+    ) -> Result<ApqProcessedMessage, ApqProcessMessageError<Provider::StorageError>>
+    where
+        F: Fn(&Credential, &Credential) -> bool,
+    {
+        let protocol_message: ApqProtocolMessage = message.into();
+        // We only export a PSK if we process a PQ message
+        let unverified_pq_message = self
+            .pq_group
+            .unprotect_message(provider, protocol_message.pq_protocol_message)?;
+        let pq_updates = extract_app_data_updates(self.pq_group, &unverified_pq_message);
+        let mut pq_message = self
+            .pq_group
+            .process_unverified_message_with_app_data_updates(
+                provider,
+                unverified_pq_message,
+                pq_updates,
+            )?;
+
+        let pq_message_info = MessageInfo::new(
+            pq_message.content(),
+            pq_message.sender().clone(),
+            &sender_equivalence,
+        )?;
+
+        // If we have a commit message and it is not a self-removal, we need to export the PSK.
+        //
+        // Self-removal is a special case where PSK injection should be skipped: The T group commit
+        // also removes us, so OpenMLS returns early before reaching the key schedule.
+        if let ProcessedMessageContent::StagedCommitMessage(staged_commit) = pq_message.content()
+            && !staged_commit.self_removed()
+        {
+            let apq_exporter_bytes = pq_message
+                .safe_export_secret(provider.crypto(), APQMLS_COMPONENT_ID)
+                .map_err(ApqPskError::ExportFromProcessed)?;
+
+            let apq_exporter: Secret = apq_exporter_bytes.into();
+
+            let apq_psk_id = apq_exporter
+                .derive_secret(provider.crypto(), self.t_group.ciphersuite(), "psk_id")
+                .map_err(ApqPskError::DerivingPskId)?;
+            let apq_psk = apq_exporter
+                .derive_secret(provider.crypto(), self.t_group.ciphersuite(), "psk")
+                .map_err(ApqPskError::DerivingPskId)?;
+            drop(apq_exporter); // Zeroize the secret
+
+            let psk = Psk::Application(ApplicationPsk::new(
+                APQMLS_COMPONENT_ID,
+                apq_psk_id.as_slice().into(),
+            ));
+            let id = PreSharedKeyId::new(self.t_group.ciphersuite(), provider.rand(), psk)
+                .map_err(ApqPskError::DerivingPskId)?;
+            store_psk(provider, id, apq_psk.as_slice())?;
+        }
+
+        let unverified_t_message = self
+            .t_group
+            .unprotect_message(provider, protocol_message.t_protocol_message)?;
+        let t_updates = extract_app_data_updates(self.t_group, &unverified_t_message);
+        let t_message = self
+            .t_group
+            .process_unverified_message_with_app_data_updates(
+                provider,
+                unverified_t_message,
+                t_updates,
+            )?;
+
+        let t_message_info = MessageInfo::new(
+            t_message.content(),
+            t_message.sender().clone(),
+            &sender_equivalence,
+        )?;
+
+        // Make sure that messages match up
+        if pq_message_info != t_message_info {
+            return Err(ApqProcessMessageValidationError::MismatchedMessages.into());
+        }
+
+        let pq_params = ValidationParams::from_mls_group(self.pq_group);
+        let t_params = ValidationParams::from_mls_group(self.t_group);
+        ValidationParams::validate(pq_params, t_params, &pq_message, &t_message)?;
+
+        Ok(ApqProcessedMessage {
+            t_message,
+            pq_message,
+        })
+    }
+}
+
+impl ApqPublicGroupMut<'_> {
+    /// Processes an incoming public AQPMLS message.
+    ///
+    /// Validates both messages, checks T/PQ consistency (same operator/sender), ApqInfo
+    /// epoch/group-id/ciphersuite invariants). No PSK derivation is performed.
+    pub fn process_message<Crypto: OpenMlsCrypto, F>(
+        &mut self,
+        crypto: &Crypto,
+        message: impl Into<ApqProtocolMessage>,
+        sender_equivalence: F,
+    ) -> Result<ApqProcessedMessage, ApqProcessPublicMessageError>
+    where
+        F: Fn(&Credential, &Credential) -> bool,
+    {
+        let protocol_message: ApqProtocolMessage = message.into();
+
+        let pq_message = self
+            .pq_public_group
+            .process_message_with_app_data_updates(crypto, protocol_message.pq_protocol_message)?;
+        let pq_message_info = MessageInfo::new(
+            pq_message.content(),
+            pq_message.sender().clone(),
+            &sender_equivalence,
+        )?;
+
+        let t_message = self
+            .t_public_group
+            .process_message_with_app_data_updates(crypto, protocol_message.t_protocol_message)?;
+        let t_message_info = MessageInfo::new(
+            t_message.content(),
+            t_message.sender().clone(),
+            &sender_equivalence,
+        )?;
+
+        // Note: no PSK export/store
+
+        // Make sure that messages match up
+        if pq_message_info != t_message_info {
+            return Err(ApqProcessMessageValidationError::MismatchedMessages.into());
+        }
+
+        let pq_params = ValidationParams::from_public_group(self.pq_public_group);
+        let t_params = ValidationParams::from_public_group(self.t_public_group);
+        ValidationParams::validate(pq_params, t_params, &pq_message, &t_message)?;
+
+        Ok(ApqProcessedMessage {
+            t_message,
+            pq_message,
+        })
+    }
+}
+
+struct ValidationParams<'a> {
+    epoch: GroupEpoch,
+    group_id: &'a GroupId,
+    ciphersuite: Ciphersuite,
+}
+
+impl<'a> ValidationParams<'a> {
+    fn from_mls_group(group: &'a MlsGroup) -> Self {
+        Self {
+            epoch: group.epoch(),
+            group_id: group.group_id(),
+            ciphersuite: group.ciphersuite(),
+        }
+    }
+
+    fn from_public_group(group: &'a PublicGroup) -> Self {
+        Self {
+            epoch: group.group_context().epoch(),
+            group_id: group.group_context().group_id(),
+            ciphersuite: group.group_context().ciphersuite(),
+        }
+    }
+
+    fn validate(
+        pq_params: Self,
+        t_params: Self,
+        pq_message: &ProcessedMessage,
+        t_message: &ProcessedMessage,
+    ) -> Result<(), ApqProcessMessageValidationError> {
+        use ApqProcessMessageValidationError::*;
+
+        // If both are commits, the [`ApqInfo`] component must be in line with the info of both groups
+        if let ProcessedMessageContent::StagedCommitMessage(pq_staged_commit) = pq_message.content()
+            && let ProcessedMessageContent::StagedCommitMessage(t_staged_commit) =
+                t_message.content()
+        {
+            let pq_apq_info =
+                ApqInfo::from_extensions(pq_staged_commit.group_context().extensions())
+                    .map_err(|_| InvalidApqInfo)?
+                    .ok_or(MissingApqInfo)?;
+            let t_apq_info = ApqInfo::from_extensions(t_staged_commit.group_context().extensions())
+                .map_err(|_| InvalidApqInfo)?
+                .ok_or(MissingApqInfo)?;
+
+            // ApqInfo contents must match
+            let apq_info_match = pq_apq_info == t_apq_info;
+
+            // Epochs must be in line with the groups
+            let epochs_match = pq_apq_info.pq_epoch == pq_staged_commit.group_context().epoch()
+                && t_apq_info.t_epoch == t_staged_commit.group_context().epoch();
+
+            // New epochs must be one higher than the current ones
+            let epochs_are_incremented = pq_apq_info.pq_epoch.as_u64()
+                == pq_params.epoch.as_u64() + 1
+                && t_apq_info.t_epoch.as_u64() == t_params.epoch.as_u64() + 1;
+
+            // Group IDs must be in line with the groups
+            let group_ids_match = pq_apq_info.pq_session_group_id == *pq_params.group_id
+                && t_apq_info.t_session_group_id == *t_params.group_id;
+
+            // Ciphersuites must be in line with the groups
+            let ciphersuites_match = pq_apq_info.pq_cipher_suite == pq_params.ciphersuite
+                && t_apq_info.t_cipher_suite == t_params.ciphersuite;
+
+            if !apq_info_match
+                || !epochs_match
+                || !epochs_are_incremented
+                || !group_ids_match
+                || !ciphersuites_match
+            {
+                return Err(InvalidApqInfo);
+            }
+        }
+
+        Ok(())
+    }
+}
+
+fn extract_app_data_updates(
+    group: &MlsGroup,
+    unverified: &UnverifiedMessage,
+) -> Option<AppDataUpdates> {
+    let mut updater = group.app_data_dictionary_updater();
+    let mut updated = false;
+    for proposal in unverified.committed_proposals()? {
+        if let ProposalOrRefIn::Proposal(p) = proposal
+            && let ProposalIn::AppDataUpdate(p) = &**p
+        {
+            match p.operation() {
+                AppDataUpdateOperation::Update(data) => {
+                    updater.set(ComponentData::from_parts(p.component_id(), data.clone()));
+                }
+                AppDataUpdateOperation::Remove => {
+                    updater.remove(&p.component_id());
+                }
+            }
+            updated = true;
+        }
+    }
+    updated.then(|| updater.changes()).flatten()
+}

--- a/apqmls/src/psk.rs
+++ b/apqmls/src/psk.rs
@@ -1,0 +1,87 @@
+// SPDX-FileCopyrightText: 2025 Phoenix R&D GmbH <hello@phnx.im>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! This module defines types and functions for handling Pre-Shared Keys (PSKs)
+//! in APQMLS.
+
+use openmls::{
+    group::{
+        MlsGroup, PendingSafeExportSecretError, ProcessedMessageSafeExportSecretError,
+        SafeExportSecretError,
+    },
+    prelude::{Ciphersuite, CryptoError},
+    schedule::{PreSharedKeyId, Psk, errors::PskError, psk::ApplicationPsk},
+    storage::OpenMlsProvider,
+};
+use openmls_traits::storage::StorageProvider as _;
+use thiserror::Error;
+
+use crate::{extension::APQMLS_COMPONENT_ID, secret::Secret};
+
+/// Error while handling PSKs in APQMLS.
+#[derive(Debug, Error)]
+pub enum ApqPskError<StorageError> {
+    #[error(transparent)]
+    ExportFromGroup(#[from] SafeExportSecretError<StorageError>),
+    #[error(transparent)]
+    ExportFromProcessed(#[from] ProcessedMessageSafeExportSecretError),
+    #[error(transparent)]
+    ExportFromPending(#[from] PendingSafeExportSecretError<StorageError>),
+    #[error("Error deriving PSK ID: {0}")]
+    DerivingPskId(#[from] CryptoError),
+    #[error("OpenMLS PSK error: {0}")]
+    Psk(#[from] PskError),
+    #[error("Error serializing PSK ID: {0}")]
+    SerializingPskId(#[from] tls_codec::Error),
+}
+
+/// <https://datatracker.ietf.org/doc/html/draft-ietf-mls-combiner#name-key-schedule>
+pub(crate) fn derive_and_store_psk<
+    Provider: openmls::storage::OpenMlsProvider,
+    const FROM_PENDING: bool,
+>(
+    provider: &Provider,
+    group: &mut MlsGroup,
+    t_ciphersuite: Ciphersuite,
+) -> Result<PreSharedKeyId, ApqPskError<Provider::StorageError>> {
+    let apq_exporter: Secret = if FROM_PENDING {
+        group
+            .safe_export_secret_from_pending(
+                provider.crypto(),
+                provider.storage(),
+                APQMLS_COMPONENT_ID,
+            )?
+            .into()
+    } else {
+        group
+            .safe_export_secret(provider.crypto(), provider.storage(), APQMLS_COMPONENT_ID)?
+            .into()
+    };
+
+    let apq_psk_id = apq_exporter.derive_secret(provider.crypto(), t_ciphersuite, "psk_id")?;
+    let apq_psk = apq_exporter.derive_secret(provider.crypto(), t_ciphersuite, "psk")?;
+    drop(apq_exporter); // Zeroize the secret
+
+    let psk = Psk::Application(ApplicationPsk::new(
+        APQMLS_COMPONENT_ID,
+        apq_psk_id.as_slice().into(),
+    ));
+
+    let id = PreSharedKeyId::new(t_ciphersuite, provider.rand(), psk)?;
+    store_psk(provider, id, apq_psk.as_slice())
+}
+
+pub(crate) fn store_psk<Provider: OpenMlsProvider>(
+    provider: &Provider,
+    psk_id: PreSharedKeyId,
+    psk: &[u8],
+) -> Result<PreSharedKeyId, ApqPskError<Provider::StorageError>> {
+    // Delete any existing PSK with the same ID.
+    provider
+        .storage()
+        .delete_psk::<Psk>(psk_id.psk())
+        .map_err(|_| ApqPskError::Psk(PskError::Storage))?;
+    psk_id.store(provider, psk)?;
+    Ok(psk_id)
+}

--- a/apqmls/src/public_group.rs
+++ b/apqmls/src/public_group.rs
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: 2026 Phoenix R&D GmbH <hello@phnx.im>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+use openmls::group::PublicGroup;
+
+/// An APQMLS public group, consisting of a traditional public group and a post-quantum public
+/// group.
+///
+/// The two groups can be used independently, except for membership updates.
+#[derive(Debug)]
+pub struct ApqPublicGroup {
+    t_public_group: PublicGroup,
+    pq_public_group: PublicGroup,
+}
+
+/// Same as [`ApqPublicGroup`], but references public groups instead of owning them.
+#[derive(Debug)]
+pub struct ApqPublicGroupMut<'a> {
+    pub(crate) t_public_group: &'a mut PublicGroup,
+    pub(crate) pq_public_group: &'a mut PublicGroup,
+}
+
+impl ApqPublicGroup {
+    /// Create a new APQMLS public group from the traditional and post-quantum MLS public groups.
+    pub fn from_groups(t_public_group: PublicGroup, pq_public_group: PublicGroup) -> Self {
+        Self {
+            t_public_group,
+            pq_public_group,
+        }
+    }
+
+    pub fn as_mut(&mut self) -> ApqPublicGroupMut<'_> {
+        ApqPublicGroupMut::from_groups(&mut self.t_public_group, &mut self.pq_public_group)
+    }
+}
+
+impl<'a> ApqPublicGroupMut<'a> {
+    /// A non-owning version of [`ApqPublicGroup::from_groups`].
+    pub fn from_groups(
+        t_public_group: &'a mut PublicGroup,
+        pq_public_group: &'a mut PublicGroup,
+    ) -> Self {
+        Self {
+            t_public_group,
+            pq_public_group,
+        }
+    }
+
+    pub fn t_public_group(&mut self) -> &mut PublicGroup {
+        self.t_public_group
+    }
+
+    pub fn pq_public_group(&mut self) -> &mut PublicGroup {
+        self.pq_public_group
+    }
+}

--- a/apqmls/src/secret.rs
+++ b/apqmls/src/secret.rs
@@ -1,0 +1,102 @@
+// SPDX-FileCopyrightText: 2026 Phoenix R&D GmbH <hello@phnx.im>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Taken verbatim from
+//! <https://github.com/openmls/openmls/blob/f0b97fc1df949a193630d40baa6ea41f0161742c/openmls/src/ciphersuite/secret.rs>
+
+use openmls::prelude::{Ciphersuite, CryptoError, OpenMlsCrypto};
+use tls_codec::{SecretVLBytes, Serialize, TlsSerialize, TlsSize};
+
+#[derive(TlsSerialize, TlsSize)]
+pub(crate) struct Secret {
+    value: SecretVLBytes,
+}
+
+impl From<Vec<u8>> for Secret {
+    fn from(value: Vec<u8>) -> Self {
+        Self {
+            value: value.into(),
+        }
+    }
+}
+
+impl Secret {
+    pub(crate) fn as_slice(&self) -> &[u8] {
+        self.value.as_slice()
+    }
+
+    /// HKDF expand where `self` is `prk`.
+    pub(crate) fn hkdf_expand(
+        &self,
+        crypto: &impl OpenMlsCrypto,
+        ciphersuite: Ciphersuite,
+        info: &[u8],
+        okm_len: usize,
+    ) -> Result<Self, CryptoError> {
+        let key = crypto
+            .hkdf_expand(
+                ciphersuite.hash_algorithm(),
+                self.value.as_slice(),
+                info,
+                okm_len,
+            )
+            .map_err(|_| CryptoError::CryptoLibraryError)?;
+        if key.as_slice().is_empty() {
+            return Err(CryptoError::InvalidLength);
+        }
+        Ok(Self { value: key })
+    }
+
+    /// Expand a `Secret` to a new `Secret` of length `length` including a
+    /// `label` and a `context`.
+    pub(crate) fn kdf_expand_label(
+        &self,
+        crypto: &impl OpenMlsCrypto,
+        ciphersuite: Ciphersuite,
+        label: &str,
+        context: &[u8],
+        length: usize,
+    ) -> Result<Secret, CryptoError> {
+        let full_label = format!("MLS 1.0 {label}");
+        let info = KdfLabel {
+            length: length
+                .try_into()
+                .map_err(|_| CryptoError::KdfLabelTooLarge)?,
+            label: full_label.as_bytes(),
+            context,
+        }
+        .tls_serialize_detached()
+        .map_err(|_| CryptoError::KdfSerializationError)?;
+        self.hkdf_expand(crypto, ciphersuite, &info, length)
+    }
+
+    /// Derive a new `Secret` from the this one by expanding it with the given
+    /// `label` and an empty `context`.
+    pub(crate) fn derive_secret(
+        &self,
+        crypto: &impl OpenMlsCrypto,
+        ciphersuite: Ciphersuite,
+        label: &str,
+    ) -> Result<Secret, CryptoError> {
+        self.kdf_expand_label(crypto, ciphersuite, label, &[], ciphersuite.hash_length())
+    }
+}
+
+/// `KdfLabel` is later serialized and used in the `label` field of
+/// `kdf_expand_label`.
+///
+/// ```c
+/// // draft-ietf-mls-protocol-16
+/// struct {
+///     uint16 length = Length;
+///     opaque label<V> = "MLS 1.0 " + Label;
+///     opaque context<V> = Context;
+/// } KDFLabel;
+/// ```
+#[derive(TlsSerialize, TlsSize)]
+struct KdfLabel<'a> {
+    length: u16,
+    label: &'a [u8],
+    context: &'a [u8],
+}

--- a/apqmls/src/welcome.rs
+++ b/apqmls/src/welcome.rs
@@ -1,0 +1,121 @@
+// SPDX-FileCopyrightText: 2025 Phoenix R&D GmbH <hello@phnx.im>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+use openmls::{
+    group::{MlsGroup, MlsGroupJoinConfig, StagedWelcome, WelcomeError as OpenMlsWelcomeError},
+    prelude::Ciphersuite,
+    storage::OpenMlsProvider,
+};
+use thiserror::Error;
+
+use crate::{
+    ApqMlsGroup,
+    messages::{ApqRatchetTreeIn, ApqWelcome},
+    psk::{ApqPskError, derive_and_store_psk},
+};
+
+/// Errors that can occur when creating a new [`ApqMlsGroup`] from a welcome
+/// message.
+#[derive(Debug, Error)]
+pub enum WelcomeError<StorageError> {
+    #[error("Failed to process welcome message: {0}")]
+    Processing(#[from] OpenMlsWelcomeError<StorageError>),
+    #[error(transparent)]
+    Psk(#[from] ApqPskError<StorageError>),
+}
+
+/// A staged APQ welcome.
+pub struct StagedApqWelcome {
+    t_staged_welcome: StagedWelcome,
+    pq_staged_welcome: StagedWelcome,
+}
+
+pub fn derive_and_store_join_psk<Provider: OpenMlsProvider>(
+    provider: &Provider,
+    pq_group: &mut MlsGroup,
+    t_ciphersuite: Ciphersuite,
+) -> Result<(), WelcomeError<Provider::StorageError>> {
+    derive_and_store_psk::<_, false>(provider, pq_group, t_ciphersuite)?;
+    Ok(())
+}
+
+impl ApqMlsGroup {
+    /// Creates a new [`ApqMlsGroup`] from a welcome message.
+    // TODO: Split into sans-io friendly parts.
+    pub fn new_from_welcome<Provider: OpenMlsProvider>(
+        provider: &Provider,
+        mls_group_config: &MlsGroupJoinConfig,
+        welcome: ApqWelcome,
+        ratchet_tree: Option<ApqRatchetTreeIn>,
+    ) -> Result<Self, WelcomeError<Provider::StorageError>> {
+        let (t_ratchet_tree, pq_ratchet_tree) = match ratchet_tree {
+            Some(r) => (Some(r.t_ratchet_tree), Some(r.pq_ratchet_tree)),
+            None => (None, None),
+        };
+        let mut pq_group = StagedWelcome::new_from_welcome(
+            provider,
+            mls_group_config,
+            welcome.pq_welcome,
+            pq_ratchet_tree,
+        )?
+        .into_group(provider)?;
+
+        let t_ciphersuite = welcome.t_welcome.ciphersuite();
+
+        derive_and_store_psk::<_, false>(provider, &mut pq_group, t_ciphersuite)?;
+
+        let t_group = StagedWelcome::new_from_welcome(
+            provider,
+            mls_group_config,
+            welcome.t_welcome,
+            t_ratchet_tree,
+        )?
+        .into_group(provider)?;
+
+        Ok(Self { t_group, pq_group })
+    }
+}
+
+impl StagedApqWelcome {
+    /// Creates a new [`StagedApqWelcome`] from a welcome message.
+    pub fn new_from_welcome<Provider: OpenMlsProvider>(
+        provider: &Provider,
+        mls_group_config: &MlsGroupJoinConfig,
+        welcome: ApqWelcome,
+        ratchet_tree: Option<ApqRatchetTreeIn>,
+    ) -> Result<Self, WelcomeError<Provider::StorageError>> {
+        let (t_ratchet_tree, pq_ratchet_tree) = match ratchet_tree {
+            Some(r) => (Some(r.t_ratchet_tree), Some(r.pq_ratchet_tree)),
+            None => (None, None),
+        };
+        let t_staged_welcome = StagedWelcome::new_from_welcome(
+            provider,
+            mls_group_config,
+            welcome.t_welcome,
+            t_ratchet_tree,
+        )?;
+        let pq_staged_welcome = StagedWelcome::new_from_welcome(
+            provider,
+            mls_group_config,
+            welcome.pq_welcome,
+            pq_ratchet_tree,
+        )?;
+
+        Ok(StagedApqWelcome {
+            t_staged_welcome,
+            pq_staged_welcome,
+        })
+    }
+
+    /// Consumes the staged welcome and creates a new [`ApqMlsGroup`].
+    pub fn into_group<Provider: OpenMlsProvider>(
+        self,
+        provider: &Provider,
+    ) -> Result<ApqMlsGroup, WelcomeError<Provider::StorageError>> {
+        let t_group = self.t_staged_welcome.into_group(provider)?;
+        let pq_group = self.pq_staged_welcome.into_group(provider)?;
+
+        Ok(ApqMlsGroup { t_group, pq_group })
+    }
+}

--- a/apqmls/tests/basic.rs
+++ b/apqmls/tests/basic.rs
@@ -1,0 +1,227 @@
+// SPDX-FileCopyrightText: 2025 Phoenix R&D GmbH <hello@phnx.im>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+use apqmls::{
+    ApqMlsGroup, authentication::ApqSigner, extension::PqtMode, messages::ApqMlsMessageIn,
+};
+use openmls::{
+    group::{GroupId, MlsGroupJoinConfig},
+    prelude::{Credential, LeafNodeIndex, MlsMessageIn, OpenMlsProvider, ProcessedMessageContent},
+};
+use openmls_rust_crypto::OpenMlsRustCrypto;
+use tls_codec::{Deserialize as _, Serialize};
+
+use crate::utils::{assert_groups_eq, client::Client};
+
+mod utils;
+
+fn compare_credentials(cred1: &Credential, cred2: &Credential) -> bool {
+    cred1 == cred2
+}
+
+fn join_group_helper(mode: PqtMode) -> JoinedGroup {
+    let ciphersuite = mode.default_ciphersuite();
+    let alice = Client::new("Alice", ciphersuite.into(), OpenMlsRustCrypto::default());
+    let bob = Client::new("Bob", ciphersuite.into(), OpenMlsRustCrypto::default());
+
+    // Create a new ApqMlsGroup for Alice
+    let mut alice_group = ApqMlsGroup::builder()
+        .with_group_ids(
+            GroupId::random(alice.provider.rand()),
+            GroupId::from_slice(b"test_pq_group"),
+        )
+        .set_mode(mode)
+        .build(
+            &alice.provider,
+            &alice.signer,
+            alice.credential_with_key.clone(),
+        )
+        .unwrap();
+
+    // Generate KeyPackages for Bob
+    let key_package = bob.generate_key_package(ciphersuite);
+
+    // Alice proposes to add Bob's KeyPackages
+    let commit_bundle = alice_group
+        .commit_builder()
+        .propose_adds([key_package])
+        .finalize(&alice.provider, &alice.signer, |_| true, |_| true)
+        .unwrap();
+
+    alice_group.merge_pending_commit(&alice.provider).unwrap();
+
+    let ratchet_tree = alice_group.export_ratchet_tree();
+
+    // Bob joins Alice's group
+    let welcome = commit_bundle.into_welcome().unwrap();
+    let mut bob_group = ApqMlsGroup::new_from_welcome(
+        &bob.provider,
+        &MlsGroupJoinConfig::default(),
+        welcome,
+        Some(ratchet_tree.into()),
+    )
+    .unwrap();
+
+    assert_groups_eq(&mut alice_group, &mut bob_group);
+
+    JoinedGroup {
+        alice,
+        bob,
+        alice_group,
+        bob_group,
+    }
+}
+
+fn update_group_helper(group: JoinedGroup) -> JoinedGroup {
+    let JoinedGroup {
+        mut alice_group,
+        mut bob_group,
+        alice,
+        bob,
+    } = group;
+
+    // Alice does an update
+    let alice_commit_bundle = alice_group
+        .commit_builder()
+        .force_self_update(true)
+        .finalize(&alice.provider, &alice.signer, |_| true, |_| true)
+        .unwrap();
+    alice_group.merge_pending_commit(&alice.provider).unwrap();
+
+    let message_in = ApqMlsMessageIn::try_from(alice_commit_bundle.commit).unwrap();
+    let protocol_message = message_in.into_protocol_message().unwrap();
+
+    // Bob processes Alice's update
+    let processed_message = bob_group
+        .process_message(&bob.provider, protocol_message, compare_credentials)
+        .unwrap();
+    bob_group
+        .merge_staged_commit(
+            &bob.provider,
+            processed_message.into_staged_commit().unwrap(),
+        )
+        .unwrap();
+
+    assert_groups_eq(&mut alice_group, &mut bob_group);
+
+    JoinedGroup {
+        alice,
+        bob,
+        alice_group,
+        bob_group,
+    }
+}
+
+struct JoinedGroup {
+    alice: Client<OpenMlsRustCrypto>,
+    bob: Client<OpenMlsRustCrypto>,
+    alice_group: ApqMlsGroup,
+    bob_group: ApqMlsGroup,
+}
+
+const TEST_MODE: [PqtMode; 2] = [PqtMode::ConfAndAuth, PqtMode::ConfOnly];
+
+#[test]
+fn join_group() {
+    for mode in TEST_MODE {
+        join_group_helper(mode);
+    }
+}
+
+#[test]
+fn update_group() {
+    for ciphersuite in TEST_MODE {
+        let joined_group = join_group_helper(ciphersuite);
+        update_group_helper(joined_group);
+    }
+}
+
+#[test]
+fn remove_from_group() {
+    for ciphersuite in TEST_MODE {
+        let JoinedGroup {
+            mut bob_group, bob, ..
+        } = join_group_helper(ciphersuite);
+
+        // Bob removes Alice
+        let _bob_commit_bundle = bob_group
+            .commit_builder()
+            .propose_removals(std::iter::once(LeafNodeIndex::new(0)))
+            .finalize(&bob.provider, &bob.signer, |_| true, |_| true)
+            .unwrap();
+        bob_group.merge_pending_commit(&bob.provider).unwrap();
+    }
+}
+
+#[test]
+fn t_only_update() {
+    for ciphersuite in TEST_MODE {
+        let JoinedGroup {
+            alice,
+            bob,
+            mut alice_group,
+            mut bob_group,
+        } = join_group_helper(ciphersuite);
+
+        // Alice does a T-only update
+        let alice_commit_bundle = alice_group
+            .t_group
+            .commit_builder()
+            .force_self_update(true)
+            .load_psks(alice.provider.storage())
+            .unwrap()
+            .build(
+                alice.provider.rand(),
+                alice.provider.crypto(),
+                alice.signer.t_signer(),
+                |_| true,
+            )
+            .unwrap()
+            .stage_commit(&alice.provider)
+            .unwrap();
+
+        alice_group
+            .t_group
+            .merge_pending_commit(&alice.provider)
+            .unwrap();
+
+        // Bob processes Alice's T-only update
+        let commit = MlsMessageIn::tls_deserialize_exact(
+            alice_commit_bundle
+                .into_commit()
+                .tls_serialize_detached()
+                .unwrap(),
+        )
+        .unwrap()
+        .try_into_protocol_message()
+        .unwrap();
+
+        let processed_message = bob_group
+            .t_group
+            .process_message(&bob.provider, commit)
+            .unwrap();
+        let ProcessedMessageContent::StagedCommitMessage(processed_message) =
+            processed_message.into_content()
+        else {
+            panic!("Expected a staged commit message");
+        };
+
+        bob_group
+            .t_group
+            .merge_staged_commit(&bob.provider, *processed_message)
+            .unwrap();
+
+        assert_groups_eq(&mut alice_group, &mut bob_group);
+
+        // Do an APQMLS update to make sure everything still works
+        let joined_group = JoinedGroup {
+            alice,
+            bob,
+            alice_group,
+            bob_group,
+        };
+
+        update_group_helper(joined_group);
+    }
+}

--- a/apqmls/tests/group_builder.rs
+++ b/apqmls/tests/group_builder.rs
@@ -1,0 +1,319 @@
+// SPDX-FileCopyrightText: 2026 Phoenix R&D GmbH <hello@phnx.im>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+use apqmls::{
+    ApqMlsGroup,
+    extension::{APQMLS_COMPONENT_ID, PqtMode},
+    messages::{ApqMlsMessageIn, ApqRatchetTreeIn, ApqWelcome},
+};
+use openmls::{
+    component::{ComponentId, ComponentType},
+    group::{GroupContext, GroupId, MlsGroupJoinConfig},
+    prelude::{
+        AppDataDictionary, AppDataDictionaryExtension, Extension, Extensions, OpenMlsProvider,
+    },
+};
+use openmls_rust_crypto::OpenMlsRustCrypto;
+use tls_codec::Deserialize as _;
+
+use crate::utils::{assert_groups_eq, client::Client};
+
+mod utils;
+
+const MODE: PqtMode = PqtMode::ConfAndAuth;
+
+fn build_group(
+    t_extensions: Option<Extensions<GroupContext>>,
+    pq_extensions: Option<Extensions<GroupContext>>,
+) -> (Client<OpenMlsRustCrypto>, ApqMlsGroup) {
+    let ciphersuite = MODE.default_ciphersuite();
+    let alice = Client::new("Alice", ciphersuite.into(), OpenMlsRustCrypto::default());
+
+    let mut builder = ApqMlsGroup::builder()
+        .with_group_ids(
+            GroupId::random(alice.provider.rand()),
+            GroupId::from_slice(b"test_pq_group"),
+        )
+        .set_mode(MODE);
+    if t_extensions.is_some() || pq_extensions.is_some() {
+        builder = builder
+            .with_group_context_extensions(
+                t_extensions.unwrap_or_default(),
+                pq_extensions.unwrap_or_default(),
+            )
+            .unwrap();
+    }
+    let group = builder
+        .build(
+            &alice.provider,
+            &alice.signer,
+            alice.credential_with_key.clone(),
+        )
+        .unwrap();
+    (alice, group)
+}
+
+fn dictionary_with(component_id: ComponentId) -> Extensions<GroupContext> {
+    let mut dictionary = AppDataDictionary::new();
+    dictionary.insert(component_id, Vec::new());
+    Extensions::from_vec(vec![Extension::AppDataDictionary(
+        AppDataDictionaryExtension::new(dictionary),
+    )])
+    .unwrap()
+}
+
+fn context_dictionary(context: &GroupContext) -> &AppDataDictionary {
+    context
+        .extensions()
+        .app_data_dictionary()
+        .expect("group context has no app data dictionary")
+        .dictionary()
+}
+
+fn app_components(dictionary: &AppDataDictionary) -> Vec<ComponentId> {
+    let bytes = dictionary
+        .get(&ComponentId::from(ComponentType::AppComponents))
+        .expect("no AppComponents entry");
+    Vec::tls_deserialize_exact(bytes).unwrap()
+}
+
+/// Default behavior (no caller dictionary): both group contexts advertise the APQMLS component and
+/// carry the ApqInfo entry; SafeAAD is not required.
+#[test]
+fn default_dictionary() {
+    let (_, group) = build_group(None, None);
+    for context in [
+        group.t_group.export_group_context(),
+        group.pq_group().export_group_context(),
+    ] {
+        let dictionary = context_dictionary(context);
+        assert!(app_components(dictionary).contains(&APQMLS_COMPONENT_ID));
+        assert!(dictionary.contains(&APQMLS_COMPONENT_ID));
+        assert!(!context.safe_aad_required());
+    }
+}
+
+/// A caller-provided dictionary entry survives the build and is merged with the APQMLS entries
+/// instead of being clobbered.
+#[test]
+fn caller_dictionary_is_merged() {
+    let safe_aad = ComponentId::from(ComponentType::SafeAad);
+    let (_, group) = build_group(
+        Some(dictionary_with(safe_aad)),
+        Some(dictionary_with(safe_aad)),
+    );
+    for context in [
+        group.t_group.export_group_context(),
+        group.pq_group().export_group_context(),
+    ] {
+        let dictionary = context_dictionary(context);
+        // Caller entry survived ...
+        assert!(context.safe_aad_required());
+        // ... and the APQMLS entries are still there.
+        assert!(app_components(dictionary).contains(&APQMLS_COMPONENT_ID));
+        assert!(dictionary.contains(&APQMLS_COMPONENT_ID));
+    }
+}
+
+/// A caller-provided AppComponents list is extended, not overwritten.
+#[test]
+fn caller_app_components_are_merged() {
+    const CALLER_COMPONENT_ID: ComponentId = 0x9000;
+    let mut dictionary = AppDataDictionary::new();
+    dictionary.insert(
+        ComponentId::from(ComponentType::AppComponents),
+        tls_codec::Serialize::tls_serialize_detached(&[CALLER_COMPONENT_ID].as_slice()).unwrap(),
+    );
+    let extensions = Extensions::from_vec(vec![Extension::AppDataDictionary(
+        AppDataDictionaryExtension::new(dictionary),
+    )])
+    .unwrap();
+
+    let (_, group) = build_group(Some(extensions), None);
+
+    let components = app_components(context_dictionary(group.t_group.export_group_context()));
+    assert!(components.contains(&CALLER_COMPONENT_ID));
+    assert!(components.contains(&APQMLS_COMPONENT_ID));
+}
+
+/// Extensions are per-group: a dictionary provided only for the T group does not leak into the PQ
+/// group.
+#[test]
+fn asymmetric_extensions() {
+    let safe_aad = ComponentId::from(ComponentType::SafeAad);
+    let (_, group) = build_group(Some(dictionary_with(safe_aad)), None);
+
+    assert!(group.t_group.export_group_context().safe_aad_required());
+    assert!(!group.pq_group().export_group_context().safe_aad_required());
+    // Both still carry the APQMLS entries.
+    for context in [
+        group.t_group.export_group_context(),
+        group.pq_group().export_group_context(),
+    ] {
+        assert!(dictionary_contains_apq_info(context));
+    }
+}
+
+/// The caller entry survives a commit: the commit-path dictionary updater must produce only the
+/// ApqInfo delta, leaving foreign entries in place.
+#[test]
+fn caller_entry_survives_commit() {
+    let safe_aad = ComponentId::from(ComponentType::SafeAad);
+    let (alice, mut group) = build_group(
+        Some(dictionary_with(safe_aad)),
+        Some(dictionary_with(safe_aad)),
+    );
+
+    group
+        .commit_builder()
+        .finalize(&alice.provider, &alice.signer, |_| true, |_| true)
+        .unwrap();
+    group.merge_pending_commit(&alice.provider).unwrap();
+
+    for context in [
+        group.t_group.export_group_context(),
+        group.pq_group().export_group_context(),
+    ] {
+        assert!(context.safe_aad_required());
+        assert!(dictionary_contains_apq_info(context));
+    }
+}
+
+fn dictionary_contains_apq_info(context: &GroupContext) -> bool {
+    context_dictionary(context).contains(&APQMLS_COMPONENT_ID)
+}
+
+/// Adds Bob to Alice's group; returns the welcome and the ratchet tree.
+fn add_member(
+    alice: &Client<OpenMlsRustCrypto>,
+    alice_group: &mut ApqMlsGroup,
+    bob: &Client<OpenMlsRustCrypto>,
+) -> (ApqWelcome, ApqRatchetTreeIn) {
+    let key_package = bob.generate_key_package(MODE.default_ciphersuite());
+    let bundle = alice_group
+        .commit_builder()
+        .propose_adds([key_package])
+        .finalize(&alice.provider, &alice.signer, |_| true, |_| true)
+        .unwrap();
+    alice_group.merge_pending_commit(&alice.provider).unwrap();
+    let ratchet_tree = alice_group.export_ratchet_tree();
+    (bundle.into_welcome().unwrap(), ratchet_tree.into())
+}
+
+fn assert_joiner_inherited_dictionary(alice_group: &ApqMlsGroup, bob_group: &ApqMlsGroup) {
+    for (alice_context, bob_context) in [
+        (
+            alice_group.t_group.export_group_context(),
+            bob_group.t_group.export_group_context(),
+        ),
+        (
+            alice_group.pq_group().export_group_context(),
+            bob_group.pq_group().export_group_context(),
+        ),
+    ] {
+        assert!(bob_context.safe_aad_required());
+        assert_eq!(
+            context_dictionary(alice_context),
+            context_dictionary(bob_context)
+        );
+    }
+}
+
+/// A joiner via `ApqMlsGroup::new_from_welcome` inherits the creator's merged dictionary (incl. the
+/// SafeAad entry) through the welcome.
+#[test]
+fn joiner_inherits_dictionary_via_new_from_welcome() {
+    let safe_aad = ComponentId::from(ComponentType::SafeAad);
+    let (alice, mut alice_group) = build_group(
+        Some(dictionary_with(safe_aad)),
+        Some(dictionary_with(safe_aad)),
+    );
+
+    let bob = Client::new(
+        "Bob",
+        MODE.default_ciphersuite().into(),
+        OpenMlsRustCrypto::default(),
+    );
+    let (welcome, ratchet_tree) = add_member(&alice, &mut alice_group, &bob);
+
+    let mut bob_group = ApqMlsGroup::new_from_welcome(
+        &bob.provider,
+        &MlsGroupJoinConfig::default(),
+        welcome,
+        Some(ratchet_tree),
+    )
+    .unwrap();
+
+    assert_joiner_inherited_dictionary(&alice_group, &bob_group);
+    assert_group_operational(&alice, &mut alice_group, &bob, &mut bob_group);
+}
+
+/// Verifies the joined group is fully operational, beyond context contents: shared group state,
+/// correct membership, and commits flowing in both directions after the join.
+fn assert_group_operational(
+    alice: &Client<OpenMlsRustCrypto>,
+    alice_group: &mut ApqMlsGroup,
+    bob: &Client<OpenMlsRustCrypto>,
+    bob_group: &mut ApqMlsGroup,
+) {
+    // Same groups and epochs on both sides.
+    assert_eq!(alice_group.t_group.group_id(), bob_group.t_group.group_id());
+    assert_eq!(
+        alice_group.pq_group().group_id(),
+        bob_group.pq_group().group_id()
+    );
+    assert_eq!(alice_group.t_group.epoch(), bob_group.t_group.epoch());
+    assert_eq!(alice_group.pq_group().epoch(), bob_group.pq_group().epoch());
+
+    // Both members are present in both views.
+    for group in [&*alice_group, &*bob_group] {
+        assert_eq!(group.t_group.members().count(), 2);
+        assert_eq!(group.pq_group().members().count(), 2);
+    }
+
+    // Epoch secrets agree (this is what proves the joiner's PSK derivation between the PQ and T
+    // joins actually worked).
+    assert_groups_eq(alice_group, bob_group);
+
+    // Bob commits a self-update; Alice processes and merges it.
+    commit_and_process(bob, bob_group, alice, alice_group);
+    // And the other direction.
+    commit_and_process(alice, alice_group, bob, bob_group);
+
+    // The SafeAad requirement survived both post-join commits.
+    assert!(bob_group.t_group.export_group_context().safe_aad_required());
+}
+
+/// `committer` creates and merges a self-update commit; `processor` processes and merges it.
+/// Asserts both views agree afterwards.
+fn commit_and_process(
+    committer: &Client<OpenMlsRustCrypto>,
+    committer_group: &mut ApqMlsGroup,
+    processor: &Client<OpenMlsRustCrypto>,
+    processor_group: &mut ApqMlsGroup,
+) {
+    let bundle = committer_group
+        .commit_builder()
+        .force_self_update(true)
+        .finalize(&committer.provider, &committer.signer, |_| true, |_| true)
+        .unwrap();
+    committer_group
+        .merge_pending_commit(&committer.provider)
+        .unwrap();
+
+    let protocol_message = ApqMlsMessageIn::try_from(bundle.commit)
+        .unwrap()
+        .into_protocol_message()
+        .unwrap();
+    let processed = processor_group
+        .process_message(&processor.provider, protocol_message, |cred1, cred2| {
+            cred1 == cred2
+        })
+        .unwrap();
+    processor_group
+        .merge_staged_commit(&processor.provider, processed.into_staged_commit().unwrap())
+        .unwrap();
+
+    assert_groups_eq(committer_group, processor_group);
+}

--- a/apqmls/tests/utils/client.rs
+++ b/apqmls/tests/utils/client.rs
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: 2025 Phoenix R&D GmbH <hello@phnx.im>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+use apqmls::{
+    ApqCiphersuite,
+    authentication::{ApqCredentialWithKey, ApqSignatureKeyPair, ApqSignatureScheme},
+    messages::ApqKeyPackage,
+};
+use openmls::storage::OpenMlsProvider;
+
+pub struct Client<Provider> {
+    pub signer: ApqSignatureKeyPair,
+    pub credential_with_key: ApqCredentialWithKey,
+    pub provider: Provider,
+}
+
+impl<Provider: OpenMlsProvider> Client<Provider> {
+    pub fn new(identity: &str, signature_scheme: ApqSignatureScheme, provider: Provider) -> Self {
+        let keypair = ApqSignatureKeyPair::new(signature_scheme).unwrap();
+        let credential_with_key = ApqCredentialWithKey::new(identity.as_bytes(), &keypair);
+
+        Client {
+            signer: keypair,
+            credential_with_key,
+            provider,
+        }
+    }
+
+    pub fn generate_key_package(&self, ciphersuite: ApqCiphersuite) -> ApqKeyPackage {
+        ApqKeyPackage::builder()
+            .build(
+                &self.provider,
+                ciphersuite,
+                &self.signer,
+                self.credential_with_key.clone(),
+            )
+            .unwrap()
+            .into_key_package()
+    }
+}

--- a/apqmls/tests/utils/mod.rs
+++ b/apqmls/tests/utils/mod.rs
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: 2025 Phoenix R&D GmbH <hello@phnx.im>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+use apqmls::ApqMlsGroup;
+
+pub mod client;
+
+pub fn assert_groups_eq(group1: &mut ApqMlsGroup, group2: &mut ApqMlsGroup) {
+    let t_group_1_authenticator = group1.t_group.epoch_authenticator();
+    let t_group_2_authenticator = group2.t_group.epoch_authenticator();
+    assert_eq!(
+        t_group_1_authenticator.as_slice(),
+        t_group_2_authenticator.as_slice(),
+        "t_group secrets do not match"
+    );
+    let pq_group_1_authenticator = group1.pq_group().epoch_authenticator();
+    let pq_group_2_authenticator = group2.pq_group().epoch_authenticator();
+    assert_eq!(
+        pq_group_1_authenticator.as_slice(),
+        pq_group_2_authenticator.as_slice(),
+        "pq_group secrets do not match"
+    );
+}

--- a/deny.toml
+++ b/deny.toml
@@ -69,7 +69,8 @@ unknown-git = "deny"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 allow-git = [
     "https://github.com/raphaelrobert/privacypass",
-    "https://github.com/boxdot/openmls",
+    # unreleased post-quantum and virtual-clients features of openmls after the 0.8.1 release
+    "https://github.com/openmls/openmls",
     "https://github.com/cryspen/hpke-rs",
     "https://github.com/RustCrypto/RSA",
 ]


### PR DESCRIPTION
We still include openmls/openmls#2063 to be able to extract the ratchet
generation.

Additionally, inline apqmls into the repository.