### PR TITLE
refactor(app): unify key package upload into a single task

### DIFF
--- a/coreclient/.sqlx/query-0664efa3913294bd3da2f96945efd109a219f13cddc4e5f0d7dcea8123a3659d.json
+++ b/coreclient/.sqlx/query-0664efa3913294bd3da2f96945efd109a219f13cddc4e5f0d7dcea8123a3659d.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "DELETE FROM key_package WHERE key_package_ref NOT IN (\n            SELECT key_package_ref FROM key_package_refs\n            UNION\n            SELECT key_package_ref FROM apq_key_package_refs\n        )",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 0
+    },
+    "nullable": []
+  },
+  "hash": "0664efa3913294bd3da2f96945efd109a219f13cddc4e5f0d7dcea8123a3659d"
+}

--- a/coreclient/src/clients/debug_info.rs
+++ b/coreclient/src/clients/debug_info.rs
@@ -91,7 +91,6 @@ impl TimedTaskKind {
     fn display_name(&self) -> &'static str {
         match self {
             TimedTaskKind::KeyPackageUpload => "Key Package Upload",
-            TimedTaskKind::ApqKeyPackageUpload => "APQ Key Package Upload",
             TimedTaskKind::UsernameRefresh => "Username Refresh",
             TimedTaskKind::SelfUpdate => "Self Update",
             TimedTaskKind::TokenReplenishment { operation_type } => match operation_type {

--- a/coreclient/src/key_stores/key_package_refs.rs
+++ b/coreclient/src/key_stores/key_package_refs.rs
@@ -1,0 +1,208 @@
+// SPDX-FileCopyrightText: 2026 Phoenix R&D GmbH <hello@phnx.im>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+use openmls::prelude::KeyPackageRef;
+use sqlx::{AssertSqlSafe, QueryBuilder};
+
+use crate::{
+    db::access::{WriteConnection, WriteDbTransaction},
+    groups::openmls_provider::KeyRefWrapper,
+};
+
+pub(crate) async fn mark_key_packages_as_live(
+    txn: &mut WriteDbTransaction<'_>,
+    key_package_refs: &[KeyPackageRef],
+    is_apq: bool,
+) -> anyhow::Result<()> {
+    let refs_table = if is_apq {
+        "apq_key_package_refs"
+    } else {
+        "key_package_refs"
+    };
+    mark_key_packages_as_live_impl(txn, refs_table, key_package_refs).await
+}
+
+async fn mark_key_packages_as_live_impl(
+    txn: &mut WriteDbTransaction<'_>,
+    refs_table: &'static str,
+    key_package_refs: &[KeyPackageRef],
+) -> anyhow::Result<()> {
+    // Delete all key packages that are not marked as live
+    sqlx::query(AssertSqlSafe(format!(
+        "DELETE FROM key_package
+            WHERE key_package_ref IN (
+              SELECT key_package_ref
+              FROM {refs_table}
+              WHERE is_live = 0
+            )"
+    )))
+    .execute(txn.as_mut())
+    .await?;
+
+    // Their refs are dead weight now; delete them explicitly instead of
+    // relying on the foreign key cascade.
+    sqlx::query(AssertSqlSafe(format!(
+        "DELETE FROM {refs_table} WHERE is_live = 0"
+    )))
+    .execute(txn.as_mut())
+    .await?;
+
+    // Mark all key packages as stale
+    sqlx::query(AssertSqlSafe(format!(
+        "UPDATE {refs_table}
+            SET is_live = 0
+            WHERE is_live = 1",
+    )))
+    .execute(txn.as_mut())
+    .await?;
+
+    if key_package_refs.is_empty() {
+        return Ok(());
+    }
+
+    // Add the newly uploaded ones as 'live'.
+    let mut qb = QueryBuilder::new(format!(
+        "INSERT INTO {refs_table} (key_package_ref, is_live) VALUES "
+    ));
+    let mut vals = qb.separated(", ");
+    for r in key_package_refs {
+        let r = KeyRefWrapper(r);
+        vals.push("(")
+            .push_bind_unseparated(r)
+            .push_unseparated(", 1)");
+    }
+    qb.build().execute(txn.as_mut()).await?;
+
+    Ok(())
+}
+
+/// Delete key packages not referenced in either refs table (usually a no-op).
+///
+/// Must only run after *both* the regular and the APQ refs of a batch are
+/// inserted: key package bundles are written to storage at generation time,
+/// before their refs are registered, so an early sweep would delete the not
+/// yet referenced half of the batch.
+pub(crate) async fn delete_orphaned_key_packages(
+    mut write: impl WriteConnection,
+) -> anyhow::Result<()> {
+    sqlx::query!(
+        "DELETE FROM key_package WHERE key_package_ref NOT IN (
+            SELECT key_package_ref FROM key_package_refs
+            UNION
+            SELECT key_package_ref FROM apq_key_package_refs
+        )",
+    )
+    .execute(write.as_mut())
+    .await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod test {
+    use aircommon::{
+        codec::PersistenceCodec, credentials::test_utils::create_test_credentials,
+        identifiers::UserId,
+    };
+    use openmls::prelude::{CredentialWithKey, KeyPackage, SignaturePublicKey};
+    use openmls_traits::OpenMlsProvider;
+    use sqlx::{Row, SqlitePool, query, query_scalar};
+    use url::Host;
+
+    use crate::{
+        clients::CIPHERSUITE, db::access::DbAccess, groups::openmls_provider::AirOpenMlsProvider,
+    };
+
+    use super::*;
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_mark_key_packages_as_live() -> anyhow::Result<()> {
+        // Note: We don't use `sqlx::test` and instead create manually a pool, because we must
+        // run on a multi-threaded flavor of tokio runtime, because `AirOpenMlsProvider` blocks
+        // the current thread.
+        let pool = SqlitePool::connect("sqlite://:memory:").await?;
+        sqlx::migrate!("./migrations").run(&pool).await?;
+
+        let pool = DbAccess::for_tests(pool);
+
+        let mut connection = pool.write().await?;
+        let provider = AirOpenMlsProvider::new(connection.as_mut());
+
+        let user_id = UserId::random(Host::Domain("example.com".to_string()).into());
+        let (_aic_sk, client_sk) = create_test_credentials(user_id);
+
+        let credential_with_key = CredentialWithKey {
+            credential: client_sk.credential().try_into().unwrap(),
+            signature_key: SignaturePublicKey::from(client_sk.credential().verifying_key().clone()),
+        };
+
+        let key_packages: Vec<KeyPackage> = (0..3)
+            .map(|_| {
+                let bundle = KeyPackage::builder()
+                    .build(
+                        CIPHERSUITE,
+                        &provider,
+                        &client_sk,
+                        credential_with_key.clone(),
+                    )
+                    .unwrap();
+                bundle.key_package().clone()
+            })
+            .collect();
+
+        let live_key_package_ref = key_packages[0].hash_ref(provider.crypto())?;
+        let stale_key_package_ref = key_packages[1].hash_ref(provider.crypto())?;
+        let new_key_package_ref = key_packages[2].hash_ref(provider.crypto())?;
+
+        query("INSERT INTO key_package_refs (key_package_ref, is_live) VALUES (?1, 1)")
+            .bind(KeyRefWrapper(&live_key_package_ref))
+            .execute(pool.write().await?.as_mut())
+            .await?;
+        query("INSERT INTO key_package_refs (key_package_ref, is_live) VALUES (?1, 0)")
+            .bind(KeyRefWrapper(&stale_key_package_ref))
+            .execute(pool.write().await?.as_mut())
+            .await?;
+
+        pool.with_write_transaction(async |txn| {
+            let is_apq = false;
+            mark_key_packages_as_live(txn, std::slice::from_ref(&new_key_package_ref), is_apq).await
+        })
+        .await?;
+
+        let rows = query(
+            "SELECT key_package_ref, is_live \
+                FROM key_package kp \
+                LEFT JOIN key_package_refs kpr USING (key_package_ref)
+                ORDER BY is_live ASC",
+        )
+        .fetch_all(pool.read().await?.as_mut())
+        .await?;
+
+        let key_packages: Vec<(KeyPackageRef, Option<bool>)> = rows
+            .into_iter()
+            .map(|row| {
+                let bytes: Vec<u8> = row.get(0);
+                let key_package_ref: KeyPackageRef = PersistenceCodec::from_slice(&bytes).unwrap();
+                let is_live: Option<bool> = row.get(1);
+                (key_package_ref, is_live)
+            })
+            .collect();
+
+        assert_eq!(key_packages.len(), 2); // stale key package is deleted
+
+        let (key_package_ref, is_live) = &key_packages[0];
+        assert_eq!(key_package_ref, &live_key_package_ref);
+        assert_eq!(is_live, &Some(false));
+
+        let (key_package_ref, is_live) = &key_packages[1];
+        assert_eq!(key_package_ref, &new_key_package_ref);
+        assert_eq!(is_live, &Some(true));
+
+        let num_refs: i32 = query_scalar("SELECT COUNT(*) FROM key_package_refs")
+            .fetch_one(pool.read().await?.as_mut())
+            .await?;
+        assert_eq!(num_refs, 2);
+
+        Ok(())
+    }
+}

--- a/coreclient/src/key_stores/mod.rs
+++ b/coreclient/src/key_stores/mod.rs
@@ -41,6 +41,7 @@ use serde::{Deserialize, Serialize};
 
 pub(crate) mod as_credentials;
 pub(crate) mod indexed_keys;
+pub(crate) mod key_package_refs;
 pub(crate) mod queue_ratchets;
 
 // For now we persist the key store along with the user. Any key material that gets rotated in the future needs to be persisted separately.

--- a/coreclient/src/outbound_service/key_packages.rs
+++ b/coreclient/src/outbound_service/key_packages.rs
@@ -1,0 +1,177 @@
+// SPDX-FileCopyrightText: 2026 Phoenix R&D GmbH <hello@phnx.im>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+use apqmls::messages::ApqKeyPackage;
+use chrono::Duration;
+use openmls::prelude::{KeyPackage, KeyPackageRef};
+use openmls_rust_crypto::OpenMlsRustCrypto;
+use openmls_traits::OpenMlsProvider;
+use tracing::{error, info};
+
+use crate::{
+    db::access::DbAccess,
+    key_stores::{
+        MemoryUserKeyStore,
+        key_package_refs::{delete_orphaned_key_packages, mark_key_packages_as_live},
+    },
+    outbound_service::{APQ_KEY_PACKAGES, KEY_PACKAGES, OutboundServiceContext},
+};
+
+impl OutboundServiceContext {
+    pub(super) async fn upload_key_packages(&self) -> anyhow::Result<Duration> {
+        let batch = self.generate_key_packages().await?; // shared: plain + APQ
+        self.upload_via_publish(batch).await
+    }
+
+    async fn upload_via_publish(&self, batch: KeyPackageBatch) -> anyhow::Result<Duration> {
+        info!(
+            plain = batch.plain.len(),
+            apq = batch.apq.len(),
+            "Uploading key packages via publish"
+        );
+
+        let api_client = self.api_clients.default_client()?;
+
+        let key_package_refs = batch.references()?;
+
+        // Publish plain key packages
+        if let Err(error) = api_client
+            .qs_publish_key_packages(
+                self.qs_client_id,
+                batch.plain,
+                &self.key_store.qs_client_signing_key,
+            )
+            .await
+        {
+            error!(%error, "Failed to upload key packages via publish");
+            key_package_refs
+                .cleanup(&self.db, &self.key_store, Cleanup::All)
+                .await;
+            return Err(error.into());
+        }
+        self.db
+            .with_write_transaction(async |txn| -> anyhow::Result<()> {
+                mark_key_packages_as_live(txn, key_package_refs.plain.as_slice(), false).await?;
+                Ok(())
+            })
+            .await?;
+
+        // Publish APQ key packages
+        if let Err(error) = api_client
+            .qs_publish_apq_key_packages(
+                self.qs_client_id,
+                batch.apq,
+                &self.key_store.qs_client_signing_key,
+            )
+            .await
+        {
+            error!(%error, "Failed to upload APQ key packages via publish");
+            key_package_refs
+                .cleanup(&self.db, &self.key_store, Cleanup::ApqOnly)
+                .await;
+            return Err(error.into());
+        }
+        self.db
+            .with_write_transaction(async |txn| -> anyhow::Result<()> {
+                mark_key_packages_as_live(txn, key_package_refs.apq.as_slice(), true).await?;
+                delete_orphaned_key_packages(txn).await?;
+                Ok(())
+            })
+            .await?;
+
+        info!("Uploaded key packages");
+
+        Ok(Duration::weeks(1))
+    }
+
+    async fn generate_key_packages(&self) -> anyhow::Result<KeyPackageBatch> {
+        self.db
+            .with_write_transaction(async move |txn| {
+                let mut plain = Vec::with_capacity(KEY_PACKAGES + 1);
+                // Non-last resort key packages
+                for _ in 0..KEY_PACKAGES {
+                    plain.push(self.key_store.generate_key_package(
+                        &mut *txn,
+                        &self.qs_client_id,
+                        false,
+                    )?);
+                }
+                // Last resort key package
+                plain.push(self.key_store.generate_key_package(
+                    &mut *txn,
+                    &self.qs_client_id,
+                    true,
+                )?);
+
+                // Non-last resort APQ key packages
+                let mut apq = Vec::with_capacity(APQ_KEY_PACKAGES + 1);
+                #[expect(clippy::reversed_empty_ranges)]
+                for _ in 0..APQ_KEY_PACKAGES {
+                    apq.push(self.key_store.generate_apq_key_package(
+                        &mut *txn,
+                        &self.qs_client_id,
+                        false,
+                    )?);
+                }
+                // Last resort APQ key package
+                apq.push(
+                    self.key_store
+                        .generate_apq_key_package(txn, &self.qs_client_id, true)?,
+                );
+
+                Ok(KeyPackageBatch { plain, apq })
+            })
+            .await
+    }
+}
+
+struct KeyPackageBatch {
+    plain: Vec<KeyPackage>,
+    apq: Vec<ApqKeyPackage>,
+}
+
+struct KeyPackageRefsBatch {
+    plain: Vec<KeyPackageRef>,
+    apq: Vec<KeyPackageRef>,
+}
+
+impl KeyPackageBatch {
+    /// Collect all key package references.
+    fn references(&self) -> anyhow::Result<KeyPackageRefsBatch> {
+        let crypto_provider = OpenMlsRustCrypto::default();
+        let mut plain = Vec::with_capacity(self.plain.len());
+        for kp in &self.plain {
+            plain.push(kp.hash_ref(crypto_provider.crypto())?);
+        }
+        let mut apq = Vec::with_capacity(2 * self.apq.len());
+        for apq_kp in &self.apq {
+            apq.push(apq_kp.t_key_package().hash_ref(crypto_provider.crypto())?);
+            apq.push(apq_kp.pq_key_package().hash_ref(crypto_provider.crypto())?);
+        }
+        Ok(KeyPackageRefsBatch { plain, apq })
+    }
+}
+
+enum Cleanup {
+    All,
+    ApqOnly,
+}
+
+impl KeyPackageRefsBatch {
+    async fn cleanup(self, db: &DbAccess, key_store: &MemoryUserKeyStore, cleanup: Cleanup) {
+        let Ok(mut write) = db.write().await else {
+            error!("Failed to acquire write lock for key package cleanup");
+            return;
+        };
+        let packages = match cleanup {
+            Cleanup::All => self.plain.into_iter().chain(self.apq),
+            Cleanup::ApqOnly => self.apq.into_iter().chain(Vec::new()),
+        };
+        for key_package_ref in packages {
+            if let Err(error) = key_store.delete_key_package(&mut write, key_package_ref) {
+                error!(%error, "Failed to delete key package after upload failure");
+            }
+        }
+    }
+}

--- a/coreclient/src/outbound_service/mod.rs
+++ b/coreclient/src/outbound_service/mod.rs
@@ -33,6 +33,7 @@ pub use timed_tasks::{APQ_KEY_PACKAGES, KEY_PACKAGES};
 mod chat_message_queue;
 mod chat_messages;
 mod error;
+mod key_packages;
 mod profile;
 mod push_tokens;
 mod reaction_queue;

--- a/coreclient/src/outbound_service/timed_tasks.rs
+++ b/coreclient/src/outbound_service/timed_tasks.rs
@@ -5,8 +5,6 @@
 use aircommon::identifiers::USERNAME_REFRESH_THRESHOLD;
 use airprotos::{auth_service::v1::OperationType, client::group::GroupData};
 use chrono::{DateTime, Duration, Utc};
-use openmls::prelude::OpenMlsProvider;
-use openmls_rust_crypto::OpenMlsRustCrypto;
 use serde::{Deserialize, Serialize};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, warn};
@@ -70,7 +68,6 @@ impl OperationData for TimedTask {
         id.extend_from_slice(b"timed_task");
         match self.kind {
             TimedTaskKind::KeyPackageUpload => id.push(0),
-            TimedTaskKind::ApqKeyPackageUpload => id.push(4),
             TimedTaskKind::UsernameRefresh => id.push(1),
             TimedTaskKind::SelfUpdate => id.push(2),
             TimedTaskKind::TokenReplenishment { operation_type } => {
@@ -85,7 +82,7 @@ impl OperationData for TimedTask {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) enum TimedTaskKind {
     KeyPackageUpload,
-    ApqKeyPackageUpload,
+    // reserved 4 = removed ApqKeyPackageUpload
     #[serde(alias = "HandleRefresh")]
     UsernameRefresh,
     SelfUpdate,
@@ -99,7 +96,6 @@ impl TimedTaskKind {
     pub(super) fn default_retry_interval(&self) -> Duration {
         match self {
             TimedTaskKind::KeyPackageUpload => Duration::minutes(5),
-            TimedTaskKind::ApqKeyPackageUpload => Duration::minutes(5),
             TimedTaskKind::UsernameRefresh => Duration::minutes(5),
             TimedTaskKind::SelfUpdate => Duration::minutes(5),
             TimedTaskKind::TokenReplenishment { operation_type } => match operation_type {
@@ -222,10 +218,7 @@ impl OutboundServiceContext {
             .into_operation()
             .enqueue_if_not_exists(self.db.write().await?)
             .await?;
-        TimedTask::new(TimedTaskKind::ApqKeyPackageUpload)
-            .into_operation()
-            .enqueue_if_not_exists(self.db.write().await?)
-            .await?;
+        // TODO delete old apq key packages upload task
         TimedTask::new(TimedTaskKind::UsernameRefresh)
             .into_operation()
             .enqueue_if_not_exists(self.db.write().await?)
@@ -254,7 +247,6 @@ impl OutboundServiceContext {
 
         match task_kind {
             TimedTaskKind::KeyPackageUpload => self.upload_key_packages().await,
-            TimedTaskKind::ApqKeyPackageUpload => self.upload_apq_key_packages().await,
             TimedTaskKind::UsernameRefresh => self.refresh_usernames().await,
             TimedTaskKind::SelfUpdate => self.self_update(run_token).await,
             TimedTaskKind::TokenReplenishment { operation_type } => {
@@ -417,145 +409,6 @@ impl OutboundServiceContext {
                 }
             }
         }
-    }
-
-    /// This function does the following:
-    /// 1. Generate a number of new key packages
-    /// 2. Upload them to the QS (and clean up on failure)
-    /// 3. Delete key packages that are marked stale
-    /// 4. Mark key packages stale that were previously marked live
-    /// 5. Marks the uploaded key packages as live in the database
-    async fn upload_key_packages(&self) -> anyhow::Result<Duration> {
-        let key_packages = self
-            .db
-            .with_write_transaction(async |txn| {
-                let mut key_packages = Vec::with_capacity(KEY_PACKAGES + 1);
-                for _ in 0..KEY_PACKAGES {
-                    let kp = self.key_store.generate_key_package(
-                        &mut *txn,
-                        &self.qs_client_id,
-                        false,
-                    )?;
-                    key_packages.push(kp);
-                }
-
-                let last_resort_kp =
-                    self.key_store
-                        .generate_key_package(txn, &self.qs_client_id, true)?;
-                key_packages.push(last_resort_kp);
-
-                Ok::<_, anyhow::Error>(key_packages)
-            })
-            .await?;
-
-        let crypto_provider = OpenMlsRustCrypto::default();
-        let key_package_refs = key_packages
-            .iter()
-            .map(|kp| kp.hash_ref(crypto_provider.crypto()))
-            .collect::<Result<Vec<_>, _>>()?;
-
-        info!(n = key_packages.len(), "Uploading key packages");
-        if let Err(error) = self
-            .api_clients
-            .default_client()?
-            .qs_publish_key_packages(
-                self.qs_client_id,
-                key_packages,
-                &self.key_store.qs_client_signing_key,
-            )
-            .await
-        {
-            error!(%error, "Failed to upload key packages");
-            // Clean up previously created key packages
-            for key_package_ref in key_package_refs {
-                if let Err(error) = self
-                    .key_store
-                    .delete_key_package(self.db.write().await?, key_package_ref)
-                {
-                    error!(%error, "Failed to delete key package after upload failure");
-                }
-            }
-
-            return Err(error.into());
-        }
-        info!("Uploaded key packages");
-
-        // If the upload was successful, we mark the uploaded ones as live and
-        // mark the others as stale.
-        self.db
-            .with_write_transaction(async |txn| {
-                let is_apq = false;
-                persistence::mark_key_packages_as_live(txn, &key_package_refs, is_apq).await
-            })
-            .await?;
-
-        Ok(Duration::weeks(1))
-    }
-
-    /// Same as [`Self::upload_key_packages`], but for APQ key packages.
-    ///
-    /// For now, we only upload one last resort APQ key package.
-    async fn upload_apq_key_packages(&self) -> anyhow::Result<Duration> {
-        let last_resort_key_package = self
-            .db
-            .with_write_transaction(async |txn| {
-                self.key_store
-                    .generate_apq_key_package(&mut *txn, &self.qs_client_id, true)
-            })
-            .await?;
-        let key_packages = vec![last_resort_key_package];
-
-        let crypto_provider = OpenMlsRustCrypto::default();
-        let key_package_refs = key_packages
-            .iter()
-            .map(|kp| {
-                let t_ref = kp.t_key_package().hash_ref(crypto_provider.crypto())?;
-                let pq_ref = kp.pq_key_package().hash_ref(crypto_provider.crypto())?;
-                Ok([t_ref, pq_ref])
-            })
-            .collect::<anyhow::Result<Vec<_>>>()?;
-
-        info!(n = key_packages.len(), "Uploading key packages");
-        if let Err(error) = self
-            .api_clients
-            .default_client()?
-            .qs_publish_apq_key_packages(
-                self.qs_client_id,
-                key_packages,
-                &self.key_store.qs_client_signing_key,
-            )
-            .await
-        {
-            error!(%error, "Failed to upload key packages");
-            // Clean up previously created key packages
-            for key_package_ref in key_package_refs.into_iter().flatten() {
-                if let Err(error) = self
-                    .key_store
-                    .delete_key_package(self.db.write().await?, key_package_ref)
-                {
-                    error!(%error, "Failed to delete key package after upload failure");
-                }
-            }
-
-            return Err(error.into());
-        }
-        info!("Uploaded key packages");
-
-        // If the upload was successful, we mark the uploaded ones as live and
-        // mark the others as stale.
-        self.db
-            .with_write_transaction(async |txn| {
-                let is_apq = true;
-                persistence::mark_key_packages_as_live(
-                    txn,
-                    key_package_refs.iter().flatten(),
-                    is_apq,
-                )
-                .await
-            })
-            .await?;
-
-        Ok(Duration::weeks(1))
     }
 
     async fn self_update(&self, run_token: &CancellationToken) -> anyhow::Result<Duration> {
@@ -738,191 +591,4 @@ fn legacy_group_data_migration(
         _ => None,
     };
     Some(ChatAttributes::new(title, legacy_picture))
-}
-
-mod persistence {
-    use openmls::prelude::KeyPackageRef;
-    use sqlx::{AssertSqlSafe, QueryBuilder};
-
-    use crate::{db::access::WriteDbTransaction, groups::openmls_provider::KeyRefWrapper};
-
-    pub(super) async fn mark_key_packages_as_live(
-        txn: &mut WriteDbTransaction<'_>,
-        key_package_refs: impl IntoIterator<Item = &KeyPackageRef>,
-        is_apq: bool,
-    ) -> anyhow::Result<()> {
-        let refs_table = if is_apq {
-            "apq_key_package_refs"
-        } else {
-            "key_package_refs"
-        };
-        mark_key_packages_as_live_impl(txn, refs_table, key_package_refs).await
-    }
-
-    async fn mark_key_packages_as_live_impl(
-        txn: &mut WriteDbTransaction<'_>,
-        refs_table: &'static str,
-        key_package_refs: impl IntoIterator<Item = &KeyPackageRef>,
-    ) -> anyhow::Result<()> {
-        // Delete all key packages that are not marked as live
-        sqlx::query(AssertSqlSafe(format!(
-            "DELETE FROM key_package
-            WHERE key_package_ref IN (
-              SELECT key_package_ref
-              FROM {refs_table}
-              WHERE is_live = 0
-            )"
-        )))
-        .execute(txn.as_mut())
-        .await?;
-
-        // Mark all key packages as stale
-        sqlx::query(AssertSqlSafe(format!(
-            "UPDATE {refs_table}
-            SET is_live = 0
-            WHERE is_live = 1",
-        )))
-        .execute(txn.as_mut())
-        .await?;
-
-        // Add the newly uploaded ones as 'live'.
-        let mut qb = QueryBuilder::new(format!(
-            "INSERT INTO {refs_table} (key_package_ref, is_live) VALUES "
-        ));
-        let mut vals = qb.separated(", ");
-        for r in key_package_refs {
-            let r = KeyRefWrapper(r);
-            vals.push("(")
-                .push_bind_unseparated(r)
-                .push_unseparated(", 1)");
-        }
-        qb.build().execute(txn.as_mut()).await?;
-
-        // Delete orphaned key packages (usually this is a no-op).
-        // Must check both tables so regular and APQ key packages don't clobber each other.
-        sqlx::query(
-            "DELETE FROM key_package WHERE key_package_ref NOT IN (
-                SELECT key_package_ref FROM key_package_refs
-                UNION
-                SELECT key_package_ref FROM apq_key_package_refs
-            )",
-        )
-        .execute(txn.as_mut())
-        .await?;
-
-        Ok(())
-    }
-
-    #[cfg(test)]
-    mod test {
-        use aircommon::{
-            codec::PersistenceCodec, credentials::test_utils::create_test_credentials,
-            identifiers::UserId,
-        };
-        use openmls::prelude::{CredentialWithKey, KeyPackage, SignaturePublicKey};
-        use openmls_traits::OpenMlsProvider;
-        use sqlx::{Row, SqlitePool, query, query_scalar};
-        use url::Host;
-
-        use crate::{
-            clients::CIPHERSUITE, db::access::DbAccess,
-            groups::openmls_provider::AirOpenMlsProvider,
-        };
-
-        use super::*;
-
-        #[tokio::test(flavor = "multi_thread")]
-        async fn test_mark_key_packages_as_live() -> anyhow::Result<()> {
-            // Note: We don't use `sqlx::test` and instead create manually a pool, because we must
-            // run on a multi-threaded flavor of tokio runtime, because `AirOpenMlsProvider` blocks
-            // the current thread.
-            let pool = SqlitePool::connect("sqlite://:memory:").await?;
-            sqlx::migrate!("./migrations").run(&pool).await?;
-
-            let pool = DbAccess::for_tests(pool);
-
-            let mut connection = pool.write().await?;
-            let provider = AirOpenMlsProvider::new(connection.as_mut());
-
-            let user_id = UserId::random(Host::Domain("example.com".to_string()).into());
-            let (_aic_sk, client_sk) = create_test_credentials(user_id);
-
-            let credential_with_key = CredentialWithKey {
-                credential: client_sk.credential().try_into().unwrap(),
-                signature_key: SignaturePublicKey::from(
-                    client_sk.credential().verifying_key().clone(),
-                ),
-            };
-
-            let key_packages: Vec<KeyPackage> = (0..3)
-                .map(|_| {
-                    let bundle = KeyPackage::builder()
-                        .build(
-                            CIPHERSUITE,
-                            &provider,
-                            &client_sk,
-                            credential_with_key.clone(),
-                        )
-                        .unwrap();
-                    bundle.key_package().clone()
-                })
-                .collect();
-
-            let live_key_package_ref = key_packages[0].hash_ref(provider.crypto())?;
-            let stale_key_package_ref = key_packages[1].hash_ref(provider.crypto())?;
-            let new_key_package_ref = key_packages[2].hash_ref(provider.crypto())?;
-
-            query("INSERT INTO key_package_refs (key_package_ref, is_live) VALUES (?1, 1)")
-                .bind(KeyRefWrapper(&live_key_package_ref))
-                .execute(pool.write().await?.as_mut())
-                .await?;
-            query("INSERT INTO key_package_refs (key_package_ref, is_live) VALUES (?1, 0)")
-                .bind(KeyRefWrapper(&stale_key_package_ref))
-                .execute(pool.write().await?.as_mut())
-                .await?;
-
-            pool.with_write_transaction(async |txn| {
-                let is_apq = false;
-                mark_key_packages_as_live(txn, [&new_key_package_ref], is_apq).await
-            })
-            .await?;
-
-            let rows = query(
-                "SELECT key_package_ref, is_live \
-                FROM key_package kp \
-                LEFT JOIN key_package_refs kpr USING (key_package_ref)
-                ORDER BY is_live ASC",
-            )
-            .fetch_all(pool.read().await?.as_mut())
-            .await?;
-
-            let key_packages: Vec<(KeyPackageRef, Option<bool>)> = rows
-                .into_iter()
-                .map(|row| {
-                    let bytes: Vec<u8> = row.get(0);
-                    let key_package_ref: KeyPackageRef =
-                        PersistenceCodec::from_slice(&bytes).unwrap();
-                    let is_live: Option<bool> = row.get(1);
-                    (key_package_ref, is_live)
-                })
-                .collect();
-
-            assert_eq!(key_packages.len(), 2); // stale key package is deleted
-
-            let (key_package_ref, is_live) = &key_packages[0];
-            assert_eq!(key_package_ref, &live_key_package_ref);
-            assert_eq!(is_live, &Some(false));
-
-            let (key_package_ref, is_live) = &key_packages[1];
-            assert_eq!(key_package_ref, &new_key_package_ref);
-            assert_eq!(is_live, &Some(true));
-
-            let num_refs: i32 = query_scalar("SELECT COUNT(*) FROM key_package_refs")
-                .fetch_one(pool.read().await?.as_mut())
-                .await?;
-            assert_eq!(num_refs, 2);
-
-            Ok(())
-        }
-    }
 }


### PR DESCRIPTION
Merge the plain and APQ key package upload timed tasks into one task in outbound_service/key_packages.rs. Ref bookkeeping moves to key_stores/key_package_refs.rs. Orphaned key packages are removed only after both the plain and the APQ half of a batch are uploaded, closing the window where one upload could delete the other kind's bundles.