### PR TITLE
feat(app): introduce device type in foundations

### DIFF
--- a/app/lib/app.dart
+++ b/app/lib/app.dart
@@ -88,14 +88,14 @@ class _AppState extends State<App> with WidgetsBindingObserver {
   Future<void> _onStateChanged(AppLifecycleState state) async {
     // Detect background transitions
 
-    if (isPointer() && state == AppLifecycleState.inactive) {
+    if (DeviceType.isDesktop && state == AppLifecycleState.inactive) {
       // On desktop platforms, the inactive state is entered when the user
       // switches to another app. In that case, we want to treat it as
       // background state.
       _appStateController.sink.add(AppState.desktopBackground);
       return;
     }
-    if (isTouch() && state == AppLifecycleState.paused) {
+    if (DeviceType.isPhone && state == AppLifecycleState.paused) {
       // On mobile platforms, the paused state is entered when the app
       // is closed. In that case, we want to treat it as background state.
       _appStateController.sink.add(AppState.mobileBackground);

--- a/app/lib/attachments/attachment_category_picker.dart
+++ b/app/lib/attachments/attachment_category_picker.dart
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import 'dart:io';
-
 import 'package:air/l10n/l10n.dart' show AppLocalizations;
 import 'package:air/ds/theme/theme.dart';
 import 'package:air/ds/foundations/themes.dart';
@@ -21,7 +19,6 @@ class AttachmentCategoryPicker extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final isMobile = Platform.isAndroid || Platform.isIOS;
     final loc = AppLocalizations.of(context);
     return Row(
       mainAxisAlignment: .spaceEvenly,
@@ -33,7 +30,7 @@ class AttachmentCategoryPicker extends StatelessWidget {
             onCategorySelected?.call(AttachmentCategory.gallery);
           },
         ),
-        if (isMobile)
+        if (DeviceType.isPhone)
           _AttachmentCategoryButton(
             icon: const AppIcon.camera(),
             label: loc.attachment_camera,

--- a/app/lib/chat/add_members_screen.dart
+++ b/app/lib/chat/add_members_screen.dart
@@ -107,7 +107,7 @@ class _AddMembersScreenViewState extends State<AddMembersScreenView> {
         child: Align(
           alignment: Alignment.topCenter,
           child: Container(
-            constraints: isPointer()
+            constraints: DeviceType.isDesktop
                 ? const BoxConstraints(maxWidth: 800)
                 : null,
             child: Column(

--- a/app/lib/chat/create_group_screen.dart
+++ b/app/lib/chat/create_group_screen.dart
@@ -121,7 +121,7 @@ class _MemberSelectionStep extends HookWidget {
         child: Align(
           alignment: Alignment.topCenter,
           child: Container(
-            constraints: isPointer()
+            constraints: DeviceType.isDesktop
                 ? const BoxConstraints(maxWidth: 800)
                 : null,
             child: Column(
@@ -249,7 +249,7 @@ class _CreateGroupDetailsStep extends HookWidget {
             child: Align(
               alignment: Alignment.topCenter,
               child: Container(
-                constraints: isPointer()
+                constraints: DeviceType.isDesktop
                     ? const BoxConstraints(maxWidth: 800)
                     : null,
                 child: Column(

--- a/app/lib/chat/group_members_screen.dart
+++ b/app/lib/chat/group_members_screen.dart
@@ -119,7 +119,7 @@ class GroupMembersView extends HookWidget {
         child: Align(
           alignment: Alignment.topCenter,
           child: Container(
-            constraints: isPointer()
+            constraints: DeviceType.isDesktop
                 ? const BoxConstraints(maxWidth: 800)
                 : null,
             child: Column(

--- a/app/lib/developer/change_user_screen.dart
+++ b/app/lib/developer/change_user_screen.dart
@@ -51,12 +51,12 @@ class ChangeUserScreenView extends StatelessWidget {
       appBar: AppBar(
         clipBehavior: Clip.none,
         title: const Text('Change User'),
-        toolbarHeight: isPointer() ? 100 : null,
+        toolbarHeight: DeviceType.isDesktop ? 100 : null,
         leading: const AppBarBackButton(),
       ),
       body: Center(
         child: Container(
-          constraints: isPointer()
+          constraints: DeviceType.isDesktop
               ? const BoxConstraints(maxWidth: _maxDesktopWidth)
               : null,
           child: _ClientRecords(clientRecords: clientRecords),

--- a/app/lib/developer/developer_settings_screen.dart
+++ b/app/lib/developer/developer_settings_screen.dart
@@ -48,7 +48,7 @@ class _DeveloperSettingsScreenState extends State<DeveloperSettingsScreen> {
   build(BuildContext context) {
     return DeveloperSettingsScreenView(
       deviceToken: deviceToken,
-      isMobile: Platform.isAndroid || Platform.isIOS,
+      isMobile: DeviceType.isPhone,
       onRefreshPushToken: () =>
           _reRegisterPushToken(context.read<CoreClient>()),
     );
@@ -112,7 +112,7 @@ class DeveloperSettingsScreenView extends StatelessWidget {
       body: SafeArea(
         child: Center(
           child: Container(
-            constraints: isPointer()
+            constraints: DeviceType.isDesktop
                 ? const BoxConstraints(maxWidth: 800)
                 : null,
             child: ListTileTheme(

--- a/app/lib/developer/logs_screen.dart
+++ b/app/lib/developer/logs_screen.dart
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import 'dart:async';
-import 'dart:io';
 
 import 'package:air/util/platform.dart';
 import 'package:file_selector/file_selector.dart';
@@ -95,14 +94,14 @@ class LogsScreenView extends StatelessWidget {
         appBar: AppBar(
           clipBehavior: Clip.none,
           title: const Text('Logs'),
-          toolbarHeight: isPointer() ? 100 : null,
+          toolbarHeight: DeviceType.isDesktop ? 100 : null,
           leading: const AppBarBackButton(),
           actions: [
             PopupMenuButton(
               itemBuilder: (context) => [
-                if (Platform.isLinux || Platform.isMacOS || Platform.isWindows)
+                if (DeviceType.isDesktop)
                   PopupMenuItem(onTap: _saveLogs, child: const Text('Save')),
-                if (Platform.isAndroid || Platform.isIOS)
+                if (DeviceType.isPhone)
                   PopupMenuItem(onTap: _shareLogs, child: const Text('Share')),
                 PopupMenuItem(onTap: reloadLogs, child: const Text('Reload')),
                 PopupMenuItem(onTap: clearLogs, child: const Text('Clear')),

--- a/app/lib/ds/foundations/device_type.dart
+++ b/app/lib/ds/foundations/device_type.dart
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: 2024 Phoenix R&D GmbH <hello@phnx.im>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import 'dart:io';
+
+/// What kind of device the UI is rendering on. Phones run on iOS / Android,
+/// everything else is treated as desktop.
+///
+/// Distinct from `ResponsiveScreenType`, which describes the viewport size and
+/// drives layout decisions (e.g. whether the chat list and message list can sit
+/// side-by-side). Device type is platform-derived and constant for the process.
+enum DeviceType {
+  phone,
+  desktop;
+
+  static DeviceType get current =>
+      (Platform.isIOS || Platform.isAndroid) ? phone : desktop;
+
+  static bool get isPhone => current == phone;
+  static bool get isDesktop => current == desktop;
+}

--- a/app/lib/ds/theme/responsive_screen.dart
+++ b/app/lib/ds/theme/responsive_screen.dart
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import 'dart:io';
-
+import 'package:air/ds/foundations/device_type.dart';
 import 'package:flutter/widgets.dart';
 
 /// Different screen types
@@ -24,7 +23,7 @@ const double kMobileBreakpoint = 576;
 ResponsiveScreenType _screenType(double width) {
   if (width < kMobileBreakpoint) {
     return ResponsiveScreenType.mobile;
-  } else if (ResponsiveScreen.isTouch) {
+  } else if (DeviceType.isPhone) {
     return ResponsiveScreenType.tablet;
   } else {
     return ResponsiveScreenType.desktop;
@@ -63,8 +62,6 @@ class ResponsiveScreen extends StatefulWidget {
       context.responsiveScreenType == ResponsiveScreenType.tablet;
   static bool isDesktop(BuildContext context) =>
       context.responsiveScreenType == ResponsiveScreenType.desktop;
-
-  static bool isTouch = Platform.isIOS || Platform.isAndroid;
 
   @override
   State<ResponsiveScreen> createState() => _ResponsiveScreenState();

--- a/app/lib/ds/theme/styles.dart
+++ b/app/lib/ds/theme/styles.dart
@@ -7,7 +7,6 @@ import 'package:air/ds/foundations/spacing.dart';
 import 'package:air/ds/theme/font.dart';
 import 'package:flutter/material.dart';
 import 'package:air/ds/foundations/themes.dart';
-import 'dart:io' show Platform;
 
 // === Devices ===
 
@@ -17,14 +16,6 @@ bool isSmallScreen(BuildContext context) {
 
 bool isLargeScreen(BuildContext context) {
   return MediaQuery.sizeOf(context).width >= kMobileBreakpoint;
-}
-
-bool isTouch() {
-  return Platform.isIOS || Platform.isAndroid;
-}
-
-bool isPointer() {
-  return Platform.isLinux || Platform.isMacOS || Platform.isWindows;
 }
 
 // === Buttons ===

--- a/app/lib/ds/theme/theme.dart
+++ b/app/lib/ds/theme/theme.dart
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 export '../foundations/spacing.dart';
+export '../foundations/device_type.dart';
 export 'theme_data.dart';
 export 'responsive_screen.dart';
 export 'styles.dart';

--- a/app/lib/ds/theme/theme_data.dart
+++ b/app/lib/ds/theme/theme_data.dart
@@ -47,7 +47,7 @@ ThemeData themeData(Brightness brightness) {
       elevation: 0,
       iconTheme: IconThemeData(color: colorScheme.text.primary),
       centerTitle: true,
-      toolbarHeight: isPointer() ? 100 : null,
+      toolbarHeight: DeviceType.isDesktop ? 100 : null,
       systemOverlayStyle: brightness == Brightness.light
           ? SystemUiOverlayStyle.dark
           : SystemUiOverlayStyle.light,

--- a/app/lib/message_list/message_composer.dart
+++ b/app/lib/message_list/message_composer.dart
@@ -36,11 +36,7 @@ import 'package:air/ds/foundations/font_size.dart';
 import 'package:provider/provider.dart';
 
 import 'package:air/util/platform.dart'
-    show
-        ClipboardImage,
-        getClipboardFilePaths,
-        getClipboardImage,
-        PlatformExtension;
+    show ClipboardImage, getClipboardFilePaths, getClipboardImage;
 
 import 'message_renderer.dart';
 import 'text_message_tile.dart' show messageHorizontalPadding;
@@ -131,7 +127,7 @@ class _MessageComposerState extends State<MessageComposer>
       }
 
       // always request focus on chat draft loading on desktop
-      bool requestFocus = PlatformExtension.isDesktop;
+      bool requestFocus = DeviceType.isDesktop;
 
       switch (state.chat?.draft) {
         // Initially loaded draft
@@ -386,7 +382,7 @@ class _MessageComposerState extends State<MessageComposer>
     if (!modifierKeyPressed &&
         evt.logicalKey == LogicalKeyboardKey.enter &&
         evt is KeyDownEvent &&
-        PlatformExtension.isDesktop) {
+        DeviceType.isDesktop) {
       final chatDetailsCubit = context.read<ChatDetailsCubit>();
       _submitMessage(chatDetailsCubit);
       return KeyEventResult.handled;

--- a/app/lib/message_list/message_list_view.dart
+++ b/app/lib/message_list/message_list_view.dart
@@ -14,7 +14,7 @@ import 'package:air/chat/chat_details.dart';
 import 'package:air/core/core.dart';
 import 'package:air/ds/foundations/themes.dart';
 import 'package:air/user/user.dart';
-import 'package:air/util/platform.dart';
+import 'package:air/ds/foundations/device_type.dart';
 import 'package:air/widgets/anchored_list/anchored_list.dart';
 import 'package:air/widgets/anchored_list/controller.dart';
 import 'package:air/widgets/widgets.dart';
@@ -261,7 +261,7 @@ class _MessageListViewState extends State<MessageListView>
   /// Dismisses the keyboard once a drag has pulled down past
   /// [_keyboardDismissDragThreshold].
   void _maybeDismissKeyboardOnDrag(ScrollUpdateNotification notification) {
-    if (!PlatformExtension.isMobile || _keyboardDismissedThisDrag) return;
+    if (!DeviceType.isPhone || _keyboardDismissedThisDrag) return;
     final drag = notification.dragDetails;
     if (drag == null) return;
     _downwardDragSinceStart = max(0, _downwardDragSinceStart + drag.delta.dy);
@@ -393,7 +393,7 @@ class _MessageListViewState extends State<MessageListView>
 
       // On mobile, we want to dismiss the keyboard by tapping anywhere in the
       // list, except when tapping interactive elements like e.g. links.
-      if (PlatformExtension.isMobile) {
+      if (DeviceType.isPhone) {
         list = GestureDetector(
           behavior: HitTestBehavior.translucent,
           onTap: () => FocusScope.of(context).unfocus(),

--- a/app/lib/registration/invitation_code_screen.dart
+++ b/app/lib/registration/invitation_code_screen.dart
@@ -40,7 +40,7 @@ class InvitationCodeScreen extends HookWidget {
           loc.invitationCodeScreen_header,
           style: const TextStyle(fontWeight: FontWeight.bold),
         ),
-        toolbarHeight: isPointer() ? 100 : null,
+        toolbarHeight: DeviceType.isDesktop ? 100 : null,
         backgroundColor: colors.backgroundBase.secondary,
       ),
       backgroundColor: backgroundColor,

--- a/app/lib/registration/sign_up_screen.dart
+++ b/app/lib/registration/sign_up_screen.dart
@@ -44,7 +44,7 @@ class SignUpScreen extends HookWidget {
           loc.signUpScreen_header,
           style: const TextStyle(fontWeight: FontWeight.bold),
         ),
-        toolbarHeight: isPointer() ? 100 : null,
+        toolbarHeight: DeviceType.isDesktop ? 100 : null,
         backgroundColor: colors.backgroundBase.secondary,
       ),
       backgroundColor: backgroundColor,

--- a/app/lib/user/contact_us_screen.dart
+++ b/app/lib/user/contact_us_screen.dart
@@ -51,7 +51,7 @@ class ContactUsScreen extends StatelessWidget {
         ),
         actions: null,
         backgroundColor: colors.backgroundBase.secondary,
-        toolbarHeight: isPointer() ? 100 : null,
+        toolbarHeight: DeviceType.isDesktop ? 100 : null,
         centerTitle: true,
       ),
       backgroundColor: colors.backgroundBase.secondary,
@@ -62,7 +62,7 @@ class ContactUsScreen extends StatelessWidget {
           child: Align(
             alignment: Alignment.topCenter,
             child: Container(
-              constraints: isPointer()
+              constraints: DeviceType.isDesktop
                   ? const BoxConstraints(maxWidth: 800)
                   : null,
               child: Theme(

--- a/app/lib/user/invitation_codes_screen.dart
+++ b/app/lib/user/invitation_codes_screen.dart
@@ -51,7 +51,9 @@ class InvitationCodesView extends StatelessWidget {
       child: Align(
         alignment: Alignment.topCenter,
         child: Container(
-          constraints: isPointer() ? const BoxConstraints(maxWidth: 800) : null,
+          constraints: DeviceType.isDesktop
+              ? const BoxConstraints(maxWidth: 800)
+              : null,
           child: SingleChildScrollView(
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,

--- a/app/lib/user/update_required_screen.dart
+++ b/app/lib/user/update_required_screen.dart
@@ -26,7 +26,7 @@ class UpdateRequiredScreen extends StatelessWidget {
     final isOutdated = context.select(
       (UserCubit cubit) => cubit.state.unsupportedVersion,
     );
-    final showUpdateButton = Platform.isIOS || Platform.isAndroid;
+    final showUpdateButton = DeviceType.isPhone;
     return isOutdated
         ? UpdateRequiredView(showUpdateButton: showUpdateButton)
         : child;
@@ -50,7 +50,7 @@ class UpdateRequiredView extends StatelessWidget {
           loc.appOutdatedScreen_title,
           style: const TextStyle(fontWeight: FontWeight.bold),
         ),
-        toolbarHeight: isPointer() ? 100 : null,
+        toolbarHeight: DeviceType.isDesktop ? 100 : null,
         backgroundColor: colors.backgroundBase.secondary,
       ),
       backgroundColor: colors.backgroundBase.secondary,

--- a/app/lib/user/user_settings_screen.dart
+++ b/app/lib/user/user_settings_screen.dart
@@ -55,7 +55,9 @@ class UserSettingsView extends StatelessWidget {
       child: Align(
         alignment: Alignment.topCenter,
         child: Container(
-          constraints: isPointer() ? const BoxConstraints(maxWidth: 800) : null,
+          constraints: DeviceType.isDesktop
+              ? const BoxConstraints(maxWidth: 800)
+              : null,
           child: const _Sections(),
         ),
       ),
@@ -109,9 +111,8 @@ class _Sections extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final loc = AppLocalizations.of(context);
-    final isMobilePlatform = Platform.isAndroid || Platform.isIOS;
-    final isDesktopPlatform =
-        Platform.isMacOS || Platform.isWindows || Platform.isLinux;
+    final isMobilePlatform = DeviceType.isPhone;
+    final isDesktopPlatform = DeviceType.isDesktop;
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,

--- a/app/lib/util/platform.dart
+++ b/app/lib/util/platform.dart
@@ -265,9 +265,3 @@ FutureOr<void> cancelNotifications(List<NotificationId> identifiers) async {
     );
   }
 }
-
-extension PlatformExtension on Platform {
-  static bool get isMobile => Platform.isAndroid || Platform.isIOS;
-  static bool get isDesktop =>
-      Platform.isMacOS || Platform.isLinux || Platform.isWindows;
-}


### PR DESCRIPTION
Use the same device type logic in the app as we use in the design system. After this PR we should no longer use `Platform`, unless we need a specific platform.