### PR TITLE
feat(app): resync APQ groups even if the local PQ group is missing

### DIFF
--- a/backend/src/ds/group_state/mod.rs
+++ b/backend/src/ds/group_state/mod.rs
@@ -18,6 +18,7 @@ use aircommon::{
     messages::client_ds::WelcomeInfoParams,
     time::TimeStamp,
 };
+use apqmls::extension::ApqInfo;
 use mimi_room_policy::{MimiProposal, RoleIndex, VerifiedRoomState};
 use mls_assist::{
     MlsAssistRustCrypto,
@@ -129,6 +130,13 @@ impl DsGroupState {
         VerifiableClientCredential::from_basic_credential(leaf.credential())
             .map_err(|error| error!(%error, "Credential is invalid"))
             .ok()
+    }
+
+    /// Returns true if the group context carries the APQMLS component, i.e. this group is a leg of
+    /// an APQ group.
+    pub(crate) fn is_apq(&self) -> bool {
+        let extensions = self.group().group_info().group_context().extensions();
+        ApqInfo::from_extensions(extensions).is_ok_and(|info| info.is_some())
     }
 
     /// Get a reference to the public group state.

--- a/backend/src/ds/grpc.rs
+++ b/backend/src/ds/grpc.rs
@@ -1163,6 +1163,14 @@ impl<Qep: QsConnector, As: AsConnector> DeliveryService for GrpcDs<Qep, As> {
                     ..
                 } = verified_data;
 
+                // A T-only resync of an APQ group would leave the PQ group with a stale leaf and
+                // strip the sender's local PQ state.
+                if group_state.is_apq() {
+                    return Err(Status::failed_precondition(
+                        "APQ group requires an APQ resync",
+                    ));
+                }
+
                 let destination_clients: Vec<_> = group_state
                     .other_destination_clients(sender_index)
                     .collect();

--- a/coreclient/src/clients/process/process_qs.rs
+++ b/coreclient/src/clients/process/process_qs.rs
@@ -471,7 +471,7 @@ impl CoreUser {
                 processed_message, ..
             }) => processed_message,
             ProcessMessageResult::Ignored => return Ok(ProcessQsMessageResult::None),
