### PR TITLE
build: use SQLx offline queries by default

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -4,3 +4,6 @@
 
 [alias]
 xtask = "run -p xtask --"
+
+[env]
+SQLX_OFFLINE = "true"

--- a/justfile
+++ b/justfile
@@ -170,7 +170,8 @@ update-goldens-ci pr='':
 
 # Start the app in debug mode.
 [working-directory: 'app']
-run-app *args='': (flutter "run {{args}}")
+run-app *args='':
+    just flutter run {{args}}
 
 # Start the server.
 run-server:


### PR DESCRIPTION
By default, we always use the offline prepared queries for sqlx by
setting the `SQLX_OFFLINE` environment variable to `true` in the
`.cargo/config.toml` file.

When working with SQL queries on live databases, either uncomment this
configuration or export the `SQLX_OFFLINE` environment variable to
`false` in your shell.

Additionally, fix the `run-app` justfile command not taking additional
arguments.