### PR TITLE
feat(server): fan-out messages to sender if it carries virtual-client data in its leaf

### DIFF
--- a/backend/src/ds/group_state/mod.rs
+++ b/backend/src/ds/group_state/mod.rs
@@ -23,6 +23,7 @@ use mls_assist::{
     MlsAssistRustCrypto,
     group::Group,
     openmls::{
+        components::vc_derivation_info::VC_COMPONENT_ID,
         group::GroupId,
         prelude::{GroupEpoch, LeafNodeIndex},
         treesync::RatchetTree,
@@ -203,15 +204,24 @@ impl DsGroupState {
         &self,
         sender_index: LeafNodeIndex,
     ) -> impl Iterator<Item = QsReference> {
+        let is_sender_virtual_client = self.leaf_is_virtual_client(sender_index);
         self.member_profiles
             .iter()
             .filter_map(move |(client_index, client_profile)| {
-                if client_index == &sender_index {
-                    None
-                } else {
+                if client_index != &sender_index || is_sender_virtual_client {
                     Some(client_profile.client_queue_config.clone())
+                } else {
+                    None
                 }
             })
+    }
+
+    /// Returns `true` if the leaf declares a `VC_COMPONENT_ID` entry in its `AppDataDictionary` extension.
+    pub(crate) fn leaf_is_virtual_client(&self, leaf_index: LeafNodeIndex) -> bool {
+        self.group()
+            .leaf(leaf_index)
+            .and_then(|leaf| leaf.extensions().app_data_dictionary())
+            .is_some_and(|dict| dict.dictionary().contains(&VC_COMPONENT_ID))
     }
 
     pub(crate) fn qs_client_ref_by_index(


### PR DESCRIPTION
This is basically a cheap test whether virtual-clients have been enabled in this sender's leaf. That way we also avoid testing how this feature breaks existing older clients.