### PR TITLE
fix(app): don't handle scroll notifications mid-layout in AnchoredList

### DIFF
--- a/app/lib/util/anchored_list/anchored_list.dart
+++ b/app/lib/util/anchored_list/anchored_list.dart
@@ -526,6 +526,12 @@ class _AnchoredListState<T> extends State<AnchoredList<T>> {
       return null;
     }
 
+    // A child that moved index has a null layoutOffset until the next layout
+    // pass; childMainAxisPosition would throw on it.
+    if (sliver.childScrollOffset(itemBox) == null) {
+      return null;
+    }
+
     // childMainAxisPosition gives the offset from the sliver's zero edge.
     // In a reversed list the zero edge is at the bottom, so we flip.
     var delta = sliver.childMainAxisPosition(itemBox);
@@ -700,6 +706,19 @@ class _AnchoredListState<T> extends State<AnchoredList<T>> {
   // -- Pagination --
 
   bool _handleScrollNotification(ScrollNotification notification) {
+    // A dimension change during the viewport's own layout can settle a
+    // ballistic activity and dispatch ScrollEndNotification synchronously,
+    // mid-layout. Reading child positions or driving the scroll position
+    // then corrupts the frame, so defer to post-frame and re-read metrics
+    // from the live position.
+    if (SchedulerBinding.instance.schedulerPhase ==
+        SchedulerPhase.persistentCallbacks) {
+      _scheduleViewportStateRefresh();
+      _schedulePaginationCheck();
+      _schedulePendingCommandProcessing();
+      return false;
+    }
+
     if (notification is ScrollUpdateNotification ||
         notification is ScrollEndNotification) {
       _checkPagination(notification.metrics);

--- a/app/lib/util/anchored_list/height_cache.dart
+++ b/app/lib/util/anchored_list/height_cache.dart
@@ -20,27 +20,24 @@ import 'dart:collection';
 ///    between older and newer messages. Without this, the average would
 ///    oscillate as pages are swapped, causing scrollbar jitter.
 ///
-/// [averageHeight] is derived from the estimate window using exponential
-/// moving average (EMA) smoothing, which dampens short-term fluctuations
-/// when a burst of unusually tall or short items is measured.
+/// [averageHeight] is the plain mean of the estimate window, and so a pure
+/// function of it: re-measuring an item at the same height leaves the
+/// average untouched. That matters because heights are recorded during
+/// layout, layout can run several passes per frame, and the average feeds
+/// the scroll extent estimate. An average that drifted per measurement
+/// would change the extent between passes of the same frame, making the
+/// viewport correct itself over and over.
+///
+/// The window size is what damps bursts of unusually tall or short items: a
+/// single outlier moves the mean by only 1/n of its deviation.
 class AnchoredListHeightCache {
   AnchoredListHeightCache({
     this.defaultHeight = 50.0,
-    this.estimateWarmupSamples = 8,
-    this.estimateSmoothingFactor = 0.25,
     this.maxRetainedEstimates = 256,
-  }) : _estimatedAverageHeight = defaultHeight;
+  });
 
   /// Fallback height for items never measured.
   final double defaultHeight;
-
-  /// Number of samples before EMA smoothing kicks in. During warmup the
-  /// average is computed directly to converge quickly from the default.
-  final int estimateWarmupSamples;
-
-  /// EMA alpha: 0.25 means ~25% weight on the new sample, ~75% on the
-  /// running average. Lower values smooth more aggressively.
-  final double estimateSmoothingFactor;
 
   /// Cap on the estimate window size. Oldest entries are evicted first.
   final int maxRetainedEstimates;
@@ -54,20 +51,20 @@ class AnchoredListHeightCache {
       LinkedHashMap<Object, double>();
   double _totalHeight = 0;
   double _estimatedTotalHeight = 0;
-  double _estimatedAverageHeight;
 
   int get cachedCount => _heights.length;
   double get totalHeight => _totalHeight;
 
-  double get averageHeight =>
-      _estimatedHeights.isNotEmpty ? _estimatedAverageHeight : defaultHeight;
+  double get averageHeight => _estimatedHeights.isEmpty
+      ? defaultHeight
+      : _estimatedTotalHeight / _estimatedHeights.length;
 
   double getHeight(Object id) => _heights[id] ?? defaultHeight;
 
   double? lookupHeight(Object id) => _heights[id];
 
   /// Records a measured height for [id]. Updates both the exact cache and
-  /// the estimate window, then refreshes the smoothed average.
+  /// the estimate window.
   void setHeight(Object id, double height) {
     final old = _heights[id];
     _heights[id] = height;
@@ -81,7 +78,6 @@ class AnchoredListHeightCache {
     _estimatedHeights[id] = height;
     _estimatedTotalHeight += height;
     _trimEstimatedHeights();
-    _refreshAverageEstimate();
   }
 
   /// Removes [id] from the exact cache only. The estimate window
@@ -97,7 +93,6 @@ class AnchoredListHeightCache {
     _estimatedHeights.clear();
     _totalHeight = 0;
     _estimatedTotalHeight = 0;
-    _estimatedAverageHeight = defaultHeight;
   }
 
   /// Evicts the oldest entries when the estimate window exceeds its cap.
@@ -109,28 +104,5 @@ class AnchoredListHeightCache {
         _estimatedTotalHeight -= removed;
       }
     }
-  }
-
-  /// Recomputes the smoothed average height.
-  ///
-  /// During warmup (≤ [estimateWarmupSamples]), uses the true average so
-  /// the estimate converges quickly from [defaultHeight]. After warmup,
-  /// applies EMA so that a sudden burst of tall/short items doesn't
-  /// cause the scroll extent to jump.
-  void _refreshAverageEstimate() {
-    if (_estimatedHeights.isEmpty) {
-      _estimatedAverageHeight = defaultHeight;
-      return;
-    }
-
-    final targetAverage = _estimatedTotalHeight / _estimatedHeights.length;
-    if (_estimatedHeights.length <= estimateWarmupSamples) {
-      _estimatedAverageHeight = targetAverage;
-      return;
-    }
-
-    // EMA: new_avg = old_avg + α × (sample_avg − old_avg)
-    _estimatedAverageHeight +=
-        (targetAverage - _estimatedAverageHeight) * estimateSmoothingFactor;
   }
 }

--- a/app/test/util/anchored_list_test.dart
+++ b/app/test/util/anchored_list_test.dart
@@ -5,6 +5,7 @@
 import 'package:air/util/anchored_list/anchored_list.dart';
 import 'package:air/util/anchored_list/controller.dart';
 import 'package:air/util/anchored_list/data.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -455,6 +456,147 @@ void main() {
           closeTo(topPadding, 0.5),
           reason: 'item $target landed at $relativeTop, expected $topPadding',
         );
