### PR TITLE
feat(app): reaction chips animations

### DIFF
--- a/app/lib/message_list/message_reactions.dart
+++ b/app/lib/message_list/message_reactions.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 
 import 'package:air/ds/components/button/glass_circle_button.dart';
 import 'package:air/ds/foundations/elevation.dart';
+import 'package:air/ds/foundations/motion.dart';
 import 'package:air/l10n/l10n.dart';
 import 'package:air/user/users_cubit.dart';
 import 'package:flutter/material.dart';
@@ -104,9 +105,12 @@ const double reactionTabHeight = 36;
 ///
 /// The chips overlap the bubble's bottom by [reactionsMessageBubbleOverlap] and the layout
 /// reserves the chips' protruding height (plus a small gap) below the bubble so
-/// following messages don't collide. Returns [bubble] unchanged when there are
-/// no reactions.
-class BubbleWithReactions extends StatelessWidget {
+/// following messages don't collide.
+///
+/// The reserve and the chips animate in when the first reaction arrives and
+/// out when the last one is removed. Tiles that mount with reactions render
+/// the settled state without animating.
+class BubbleWithReactions extends StatefulWidget {
   const BubbleWithReactions({
     super.key,
     required this.bubble,
@@ -123,31 +127,105 @@ class BubbleWithReactions extends StatelessWidget {
   final void Function(String? emoji) onTap;
 
   @override
-  Widget build(BuildContext context) {
-    if (reactions.isEmpty) {
-      return bubble;
+  State<BubbleWithReactions> createState() => _BubbleWithReactionsState();
+}
+
+class _BubbleWithReactionsState extends State<BubbleWithReactions>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+  late final Animation<double> _reveal;
+  late final Animation<double> _chipScale;
+
+  /// Last non-empty reactions, kept while the chips animate out.
+  List<UiReaction> _reactions = const [];
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      vsync: this,
+      duration: motionShort,
+      value: widget.reactions.isEmpty ? 0.0 : 1.0,
+    );
+    _controller.addStatusListener(_onStatusChanged);
+    _reveal = CurvedAnimation(
+      parent: _controller,
+      curve: motionEasing,
+      // Mirrored so removal collapses the reserve in sync with the
+      // AnimatedPaddings tracking it in the message tile.
+      reverseCurve: const FlippedCurve(motionEasing),
+    );
+    _chipScale = Tween<double>(begin: 0.6, end: 1.0).animate(_reveal);
+    if (widget.reactions.isNotEmpty) {
+      _reactions = widget.reactions;
     }
+  }
+
+  void _onStatusChanged(AnimationStatus status) {
+    // Drop the stale chips once the exit animation settled.
+    if (status == AnimationStatus.dismissed && widget.reactions.isEmpty) {
+      setState(() => _reactions = const []);
+    }
+  }
+
+  @override
+  void didUpdateWidget(covariant BubbleWithReactions oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.reactions.isNotEmpty) {
+      _reactions = widget.reactions;
+      _controller.forward();
+    } else if (oldWidget.reactions.isNotEmpty) {
+      _controller.reverse();
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // Constant Stack/Padding structure so the first reaction doesn't
+    // reparent the bubble subtree (which would drop its state).
     return Stack(
       clipBehavior: Clip.none,
       children: [
-        Padding(
-          // reactions is non-empty here, so reserve the chips' protrusion.
-          padding: EdgeInsets.only(
-            bottom: reactionsReservedBelow(context, true),
+        AnimatedBuilder(
+          animation: _reveal,
+          builder: (context, child) => Padding(
+            padding: EdgeInsets.only(
+              bottom: reactionsReservedBelow(context, true) * _reveal.value,
+            ),
+            child: child,
           ),
-          child: bubble,
+          child: widget.bubble,
         ),
-        Positioned(
-          bottom: reactionsGapBelow,
-          left: reactionsHorizontalInset,
-          right: reactionsHorizontalInset,
-          child: MessageReactions(
-            reactions: reactions,
-            isSender: isSender,
-            ownUserId: ownUserId,
-            onTap: onTap,
+        if (_reactions.isNotEmpty)
+          Positioned(
+            bottom: reactionsGapBelow,
+            left: reactionsHorizontalInset,
+            right: reactionsHorizontalInset,
+            // Pinned to the Stack's bottom: the chips slide out of the
+            // bubble's edge while the reserve grows.
+            child: IgnorePointer(
+              ignoring: widget.reactions.isEmpty,
+              child: FadeTransition(
+                opacity: _reveal,
+                child: ScaleTransition(
+                  scale: _chipScale,
+                  alignment: Alignment.bottomLeft,
+                  child: MessageReactions(
+                    reactions: _reactions,
+                    isSender: widget.isSender,
+                    ownUserId: widget.ownUserId,
+                    onTap: widget.onTap,
+                  ),
+                ),
+              ),
+            ),
           ),
-        ),
       ],
     );
   }
@@ -554,11 +632,43 @@ class _QuickReactionBarLayoutDelegate extends SingleChildLayoutDelegate {
       oldDelegate.anchorRect != anchorRect || oldDelegate.safeArea != safeArea;
 }
 
-class _QuickReactionButton extends StatelessWidget {
+class _QuickReactionButton extends StatefulWidget {
   const _QuickReactionButton({required this.emoji, required this.onTap});
 
   final String emoji;
   final VoidCallback onTap;
+
+  @override
+  State<_QuickReactionButton> createState() => _QuickReactionButtonState();
+}
+
+class _QuickReactionButtonState extends State<_QuickReactionButton>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _pulse;
+  late final Animation<double> _scale;
+
+  @override
+  void initState() {
+    super.initState();
+    _pulse = AnimationController(vsync: this, duration: motionShort);
+    _scale = TweenSequence<double>([
+      TweenSequenceItem(tween: Tween(begin: 1.0, end: 1.25), weight: 40),
+      TweenSequenceItem(tween: Tween(begin: 1.25, end: 1.0), weight: 60),
+    ]).animate(_pulse);
+  }
+
+  @override
+  void dispose() {
+    _pulse.dispose();
+    super.dispose();
+  }
+
+  void _handleTap() {
+    // The pulse plays while the bar fades out.
+    HapticFeedback.lightImpact();
+    _pulse.forward(from: 0);
+    widget.onTap();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -566,14 +676,17 @@ class _QuickReactionButton extends StatelessWidget {
       cursor: SystemMouseCursors.click,
       child: GestureDetector(
         behavior: HitTestBehavior.opaque,
-        onTap: onTap,
+        onTap: _handleTap,
         child: SizedBox(
           width: quickReactionBarTapSize,
           height: quickReactionBarTapSize,
           child: Center(
-            child: CenteredEmoji(
-              emoji: emoji,
-              style: const TextStyle(fontSize: quickReactionBarGlyphSize),
+            child: ScaleTransition(
+              scale: _scale,
+              child: CenteredEmoji(
+                emoji: widget.emoji,
+                style: const TextStyle(fontSize: quickReactionBarGlyphSize),
+              ),
             ),
           ),
         ),

--- a/app/lib/message_list/mobile_message_actions.dart
+++ b/app/lib/message_list/mobile_message_actions.dart
@@ -41,6 +41,11 @@ Future<void> showMobileMessageActions({
   void Function(String emoji)? onReact,
   VoidCallback? onReactMore,
 }) {
+  // Deliver a picked reaction only after the exit transition settled.
+  // Mutating the message earlier would relayout the list while the bubble
+  // copy flies back and make it land off target.
+  String? pickedEmoji;
+  var exitListenerAttached = false;
   return showGeneralDialog(
     context: context,
     barrierDismissible: true,
@@ -50,6 +55,14 @@ Future<void> showMobileMessageActions({
     pageBuilder: (context, animation, secondaryAnimation) =>
         const SizedBox.shrink(),
     transitionBuilder: (dialogContext, animation, secondaryAnimation, child) {
+      if (!exitListenerAttached) {
+        exitListenerAttached = true;
+        animation.addStatusListener((status) {
+          if (status == AnimationStatus.dismissed && pickedEmoji != null) {
+            onReact?.call(pickedEmoji!);
+          }
+        });
+      }
       final curvedAnimation = CurvedAnimation(
         parent: animation,
         curve: Curves.easeOutCubic,
@@ -62,7 +75,7 @@ Future<void> showMobileMessageActions({
         messageContent: messageContent,
         alignEnd: alignEnd,
         reactionSkinTone: reactionSkinTone,
-        onReact: onReact,
+        onReact: onReact == null ? null : (emoji) => pickedEmoji = emoji,
         onReactMore: onReactMore,
       );
       final defaultTextStyle = DefaultTextStyle.of(context);
@@ -244,8 +257,10 @@ class _MobileMessageActionView extends StatelessWidget {
                     skinTone: reactionSkinTone,
                     showShadow: false,
                     onReact: (emoji) {
-                      Navigator.of(context).pop();
+                      // Delivered after the exit transition, see
+                      // [showMobileMessageActions].
                       onReact!(emoji);
+                      Navigator.of(context).pop();
                     },
                     onMore: () {
                       Navigator.of(context).pop();

--- a/app/lib/message_list/text_message_tile.dart
+++ b/app/lib/message_list/text_message_tile.dart
@@ -19,6 +19,7 @@ import 'package:air/message_list/message_reactions.dart';
 import 'package:air/message_list/mobile_message_actions.dart';
 import 'package:air/message_list/timestamp.dart';
 import 'package:air/navigation/navigation.dart';
+import 'package:air/ds/foundations/motion.dart';
 import 'package:air/ds/theme/theme.dart';
 import 'package:air/ds/foundations/themes.dart';
 import 'package:air/ds/components/button/button.dart';
@@ -250,7 +251,10 @@ class _IncomingMessageTile extends StatelessWidget {
         Row(
           crossAxisAlignment: CrossAxisAlignment.end,
           children: [
-            Padding(
+            AnimatedPadding(
+              // Tracks the animated reserve in [BubbleWithReactions].
+              duration: motionShort,
+              curve: motionEasing,
               padding: EdgeInsets.only(
                 bottom: reactionsReservedBelow(context, reactions.isNotEmpty),
               ),
@@ -391,6 +395,8 @@ class _MessageView extends HookWidget {
     Rect? reactionAnchorRect() => globalRectOf(messageBubbleKey);
 
     void sendReaction(String emoji) {
+      // May run after the reaction overlay's exit transition.
+      if (!context.mounted) return;
       context.read<ChatDetailsCubit>().sendReaction(
         messageId: messageId,
         emoji: emoji,
@@ -759,8 +765,11 @@ class _MessageView extends HookWidget {
     );
 
     // Padded at the bottom by the chip reserve so the trailing-affordance Row
-    // centers it on the bubble itself (not the bubble + reaction chips).
-    final hoverAffordance = Padding(
+    // centers it on the bubble itself (not the bubble + reaction chips),
+    // in sync with the animated reserve in [BubbleWithReactions].
+    final hoverAffordance = AnimatedPadding(
+      duration: motionShort,
+      curve: motionEasing,
       padding: EdgeInsets.only(
         bottom: reactionsReservedBelow(context, reactions.isNotEmpty),
         left: isSender ? 0 : Spacing.px8,

--- a/app/test/message_list/mobile_message_actions_test.dart
+++ b/app/test/message_list/mobile_message_actions_test.dart
@@ -245,5 +245,51 @@ void main() {
         matchesGoldenFile('goldens/message_list_mobile_actions.png'),
       );
     });
+
+    testWidgets('defers a picked reaction until the overlay is dismissed', (
+      tester,
+    ) async {
+      tester.view.physicalSize = _testSize;
+      addTearDown(() {
+        tester.view.resetPhysicalSize();
+      });
+
+      when(
+        () => chatDetailsCubit.sendReaction(
+          messageId: any(named: 'messageId'),
+          emoji: any(named: 'emoji'),
+        ),
+      ).thenAnswer((_) async {});
+
+      await tester.pumpWidget(buildSubject());
+      await tester.pump();
+
+      final messageFinder = find.text("Hello Alice, it's Bob");
+      await tester.longPress(messageFinder);
+      await tester.pumpAndSettle();
+
+      // The bar emoji is a painted glyph, not a Text, find it via semantics.
+      final semantics = tester.ensureSemantics();
+      await tester.tap(find.bySemanticsLabel(RegExp('👍')));
+      semantics.dispose();
+      await tester.pump();
+
+      // Not delivered while the exit transition is still running.
+      verifyNever(
+        () => chatDetailsCubit.sendReaction(
+          messageId: any(named: 'messageId'),
+          emoji: any(named: 'emoji'),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      verify(
+        () => chatDetailsCubit.sendReaction(
+          messageId: 1.messageId(),
+          emoji: '👍',
+        ),
+      ).called(1);
+    });
   });
 }


### PR DESCRIPTION
Add some animation around reaction chips and resolves the issue that moved messages on mobile would not snap back to the right location.