### PR TITLE
fix(app): fix cached image proportions

### DIFF
--- a/app/lib/util/cached_memory_image.dart
+++ b/app/lib/util/cached_memory_image.dart
@@ -60,10 +60,10 @@ class CachedMemoryImage extends ImageProvider<CachedMemoryImage> {
     return decode(
       buffer,
       getTargetSize: (intrinsicWidth, intrinsicHeight) {
-        final widthScale = targetWidth != null
+        final widthScale = (targetWidth != null && intrinsicWidth > 0)
             ? targetWidth! / intrinsicWidth
             : null;
-        final heightScale = targetHeight != null
+        final heightScale = (targetHeight != null && intrinsicHeight > 0)
             ? targetHeight! / intrinsicHeight
             : null;
         final double scale;

--- a/app/lib/util/cached_memory_image.dart
+++ b/app/lib/util/cached_memory_image.dart
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+import 'dart:math' as math;
 import 'dart:ui' as ui;
 
 import 'package:flutter/foundation.dart';
@@ -58,8 +59,25 @@ class CachedMemoryImage extends ImageProvider<CachedMemoryImage> {
     }
     return decode(
       buffer,
-      getTargetSize: (intrinsicWidth, intrinsicHeight) =>
-          ui.TargetImageSize(width: targetWidth, height: targetHeight),
+      getTargetSize: (intrinsicWidth, intrinsicHeight) {
+        final widthScale = targetWidth != null
+            ? targetWidth! / intrinsicWidth
+            : null;
+        final heightScale = targetHeight != null
+            ? targetHeight! / intrinsicHeight
+            : null;
+        final double scale;
+        if (widthScale != null && heightScale != null) {
+          scale = math.max(widthScale, heightScale);
+        } else {
+          scale = widthScale ?? heightScale!;
+        }
+        final clampedScale = math.min(scale, 1.0);
+        return ui.TargetImageSize(
+          width: (intrinsicWidth * clampedScale).round(),
+          height: (intrinsicHeight * clampedScale).round(),
+        );
+      },
     );
   }
 


### PR DESCRIPTION
Fixes a regression introduced in #1314. When both dimensions are given to the Flutter image decoder, it does _not_ preserve aspect ratio. Any non-square profile picture would therefore be squished into a square before entering the cache.