+      }
+    });
+  });
+
+  group('AnchoredList frame safety', () {
+    // Sending shifts every index while the composer collapses and the image
+    // decodes. Each changes maxScrollExtent mid-layout, which used to
+    // dispatch a scroll notification we handled against a half-laid-out
+    // sliver.
+    Widget buildResizingSubject({
+      required AnchoredListData<int> data,
+      required AnchoredListController controller,
+      required Map<int, double> heights,
+      required ValueListenable<double> bottomPadding,
+      required double viewportHeight,
+    }) {
+      return MaterialApp(
+        home: Scaffold(
+          body: SizedBox(
+            width: 400,
+            height: viewportHeight,
+            child: ValueListenableBuilder<double>(
+              valueListenable: bottomPadding,
+              builder: (context, padding, _) => AnchoredList<int>(
+                data: data,
+                controller: controller,
+                idExtractor: (item) => item,
+                canLoadOlder: false,
+                canLoadNewer: false,
+                topPadding: 100,
+                bottomPadding: padding,
+                itemBuilder: (context, item, index) => SizedBox(
+                  height: heights[item] ?? 40,
+                  child: const ColoredBox(color: Colors.blue),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+    }
+
+    testWidgets(
+      'sending a tall item at the oldest edge keeps the frame valid',
+      (tester) async {
+        tester.view.physicalSize = const Size(400, 600);
+        tester.view.devicePixelRatio = 1.0;
+        addTearDown(() {
+          tester.view.resetPhysicalSize();
+          tester.view.resetDevicePixelRatio();
+        });
+
+        final heights = <int, double>{for (var i = 0; i < 3000; i++) i: 40.0};
+        for (var i = 0; i < 3000; i += 9) {
+          heights[i] = 900.0;
+        }
+        final data = AnchoredListData<int>(List.generate(3000, (i) => i));
+        final controller = AnchoredListController();
+        final bottomPadding = ValueNotifier<double>(80);
+        addTearDown(bottomPadding.dispose);
+
+        await tester.pumpWidget(
+          buildResizingSubject(
+            data: data,
+            controller: controller,
+            heights: heights,
+            bottomPadding: bottomPadding,
+            viewportHeight: 600,
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        // Scrolled to the oldest loaded message: in a reversed list that puts
+        // pixels at maxScrollExtent, so physics clamps on every layout pass.
+        controller.position!.jumpTo(controller.position!.maxScrollExtent);
+        await tester.pumpAndSettle();
+
+        for (var n = 0; n < 10; n++) {
+          final id = 3000 + n;
+          // Composer grows with the attachment preview.
+          bottomPadding.value = 240;
+          data.insert(0, id);
+          heights[id] = 30; // placeholder, before the image decodes
+          await tester.pump();
+          expect(tester.takeException(), isNull, reason: 'insert $n');
+
+          // The image decodes: the row grows and the composer collapses back.
+          heights[id] = 460;
+          bottomPadding.value = 80;
+          await tester.pump();
+          expect(tester.takeException(), isNull, reason: 'decode $n');
+        }
+      },
+    );
+
+    testWidgets('stays valid when padding exceeds the viewport', (
+      tester,
+    ) async {
+      // Keyboard open plus an image preview in the composer can make the
+      // combined insets taller than the remaining viewport.
+      tester.view.physicalSize = const Size(400, 320);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(() {
+        tester.view.resetPhysicalSize();
+        tester.view.resetDevicePixelRatio();
+      });
+
+      final heights = <int, double>{for (var i = 0; i < 400; i++) i: 40.0};
+      for (var i = 0; i < 400; i += 9) {
+        heights[i] = 620.0;
+      }
+      final data = AnchoredListData<int>(List.generate(400, (i) => i));
+      final controller = AnchoredListController();
+      final bottomPadding = ValueNotifier<double>(240);
+      addTearDown(bottomPadding.dispose);
+
+      await tester.pumpWidget(
+        buildResizingSubject(
+          data: data,
+          controller: controller,
+          heights: heights,
+          bottomPadding: bottomPadding,
+          viewportHeight: 320,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      controller.position!.jumpTo(controller.position!.maxScrollExtent * 0.6);
+      await tester.pumpAndSettle();
+
+      for (var n = 0; n < 6; n++) {
+        final id = 400 + n;
+        data.insert(0, id);
+        heights[id] = 20;
+        await tester.pump();
+        expect(tester.takeException(), isNull, reason: 'insert $n');
+
+        heights[id] = 600;
+        bottomPadding.value = n.isEven ? 90 : 240;
+        await tester.pump();
+        expect(tester.takeException(), isNull, reason: 'decode $n');
       }
     });
   });

--- a/app/test/util/anchored_list_test.dart
+++ b/app/test/util/anchored_list_test.dart
@@ -461,10 +461,17 @@ void main() {
   });
 
   group('AnchoredList frame safety', () {
-    // Sending shifts every index while the composer collapses and the image
-    // decodes. Each changes maxScrollExtent mid-layout, which used to
-    // dispatch a scroll notification we handled against a half-laid-out
-    // sliver.
+    // Three things have to land on one frame: an insert at index 0 (which
+    // shifts every live child's index), a height change applied during the
+    // viewport's own layout, and a settling ballistic scroll. The settle is
+    // what dispatches a ScrollEndNotification from inside layout, and
+    // handling it there read a half-laid-out sliver, whose moved children
+    // still have a null layoutOffset.
+    //
+    // Images are the common trigger because their row resolves its real
+    // height a frame or more after the insert, at a time nothing
+    // coordinates -- so it can coincide with a settle. A text row is at its
+    // final height on the insert frame itself.
     Widget buildResizingSubject({
       required AnchoredListData<int> data,
       required AnchoredListController controller,
@@ -498,64 +505,65 @@ void main() {
       );
     }
 
-    testWidgets(
-      'sending a tall item at the oldest edge keeps the frame valid',
-      (tester) async {
-        tester.view.physicalSize = const Size(400, 600);
-        tester.view.devicePixelRatio = 1.0;
-        addTearDown(() {
-          tester.view.resetPhysicalSize();
-          tester.view.resetDevicePixelRatio();
-        });
+    testWidgets('sending an image while the list is still settling', (
+      tester,
+    ) async {
+      tester.view.physicalSize = const Size(400, 600);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(() {
+        tester.view.resetPhysicalSize();
+        tester.view.resetDevicePixelRatio();
+      });
 
-        final heights = <int, double>{for (var i = 0; i < 3000; i++) i: 40.0};
-        for (var i = 0; i < 3000; i += 9) {
-          heights[i] = 900.0;
-        }
-        final data = AnchoredListData<int>(List.generate(3000, (i) => i));
-        final controller = AnchoredListController();
-        final bottomPadding = ValueNotifier<double>(80);
-        addTearDown(bottomPadding.dispose);
+      final heights = <int, double>{for (var i = 0; i < 3000; i++) i: 40.0};
+      for (var i = 0; i < 3000; i += 9) {
+        heights[i] = 900.0;
+      }
+      final data = AnchoredListData<int>(List.generate(3000, (i) => i));
+      final controller = AnchoredListController();
+      // Insets stay constant: the row's own decode is the only dimension
+      // change, so nothing here depends on the composer.
+      final bottomPadding = ValueNotifier<double>(80);
+      addTearDown(bottomPadding.dispose);
 
-        await tester.pumpWidget(
-          buildResizingSubject(
-            data: data,
-            controller: controller,
-            heights: heights,
-            bottomPadding: bottomPadding,
-            viewportHeight: 600,
-          ),
-        );
-        await tester.pumpAndSettle();
+      await tester.pumpWidget(
+        buildResizingSubject(
+          data: data,
+          controller: controller,
+          heights: heights,
+          bottomPadding: bottomPadding,
+          viewportHeight: 600,
+        ),
+      );
+      await tester.pumpAndSettle();
 
-        // Scrolled to the oldest loaded message: in a reversed list that puts
-        // pixels at maxScrollExtent, so physics clamps on every layout pass.
-        controller.position!.jumpTo(controller.position!.maxScrollExtent);
-        await tester.pumpAndSettle();
+      // Flick upward and leave the list coasting, so the frames below land
+      // while a ballistic activity is still settling.
+      await tester.fling(
+        find.byType(CustomScrollView),
+        const Offset(0, 300),
+        800,
+      );
+      await tester.pump(const Duration(milliseconds: 40));
 
-        for (var n = 0; n < 10; n++) {
-          final id = 3000 + n;
-          // Composer grows with the attachment preview.
-          bottomPadding.value = 240;
-          data.insert(0, id);
-          heights[id] = 30; // placeholder, before the image decodes
-          await tester.pump();
-          expect(tester.takeException(), isNull, reason: 'insert $n');
+      for (var n = 0; n < 12; n++) {
+        final id = 3000 + n;
+        data.insert(0, id);
+        heights[id] = 30; // placeholder, before the image decodes
+        await tester.pump(const Duration(milliseconds: 16));
+        expect(tester.takeException(), isNull, reason: 'insert $n');
 
-          // The image decodes: the row grows and the composer collapses back.
-          heights[id] = 460;
-          bottomPadding.value = 80;
-          await tester.pump();
-          expect(tester.takeException(), isNull, reason: 'decode $n');
-        }
-      },
-    );
+        heights[id] = 700; // decoded, at its real height
+        await tester.pump(const Duration(milliseconds: 16));
+        expect(tester.takeException(), isNull, reason: 'decode $n');
+      }
+    });
 
     testWidgets('stays valid when padding exceeds the viewport', (
       tester,
     ) async {
-      // Keyboard open plus an image preview in the composer can make the
-      // combined insets taller than the remaining viewport.
+      // bottomPadding tracks the composer, so the keyboard opening can leave
+      // the combined insets taller than the remaining viewport.
       tester.view.physicalSize = const Size(400, 320);
       tester.view.devicePixelRatio = 1.0;
       addTearDown(() {

--- a/app/test/util/height_cache_test.dart
+++ b/app/test/util/height_cache_test.dart
@@ -21,30 +21,42 @@ void main() {
     expect(cache.getHeight(2), 50);
   });
 
-  test('dampens extent estimate changes after warmup', () {
-    final cache = AnchoredListHeightCache(
-      defaultHeight: 50,
-      estimateWarmupSamples: 3,
-      estimateSmoothingFactor: 0.25,
-    );
+  test('damps a tall outlier across the estimate window', () {
+    final cache = AnchoredListHeightCache(defaultHeight: 50);
 
-    cache.setHeight(1, 100);
-    cache.setHeight(2, 100);
-    cache.setHeight(3, 100);
+    for (var id = 0; id < 100; id++) {
+      cache.setHeight(id, 100);
+    }
     expect(cache.averageHeight, 100);
 
-    cache.setHeight(4, 500);
+    // One image among a hundred text rows barely moves the estimate.
+    cache.setHeight(100, 500);
+    expect(cache.averageHeight, closeTo(103.96, 0.01));
+  });
 
-    // The raw historical average would jump to 200 here. We damp the update
-    // so the scrollbar estimate changes more gradually as new items are
-    // measured during scrolling.
-    expect(cache.averageHeight, 125);
+  test('re-measuring the same heights leaves the average unchanged', () {
+    // Heights are recorded during layout, and layout can run several passes
+    // per frame over the same children. If re-measuring moved the average,
+    // the scroll extent estimate would differ between passes of one frame
+    // and the viewport would keep correcting itself.
+    final cache = AnchoredListHeightCache(defaultHeight: 50);
+
+    for (var id = 0; id < 20; id++) {
+      cache.setHeight(id, id.isEven ? 40 : 900);
+    }
+    final afterFirstPass = cache.averageHeight;
+
+    for (var pass = 0; pass < 5; pass++) {
+      for (var id = 0; id < 20; id++) {
+        cache.setHeight(id, id.isEven ? 40 : 900);
+      }
+      expect(cache.averageHeight, afterFirstPass);
+    }
   });
 
   test('caps retained historical estimates', () {
     final cache = AnchoredListHeightCache(
       defaultHeight: 50,
-      estimateWarmupSamples: 10,
       maxRetainedEstimates: 2,
     );
 


### PR DESCRIPTION
Sending a message (most often an image) blanked the message list with:

```
Null check operator used on a null value
#0  RenderSliverMultiBoxAdaptor.childMainAxisPosition (sliver_multi_box_adaptor.dart:660)
#1  RenderSliverMultiBoxAdaptor.paint (sliver_multi_box_adaptor.dart:728)
```

The send itself succeeded: this was purely a render-layer failure.

Scroll notifications aren't always dispatched from a safe phase: `_handleScrollNotification` handled that inline, so it walked the sliver's children and drove the scroll position while the sliver was half laid out.

Images make it more likely because a send inserts a sliver at index 0 while the composer's attachment preview goes away and the image decodes (so it triggers `applyNewDimensions` multiple times).