### PR TITLE
fix(app): update leaf node extensions in APQ groups

### DIFF
--- a/apqmls/src/commit_builder.rs
+++ b/apqmls/src/commit_builder.rs
@@ -19,9 +19,9 @@ use tap::Pipe as _;
 use thiserror::Error;
 
 use crate::{
-    ApqMlsGroup, ApqMlsGroupMut,
+    ApqCiphersuite, ApqMlsGroup, ApqMlsGroupMut,
     authentication::ApqSigner,
-    extension::APQMLS_COMPONENT_ID,
+    extension::{APQMLS_COMPONENT_ID, ensure_leaf_node_parameters},
     messages::{ApqGroupInfo, ApqKeyPackage, ApqMlsMessageOut, ApqWelcome},
     psk::{ApqPskError, derive_and_store_psk},
 };
@@ -126,11 +126,13 @@ impl ConfigValues {
         if let Some(force) = self.force_self_update {
             builder = builder.force_self_update(force);
         }
-        if let Some(t_leaf_node_parameters) = &self.t_leaf_node_parameters {
-            builder = builder.leaf_node_parameters(t_leaf_node_parameters.clone());
-        }
-        if let Some(pq_leaf_node_parameters) = &self.pq_leaf_node_parameters {
-            builder = builder.leaf_node_parameters(pq_leaf_node_parameters.clone());
+        let leaf_node_parameters = if IS_TRADITIONAL {
+            &self.t_leaf_node_parameters
+        } else {
+            &self.pq_leaf_node_parameters
+        };
+        if let Some(leaf_node_parameters) = leaf_node_parameters {
+            builder = builder.leaf_node_parameters(leaf_node_parameters.clone());
         }
         let (t_kps, pq_kps): (Vec<_>, Vec<_>) = self
             .proposed_adds
@@ -251,12 +253,24 @@ impl<'a> CommitBuilder<'a> {
     ///
     /// TODO: Split this up to enable sans-io usage.
     pub fn finalize<S: ApqSigner, Provider: OpenMlsProvider>(
-        self,
+        mut self,
         provider: &Provider,
         signer: &S,
         t_f: impl FnMut(&QueuedProposal) -> bool,
         pq_f: impl FnMut(&QueuedProposal) -> bool,
     ) -> Result<ApqCommitMessageBundle, CreateCommitError<Provider::StorageError>> {
+        // Augment the configured leaf node parameters with the support required in an APQMLS group
+        let apq_ciphersuite = ApqCiphersuite::new(
+            self.group.t_group.ciphersuite(),
+            self.group.pq_group.ciphersuite(),
+        );
+        if let Some(params) = &mut self.values.t_leaf_node_parameters {
+            *params = ensure_leaf_node_parameters(params, apq_ciphersuite)?;
+        }
+        if let Some(params) = &mut self.values.pq_leaf_node_parameters {
+            *params = ensure_leaf_node_parameters(params, apq_ciphersuite)?;
+        }
+
         let mut apq_info = self
             .group
             .apq_info()

--- a/apqmls/src/extension.rs
+++ b/apqmls/src/extension.rs
@@ -7,13 +7,16 @@ use openmls::{
     group::{GroupContext, GroupEpoch, GroupId},
     prelude::{
         AppDataDictionary, AppDataDictionaryExtension, Capabilities, Ciphersuite, Extension,
-        ExtensionType, Extensions, LeafNode, ProposalType,
+        ExtensionType, Extensions, LeafNode, LeafNodeParameters, ProposalType,
     },
 };
 use tap::Pipe;
 use tls_codec::{Deserialize as _, Serialize as _, TlsDeserialize, TlsSerialize, TlsSize};
 
-use crate::{ApqCiphersuite, ApqGroupId, ApqMlsGroup, ApqMlsGroupMut};
+use crate::{
+    ApqCiphersuite, ApqGroupId, ApqMlsGroup, ApqMlsGroupMut,
+    key_package::ensure_ciphersuite_support,
+};
 
 /// The component ID of the APQMLS component.
 ///
@@ -153,6 +156,32 @@ pub(super) fn ensure_leaf_node_component_support(
         .add_or_replace(extension)
         .expect("logic error: extension is valid");
     Ok(extensions)
+}
+
+/// Augments the capabilities and extensions of the given leaf node parameters with the support
+/// required in an APQMLS group.
+pub(super) fn ensure_leaf_node_parameters(
+    params: &LeafNodeParameters,
+    apq_ciphersuite: ApqCiphersuite,
+) -> Result<LeafNodeParameters, tls_codec::Error> {
+    let capabilities = params
+        .capabilities()
+        .cloned()
+        .unwrap_or_default()
+        .pipe(ensure_extension_support)?
+        .pipe(|c| ensure_ciphersuite_support(c, apq_ciphersuite))?;
+    let ln_extensions = params
+        .extensions()
+        .cloned()
+        .unwrap_or_default()
+        .pipe(ensure_leaf_node_component_support)?;
+    let mut builder = LeafNodeParameters::builder()
+        .with_capabilities(capabilities)
+        .with_extensions(ln_extensions);
+    if let Some(credential_with_key) = params.credential_with_key() {
+        builder = builder.with_credential_with_key(credential_with_key.clone());
+    };
+    Ok(builder.build())
 }
 
 impl ApqMlsGroup {

--- a/apqmls/tests/basic.rs
+++ b/apqmls/tests/basic.rs
@@ -6,8 +6,12 @@ use apqmls::{
     ApqMlsGroup, authentication::ApqSigner, extension::PqtMode, messages::ApqMlsMessageIn,
 };
 use openmls::{
-    group::{GroupId, MlsGroupJoinConfig},
-    prelude::{Credential, LeafNodeIndex, MlsMessageIn, OpenMlsProvider, ProcessedMessageContent},
+    group::{GroupId, MlsGroup, MlsGroupJoinConfig},
+    prelude::{
+        Capabilities, Credential, Extension, ExtensionType, Extensions, LeafNodeIndex,
+        LeafNodeParameters, MlsMessageIn, OpenMlsProvider, ProcessedMessageContent,
+        UnknownExtension,
+    },
 };
 use openmls_rust_crypto::OpenMlsRustCrypto;
 use tls_codec::{Deserialize as _, Serialize};
@@ -134,6 +138,76 @@ fn update_group() {
     for ciphersuite in TEST_MODE {
         let joined_group = join_group_helper(ciphersuite);
         update_group_helper(joined_group);
+    }
+}
+
+/// The T and PQ leaf node parameters must each be applied to their own group,
+/// not swapped or overwritten by one another.
+#[test]
+fn update_with_leaf_node_parameters() {
+    const MARKER_EXTENSION_TYPE: u16 = 0xff00;
+
+    // The marker extension must be advertised in the capabilities; all other
+    // APQMLS-specific support is augmented by the commit builder.
+    fn marker_parameters(data: &[u8]) -> LeafNodeParameters {
+        let extension = Extension::Unknown(MARKER_EXTENSION_TYPE, UnknownExtension(data.to_vec()));
+        LeafNodeParameters::builder()
+            .with_capabilities(Capabilities::new(
+                None,
+                None,
+                Some(&[ExtensionType::Unknown(MARKER_EXTENSION_TYPE)]),
+                None,
+                None,
+            ))
+            .with_extensions(Extensions::from_vec(vec![extension]).unwrap())
+            .build()
+    }
+
+    fn marker(group: &MlsGroup) -> &[u8] {
+        &group
+            .own_leaf_node()
+            .unwrap()
+            .extensions()
+            .unknown(MARKER_EXTENSION_TYPE)
+            .unwrap()
+            .0
+    }
+
+    for mode in TEST_MODE {
+        let JoinedGroup {
+            alice,
+            bob,
+            mut alice_group,
+            mut bob_group,
+        } = join_group_helper(mode);
+
+        // Alice does an update with distinguishable leaf node parameters
+        let alice_commit_bundle = alice_group
+            .commit_builder()
+            .force_self_update(true)
+            .leaf_node_parameters(marker_parameters(b"t"), marker_parameters(b"pq"))
+            .finalize(&alice.provider, &alice.signer, |_| true, |_| true)
+            .unwrap();
+        alice_group.merge_pending_commit(&alice.provider).unwrap();
+
+        // Each group's new leaf carries its own parameters
+        assert_eq!(marker(&alice_group.t_group), b"t".as_slice());
+        assert_eq!(marker(alice_group.pq_group()), b"pq".as_slice());
+
+        // Bob processes Alice's update
+        let message_in = ApqMlsMessageIn::try_from(alice_commit_bundle.commit).unwrap();
+        let protocol_message = message_in.into_protocol_message().unwrap();
+        let processed_message = bob_group
+            .process_message(&bob.provider, protocol_message, compare_credentials)
+            .unwrap();
+        bob_group
+            .merge_staged_commit(
+                &bob.provider,
+                processed_message.into_staged_commit().unwrap(),
+            )
+            .unwrap();
+
+        assert_groups_eq(&mut alice_group, &mut bob_group);
     }
 }
 

--- a/coreclient/src/groups/mod.rs
+++ b/coreclient/src/groups/mod.rs
@@ -1800,10 +1800,23 @@ impl Group {
         .tls_serialize_detached()?;
         self.mls_group.set_aad(aad);
 
+        let t_own_leaf_node = self.mls_group.own_leaf_node().context("No own leaf node")?;
+        let t_leaf_node_parameters =
+            Self::update_leaf_node_extensions(t_own_leaf_node.extensions())?;
+        let pq_own_leaf_node = self
+            .pq()
+            .context("No PQ group found")?
+            .mls_group
+            .own_leaf_node()
+            .context("No own PQ leaf node")?;
+        let pq_leaf_node_parameters =
+            Self::update_leaf_node_extensions(pq_own_leaf_node.extensions())?;
+
         let provider = AirOpenMlsProvider::new(txn.as_mut());
         let (t_mls_group, pq_mls_group) = self.apq_mls_groups_mut()?;
         let bundle = apqmls::commit_builder::CommitBuilder::from_groups(t_mls_group, pq_mls_group)
             .force_self_update(true)
+            .leaf_node_parameters(t_leaf_node_parameters, pq_leaf_node_parameters)
             .create_group_info(true)
             .finalize(&provider, signer, |_| true, |_| true)?;
 


### PR DESCRIPTION
APQ update now refreshes leaf node parameters for both T and PQ groups
using the same helper that traditional update uses. In particular, air
features and other app component changes now propagate on APQ self-updates.

Additionally, fix 2 bugs in apqmls:

1. Leaf node parameters where applied sequentially to T and PQ MLS
   groups, so the PQ params would have silently overwritten the T
   params.
2. Commit builder now normalizes caller-provided leaf-node parameters
   the same way the other apqmls builders do.