### PR TITLE
fix(app): add guard against concurrent group creation

### DIFF
--- a/app/lib/chat/create_group_screen.dart
+++ b/app/lib/chat/create_group_screen.dart
@@ -380,7 +380,8 @@ class _CreateGroupDetailsStep extends HookWidget {
     Uint8List? picture,
     bool isApq,
   ) async {
-    if (groupName.isEmpty) return;
+    if (groupName.isEmpty || isCreating.value) return;
+
     final navigationCubit = context.read<NavigationCubit>();
     final userCubit = context.read<UserCubit>();
     final addMembersCubit = context.read<AddMembersCubit>();


### PR DESCRIPTION
The existing guard is checked when the widget builds, not when the button is tapped, allowing a nervous user (like me) to click the button many times if the UI lags.