### PR TITLE
fix(app): don't re-encode gallery and camera input in Flutter

### DIFF
--- a/app/lib/message_list/message_composer.dart
+++ b/app/lib/message_list/message_composer.dart
@@ -503,16 +503,11 @@ class _MessageComposerState extends State<MessageComposer>
       ),
     );
 
-    // Reduce image quality to re-encode the image.
+    // Note: using imageQuality triggers re-encoding, which loses animation
+    // properties from GIFs or other animated formats.
     final XFile? file = switch (selectedCategory) {
-      .gallery => await ImagePicker().pickImage(
-        source: .gallery,
-        imageQuality: 99,
-      ),
-      .camera => await ImagePicker().pickImage(
-        source: .camera,
-        imageQuality: 99,
-      ),
+      .gallery => await ImagePicker().pickImage(source: .gallery),
+      .camera => await ImagePicker().pickImage(source: .camera),
       .file => await openFile(),
       null => null,
     };


### PR DESCRIPTION
Passing imageQuality had two side-effects:
- re-encode the image to JPEG, which is useless since we then re-encode to WEBP in coreclient
- for animated input (i.e. GIFs) it takes the first frame and outputs a JPEG

Verified in the implementation: on both iOS and Android 13+ `pickImage` internally re-encodes HEIC to JPEG to avoid compatibility issues. (on Android, it is actually handled by the system photo picker implementation).