-            ProcessMessageResult::TooDistant => {
+            ProcessMessageResult::ResyncRequired => {
                 // TODO: Once we have a UX for resyncs, we should schedule one
                 // here and re-enable the resync test in integration.rs
                 let _resync = Resync {
@@ -566,7 +566,7 @@ impl CoreUser {
         {
             ProcessMessageResult::Processed(process_message_result) => process_message_result,
             ProcessMessageResult::Ignored => return Ok(ProcessQsMessageResult::None),
-            ProcessMessageResult::TooDistant => {
+            ProcessMessageResult::ResyncRequired => {
                 // TODO: Once we have a UX for resyncs, we should schedule one
                 // here and re-enable the resync test in integration.rs
                 let _resync = Resync {
@@ -641,7 +641,7 @@ impl CoreUser {
         {
             ProcessMessageResult::Processed(processed) => processed,
             ProcessMessageResult::Ignored => return Ok(ProcessQsMessageResult::None),
-            ProcessMessageResult::TooDistant => {
+            ProcessMessageResult::ResyncRequired => {
                 // TODO: Once we have a UX for resyncs, we should schedule one
                 // here and re-enable the resync test in integration.rs
                 let _resync = Resync {

--- a/coreclient/src/clients/process/process_qs.rs
+++ b/coreclient/src/clients/process/process_qs.rs
@@ -477,7 +477,7 @@ impl CoreUser {
                 let _resync = Resync {
                     chat_id: chat.id(),
                     group_id: group.group_id().clone(),
-                    pq_group_id: group.pq().map(|pq| pq.group_id().clone()),
+                    pq_group_id: group.pq_group_id(),
                     group_state_ear_key: group.group_state_ear_key().clone(),
                     identity_link_wrapper_key: group.identity_link_wrapper_key().clone(),
                     original_leaf_index: group.own_index(),
@@ -572,7 +572,7 @@ impl CoreUser {
                 let _resync = Resync {
                     chat_id,
                     group_id: group.group_id().clone(),
-                    pq_group_id: group.pq().map(|pq| pq.group_id().clone()),
+                    pq_group_id: group.pq_group_id(),
                     group_state_ear_key: group.group_state_ear_key().clone(),
                     identity_link_wrapper_key: group.identity_link_wrapper_key().clone(),
                     original_leaf_index: group.own_index(),
@@ -647,7 +647,7 @@ impl CoreUser {
                 let _resync = Resync {
                     chat_id,
                     group_id: group.group_id().clone(),
-                    pq_group_id: group.pq().map(|pq| pq.group_id().clone()),
+                    pq_group_id: group.pq_group_id(),
                     group_state_ear_key: group.group_state_ear_key().clone(),
                     identity_link_wrapper_key: group.identity_link_wrapper_key().clone(),
                     original_leaf_index: group.own_index(),

--- a/coreclient/src/clients/test_utils.rs
+++ b/coreclient/src/clients/test_utils.rs
@@ -95,7 +95,7 @@ impl CoreUser {
         let resync = Resync {
             chat_id,
             group_id: fake_group_id,
-            pq_group_id: group.pq().map(|pq| pq.group_id().clone()),
+            pq_group_id: group.pq_group_id(),
             group_state_ear_key: group.group_state_ear_key().clone(),
             identity_link_wrapper_key: group.identity_link_wrapper_key().clone(),
             original_leaf_index: group.own_index(),

--- a/coreclient/src/groups/mod.rs
+++ b/coreclient/src/groups/mod.rs
@@ -17,6 +17,7 @@ pub(crate) mod process;
 use apqmls::{
     authentication::ApqCredentialWithKey,
     commit_builder::ApqCommitMessageBundle,
+    extension::ApqInfo,
     external_commit_builder::{ApqExternalCommitBuilder, ApqExternalCommitBuilderError},
     messages::{ApqProposalIn, ApqRatchetTreeIn, VerifiableApqGroupInfo},
 };
@@ -318,6 +319,17 @@ impl Group {
 
     pub(crate) fn pq(&self) -> Option<&PqGroup> {
         self.pq.as_ref()
+    }
+
+    /// Returns the PQ group ID of this group, if it is an APQ group.
+    ///
+    /// The ID is read from the APQMLS component in the T group's context extensions, so it is
+    /// available even when the local PQ group state is missing (e.g. after a legacy T-only resync).
+    pub(crate) fn pq_group_id(&self) -> Option<GroupId> {
+        let info = ApqInfo::from_extensions(self.mls_group.extensions())
+            .inspect_err(|error| error!(%error, "Failed to parse APQMLS component"))
+            .ok()??;
+        Some(info.pq_session_group_id)
     }
 
     pub(crate) fn pq_mut(&mut self) -> Option<&mut PqGroup> {

--- a/coreclient/src/groups/process.rs
+++ b/coreclient/src/groups/process.rs
@@ -32,7 +32,7 @@ use openmls::{
 };
 use openmls_traits::OpenMlsProvider;
 use tls_codec::DeserializeBytes as TlsDeserializeBytes;
-use tracing::{debug, instrument};
+use tracing::{debug, instrument, warn};
 
 use crate::{
     clients::api_clients::ApiClients, db::access::WriteDbTransaction,
@@ -46,7 +46,9 @@ pub(crate) enum ProcessMessageResult {
     Processed(ProcessMessageProcessed),
     /// This message was skipped because we have processed it (or its side-effect) already.
     Ignored,
-    /// We got a message that's too far in the future, and there's nothing we can do about it.
+    /// We got a message that we can't process from our current group state, e.g. because it's too
+    /// far in the future or because the local PQ group state is missing. Only a resync can recover
+    /// the group.
     TooDistant,
 }
 
@@ -670,6 +672,15 @@ impl Group {
         api_clients: &ApiClients,
         message: impl Into<ApqProtocolMessage>,
     ) -> Result<ProcessMessageResult> {
+        if self.pq.is_none() {
+            // The local PQ group state is missing, e.g. because a legacy
+            // T-only resync dropped it. We can't process any APQ message in
+            // this state, but a resync restores both legs, so report the
+            // message as too distant instead of failing.
+            warn!("No local PQ group state; a resync is required");
+            return Ok(ProcessMessageResult::TooDistant);
+        }
+
         let message: ApqProtocolMessage = message.into();
         let message_t_epoch = message.t_epoch();
         let current_t_epoch = self.mls_group.epoch();

--- a/coreclient/src/groups/process.rs
+++ b/coreclient/src/groups/process.rs
@@ -49,7 +49,7 @@ pub(crate) enum ProcessMessageResult {
     /// We got a message that we can't process from our current group state, e.g. because it's too
     /// far in the future or because the local PQ group state is missing. Only a resync can recover
     /// the group.
-    TooDistant,
+    ResyncRequired,
 }
 
 pub(crate) struct ProcessMessageProcessed {
@@ -106,7 +106,7 @@ impl Group {
                     }
                     // If the message epoch is in the future, we need to re-join
                     // the group.
-                    return Ok(ProcessMessageResult::TooDistant);
+                    return Ok(ProcessMessageResult::ResyncRequired);
                 }
                 Err(e) => {
                     bail!("Could not process message: {e:?}");
@@ -678,7 +678,7 @@ impl Group {
             // this state, but a resync restores both legs, so report the
             // message as too distant instead of failing.
             warn!("No local PQ group state; a resync is required");
-            return Ok(ProcessMessageResult::TooDistant);
+            return Ok(ProcessMessageResult::ResyncRequired);
         }
 
         let message: ApqProtocolMessage = message.into();
@@ -713,7 +713,7 @@ impl Group {
                 }
                 // A future-epoch message means we are behind and the caller
                 // must trigger a resync.
-                return Ok(ProcessMessageResult::TooDistant);
+                return Ok(ProcessMessageResult::ResyncRequired);
             }
             Err(e) => {
                 return Err(e).context("Failed to process APQ message");

--- a/coreclient/src/outbound_service/resync.rs
+++ b/coreclient/src/outbound_service/resync.rs
@@ -48,7 +48,7 @@ impl CoreUser {
         let resync = Resync {
             chat_id,
             group_id: group.group_id().clone(),
-            pq_group_id: group.pq().map(|pq| pq.group_id().clone()),
+            pq_group_id: group.pq_group_id(),
             group_state_ear_key: group.group_state_ear_key().clone(),
             identity_link_wrapper_key: group.identity_link_wrapper_key().clone(),
             original_leaf_index: group.own_index(),


### PR DESCRIPTION
We now check whether the group is an APQ group via it ApqInfo extension.

Additionally, reject T resyncs of APQ groups on the server.