### PR TITLE
build(deps): bump event-listener from 5.4.1 to 5.4.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2803,11 +2803,10 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "5.4.1"
+version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
 dependencies = [
- "concurrent-queue",
  "parking",
  "pin-project-lite",
 ]


### PR DESCRIPTION
Fixes advisory https://rustsec.org/advisories/RUSTSEC-2026-0221.