### PR TITLE
perf(CI): decrease the amount of key and connection packages when testing

### DIFF
--- a/coreclient/src/clients/mod.rs
+++ b/coreclient/src/clients/mod.rs
@@ -113,7 +113,11 @@ pub(crate) mod user_settings;
 pub(crate) const CIPHERSUITE: Ciphersuite =
     Ciphersuite::MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519;
 
+#[cfg(not(feature = "test_utils"))]
 pub(crate) const CONNECTION_PACKAGES: usize = 50;
+
+#[cfg(feature = "test_utils")]
+pub(crate) const CONNECTION_PACKAGES: usize = 5;
 
 #[derive(Debug, Clone)]
 pub struct CoreUser {

--- a/coreclient/src/outbound_service/timed_tasks.rs
+++ b/coreclient/src/outbound_service/timed_tasks.rs
@@ -29,7 +29,11 @@ use crate::{
 use super::OutboundServiceContext;
 
 /// Number of key packages to upload (excluding the last resort key package)
+#[cfg(not(feature = "test_utils"))]
 pub const KEY_PACKAGES: usize = 100;
+
+#[cfg(feature = "test_utils")]
+pub const KEY_PACKAGES: usize = 10; // to go faster
 
 /// Number of APQ key packages to upload (excluding the last resort key package)
 ///


### PR DESCRIPTION
On my machine, running integration tests with `cargo nextest` goes from 120s to ~75s. I suppose the difference in CI will also be very noticeable.