### PR TITLE
chore(deps): bump anyhow, webpx and crypto-bigint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -547,9 +547,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "apqmls"
@@ -1397,7 +1397,7 @@ version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7c8e1ec3966bafbe115ad484420b260f5fabf88528e4ef8cd3024ffedb50e46"
 dependencies = [
- "crypto-bigint 0.7.3",
+ "crypto-bigint 0.7.5",
  "crypto-primes",
  "ct-codecs",
  "derive-new",
@@ -2099,9 +2099,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-bigint"
-version = "0.7.3"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42a0d26b245348befa0c121944541476763dcc46ede886c88f9d12e1697d27c3"
+checksum = "1a52aa3fcda4e6302a9f48734f234d35d4721b96f8fe07d073f07ce9df4f0271"
 dependencies = [
  "cpubits",
  "ctutils",
@@ -2139,7 +2139,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21f41f23de7d24cdbda7f0c4d9c0351f99a4ceb258ef30e5c1927af8987ffe5a"
 dependencies = [
- "crypto-bigint 0.7.3",
+ "crypto-bigint 0.7.5",
  "libm",
  "rand_core 0.10.1",
 ]
@@ -6400,7 +6400,7 @@ version = "0.10.0-rc.18"
 source = "git+https://github.com/RustCrypto/RSA?rev=99f80888cdc838da78a48ad14f6e1f5c01be5c30#99f80888cdc838da78a48ad14f6e1f5c01be5c30"
 dependencies = [
  "const-oid 0.10.2",
- "crypto-bigint 0.7.3",
+ "crypto-bigint 0.7.5",
  "crypto-primes",
  "digest 0.11.3",
  "pkcs1 0.8.0-rc.4",
@@ -8288,9 +8288,9 @@ dependencies = [
 
 [[package]]
 name = "webpx"
-version = "0.3.4"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b28247f4d01528a87716eccf25edac8d3787ce4da26f7f5893b790615f2832d"
+checksum = "8fdf16a15bf6251e368835a9b27372a90daba57eab09c2d98e4a7b824622fcbe"
 dependencies = [
  "enough",
  "imgref",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,7 +131,7 @@ tracing-log = "0.2"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "tracing-log", "parking_lot"] }
 url = "2.5.4"
 uuid = "1.16.0"
-webpx = { version = "0.3.4", default-features = false, features = ["encode", "animation", "std"] }
+webpx = { version = "0.4.0", default-features = false, features = ["encode", "animation", "std"] }
 xshell = "0.2"
 zeroize = "1.8.2"
 


### PR DESCRIPTION
- `anyhow` 1.0.102 has potential unsound behaviour (see https://rustsec.org/advisories/RUSTSEC-2026-0190)
- `webpx` 0.3.4 was yanked
- `crypto-bigint` 0.7.3 was yanked