### PR TITLE
refactor(app): no need to add aad to PQ group in delete/invite

### DIFF
--- a/coreclient/src/groups/mod.rs
+++ b/coreclient/src/groups/mod.rs
@@ -1357,7 +1357,6 @@ impl Group {
         });
         let aad = AadMessage::from(aad_payload).tls_serialize_detached()?;
         t_mls_group.set_aad(aad.clone());
-        pq_mls_group.set_aad(aad);
 
         let bundle = apqmls::commit_builder::CommitBuilder::from_groups(t_mls_group, pq_mls_group)
             .force_self_update(true)
@@ -1444,7 +1443,6 @@ impl Group {
         let aad_payload = AadPayload::DeleteGroup;
         let aad = AadMessage::from(aad_payload).tls_serialize_detached()?;
         t_group.set_aad(aad.clone());
-        pq_group.set_aad(aad);
 
         let bundle = apqmls::commit_builder::CommitBuilder::from_groups(t_group, pq_group)
             .force_self_update(true)

--- a/coreclient/src/groups/mod.rs
+++ b/coreclient/src/groups/mod.rs
@@ -1356,7 +1356,7 @@ impl Group {
             new_encrypted_user_profile_keys: Vec::new(),
         });
         let aad = AadMessage::from(aad_payload).tls_serialize_detached()?;
-        t_mls_group.set_aad(aad.clone());
+        t_mls_group.set_aad(aad);
 
         let bundle = apqmls::commit_builder::CommitBuilder::from_groups(t_mls_group, pq_mls_group)
             .force_self_update(true)
@@ -1442,7 +1442,7 @@ impl Group {
 
         let aad_payload = AadPayload::DeleteGroup;
         let aad = AadMessage::from(aad_payload).tls_serialize_detached()?;
-        t_group.set_aad(aad.clone());
+        t_group.set_aad(aad);
 
         let bundle = apqmls::commit_builder::CommitBuilder::from_groups(t_group, pq_group)
             .force_self_update(true)


### PR DESCRIPTION
The empty list of newly encrypted user profiles is only needed in the T group. This makes these operation aligned with the APQ update operation.