### PR TITLE
fix(app): keep outbound service alive when the global lock fails

### DIFF
--- a/coreclient/src/outbound_service/mod.rs
+++ b/coreclient/src/outbound_service/mod.rs
@@ -221,10 +221,20 @@ impl<C: OutboundServiceWork> OutboundServiceTask<C> {
             };
 
             {
-                let _guard = global_lock
-                    .lock()
-                    .await
-                    .expect("fatal: failed to acquire global lock");
+                let _guard = match global_lock.lock().await {
+                    Ok(guard) => guard,
+                    Err(error) => {
+                        error!(
+                            %error,
+                            "failed to acquire global lock, skipping outbound service run"
+                        );
+                        // This run is skipped and the periodic wake retries the work soon. That is
+                        // why the ticker is not reset here. The task must stay alive, because all
+                        // awaiters of the done token would hang forever otherwise.
+                        run_token.mark_as_done();
+                        continue;
+                    }
+                };
                 debug!("starting doing work in background task");
                 self.context.work(run_token.cancel.clone()).await;
                 debug!("finished work in background task");
@@ -475,6 +485,36 @@ mod test {
         service.start().await;
 
         assert_eq!(1, context.counter.load(Ordering::SeqCst));
+    }
+
+    /// A failing lock must not kill the background task.
+    ///
+    /// The lock file lives in a directory which does not exist, so every acquisition fails fast.
+    /// The Android global lock is an in-process mutex which never fails, hence the cfg gate.
+    #[cfg(not(target_os = "android"))]
+    #[tokio::test]
+    async fn lock_failure_does_not_kill_background_task() {
+        init_test_tracing();
+
+        let lock = GlobalLock::from_path("/nonexistent/outbound-service.lock")
+            .expect("failed to create the global lock");
+        let context = DelayedCounterContext::default();
+        let service = OutboundService::with_context(context.clone(), lock);
+
+        timeout(Duration::from_secs(5), service.start())
+            .await
+            .expect("start must not hang when the lock cannot be acquired");
+
+        // Without the lock the work never runs.
+        assert_eq!(0, context.counter.load(Ordering::SeqCst));
+
+        // The background task is still alive and keeps serving new requests.
+        timeout(Duration::from_secs(5), service.notify_work())
+            .await
+            .expect("notify_work must not hang when the lock cannot be acquired");
+        timeout(Duration::from_secs(5), service.stop())
+            .await
+            .expect("stop must not hang when the lock cannot be acquired");
     }
 
     /// A short wake interval used in tests so the periodic ticker fires quickly.

--- a/coreclient/src/outbound_service/mod.rs
+++ b/coreclient/src/outbound_service/mod.rs
@@ -487,10 +487,6 @@ mod test {
         assert_eq!(1, context.counter.load(Ordering::SeqCst));
     }
 
-    /// A failing lock must not kill the background task.
-    ///
-    /// The lock file lives in a directory which does not exist, so every acquisition fails fast.
-    /// The Android global lock is an in-process mutex which never fails, hence the cfg gate.
     #[cfg(not(target_os = "android"))]
     #[tokio::test]
     async fn lock_failure_does_not_kill_background_task() {


### PR DESCRIPTION
The background task panicked when acquiring the global lock failed. The panic is swallowed by tokio::spawn, so the task died silently and every future returned by start, stop, or notify_work waited forever on a done token that was never cancelled. Lock acquisition can fail transiently, for example with SQLITE_BUSY under load, because the previous guard's connection closes asynchronously.

Log the error, mark the run as done and skip it instead. The periodic wake retries the work within the wake interval.