### PR TITLE
feat(server): echo a client's group commit back to all its siblings

### DIFF
--- a/backend/src/ds/group_state/mod.rs
+++ b/backend/src/ds/group_state/mod.rs
@@ -35,7 +35,10 @@ use tls_codec::{Serialize as _, TlsDeserializeBytes, TlsSerialize, TlsSize, VLBy
 use tracing::error;
 use uuid::Uuid;
 
-use crate::errors::{CborMlsAssistStorage, StorageError};
+use crate::{
+    errors::{CborMlsAssistStorage, GroupOperationError, StorageError},
+    messages::intra_backend::{DsFanOutMessage, DsFanOutPayload},
+};
 
 use super::{GROUP_STATE_EXPIRATION, ReservedGroupId, process::ExternalCommitInfo};
 
@@ -205,6 +208,21 @@ impl DsGroupState {
         self.member_profiles
             .get(&member_index)
             .map(|cp| cp.client_queue_config.clone())
+    }
+
+    pub(super) fn self_commit_message(
+        &self,
+        sender_index: LeafNodeIndex,
+        commit: DsFanOutPayload,
+    ) -> Result<DsFanOutMessage, GroupOperationError> {
+        let sender_client_reference = self
+            .qs_client_ref_by_index(sender_index)
+            .ok_or(GroupOperationError::InvalidMessage)?;
+        Ok(DsFanOutMessage {
+            payload: commit,
+            client_reference: sender_client_reference,
+            suppress_notifications: true.into(),
+        })
     }
 }
 

--- a/backend/src/ds/grpc.rs
+++ b/backend/src/ds/grpc.rs
@@ -1181,6 +1181,11 @@ impl<Qep: QsConnector, As: AsConnector> DeliveryService for GrpcDs<Qep, As> {
                     .create_commit_response(sender_index, fan_out_payload.timestamp())?;
                 individual_fan_out_messages.push(commit_response);
 
+                // Echo the full commit to the committer's own leaf (QS fans it to all
+                // emulator clients). Older clients will error but skip it.
+                individual_fan_out_messages
+                    .push(group_state.self_commit_message(sender_index, fan_out_payload.clone())?);
+
                 Ok((
                     destination_clients,
                     fan_out_payload,
@@ -1410,6 +1415,13 @@ impl<Qep: QsConnector, As: AsConnector> DeliveryService for GrpcDs<Qep, As> {
 
         let commit_response = t_group_state.create_commit_response(t_sender_index, timestamp)?;
         individual_fan_out_messages.push(commit_response);
+
+        // Echo the full commit to the committer's own leaf (QS fans it to all
+        // emulator clients). Older clients will error but skip it.
+        individual_fan_out_messages.push(t_group_state.self_commit_message(
+            t_sender_index,
+            DsFanOutPayload::QueueMessage(apq_payload.clone()),
+        )?);
 
         // Persist and commit the DS state *before* dispatching welcome bundles, so that joiners
         // fetching welcome info always observe the freshly stored past group state.


### PR DESCRIPTION
Groundwork for virtual clients: a sibling client that didn't perform the commit
has no pending commit to merge and needs the full commit to reach the new epoch.

When a client commits a group operation, the DS now also echoes the full commit
back to the committer's own leaf, in addition to the existing `DsCommitResponse`.