### PR TITLE
build(deps): upgrade openmls to the latest revision on main

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5222,8 +5222,8 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openmls"
-version = "0.8.1"
-source = "git+https://github.com/openmls/openmls?rev=65396d8ed3121506d1b9c7d0e6ec9fce1bed486d#65396d8ed3121506d1b9c7d0e6ec9fce1bed486d"
+version = "0.9.0-rc.1"
+source = "git+https://github.com/openmls/openmls?rev=17a17446f03715e61759febdca3792fc936df428#17a17446f03715e61759febdca3792fc936df428"
 dependencies = [
  "backtrace",
  "itertools 0.14.0",
@@ -5250,8 +5250,8 @@ dependencies = [
 
 [[package]]
 name = "openmls_basic_credential"
-version = "0.5.0"
-source = "git+https://github.com/openmls/openmls?rev=65396d8ed3121506d1b9c7d0e6ec9fce1bed486d#65396d8ed3121506d1b9c7d0e6ec9fce1bed486d"
+version = "0.6.0-rc.1"
+source = "git+https://github.com/openmls/openmls?rev=17a17446f03715e61759febdca3792fc936df428#17a17446f03715e61759febdca3792fc936df428"
 dependencies = [
  "ed25519-dalek",
  "ml-dsa",
@@ -5266,8 +5266,8 @@ dependencies = [
 
 [[package]]
 name = "openmls_libcrux_crypto"
-version = "0.3.1"
-source = "git+https://github.com/openmls/openmls?rev=65396d8ed3121506d1b9c7d0e6ec9fce1bed486d#65396d8ed3121506d1b9c7d0e6ec9fce1bed486d"
+version = "0.4.0-rc.1"
+source = "git+https://github.com/openmls/openmls?rev=17a17446f03715e61759febdca3792fc936df428#17a17446f03715e61759febdca3792fc936df428"
 dependencies = [
  "aes",
  "fpe",
@@ -5289,8 +5289,8 @@ dependencies = [
 
 [[package]]
 name = "openmls_memory_storage"
-version = "0.5.0"
-source = "git+https://github.com/openmls/openmls?rev=65396d8ed3121506d1b9c7d0e6ec9fce1bed486d#65396d8ed3121506d1b9c7d0e6ec9fce1bed486d"
+version = "0.6.0-rc.1"
+source = "git+https://github.com/openmls/openmls?rev=17a17446f03715e61759febdca3792fc936df428#17a17446f03715e61759febdca3792fc936df428"
 dependencies = [
  "hex",
  "log",
@@ -5302,8 +5302,8 @@ dependencies = [
 
 [[package]]
 name = "openmls_rust_crypto"
-version = "0.5.1"
-source = "git+https://github.com/openmls/openmls?rev=65396d8ed3121506d1b9c7d0e6ec9fce1bed486d#65396d8ed3121506d1b9c7d0e6ec9fce1bed486d"
+version = "0.6.0-rc.1"
+source = "git+https://github.com/openmls/openmls?rev=17a17446f03715e61759febdca3792fc936df428#17a17446f03715e61759febdca3792fc936df428"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -5330,8 +5330,8 @@ dependencies = [
 
 [[package]]
 name = "openmls_serialization_helpers"
-version = "0.1.0"
-source = "git+https://github.com/openmls/openmls?rev=65396d8ed3121506d1b9c7d0e6ec9fce1bed486d#65396d8ed3121506d1b9c7d0e6ec9fce1bed486d"
+version = "0.1.0-rc.1"
+source = "git+https://github.com/openmls/openmls?rev=17a17446f03715e61759febdca3792fc936df428#17a17446f03715e61759febdca3792fc936df428"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5341,8 +5341,8 @@ dependencies = [
 
 [[package]]
 name = "openmls_sqlite_storage"
-version = "0.2.0"
-source = "git+https://github.com/openmls/openmls?rev=65396d8ed3121506d1b9c7d0e6ec9fce1bed486d#65396d8ed3121506d1b9c7d0e6ec9fce1bed486d"
+version = "0.3.0-rc.1"
+source = "git+https://github.com/openmls/openmls?rev=17a17446f03715e61759febdca3792fc936df428#17a17446f03715e61759febdca3792fc936df428"
 dependencies = [
  "openmls_traits",
  "refinery",
@@ -5352,8 +5352,8 @@ dependencies = [
 
 [[package]]
 name = "openmls_test"
-version = "0.2.1"
-source = "git+https://github.com/openmls/openmls?rev=65396d8ed3121506d1b9c7d0e6ec9fce1bed486d#65396d8ed3121506d1b9c7d0e6ec9fce1bed486d"
+version = "0.3.0-rc.1"
+source = "git+https://github.com/openmls/openmls?rev=17a17446f03715e61759febdca3792fc936df428#17a17446f03715e61759febdca3792fc936df428"
 dependencies = [
  "openmls_libcrux_crypto",
  "openmls_rust_crypto",
@@ -5365,8 +5365,8 @@ dependencies = [
 
 [[package]]
 name = "openmls_traits"
-version = "0.5.0"
-source = "git+https://github.com/openmls/openmls?rev=65396d8ed3121506d1b9c7d0e6ec9fce1bed486d#65396d8ed3121506d1b9c7d0e6ec9fce1bed486d"
+version = "0.6.0-rc.1"
+source = "git+https://github.com/openmls/openmls?rev=17a17446f03715e61759febdca3792fc936df428#17a17446f03715e61759febdca3792fc936df428"
 dependencies = [
  "serde",
  "tls_codec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,12 +83,12 @@ minicbor = { version = "2.2.1", features = ["std"] }
 minicbor-serde = { version = "0.6", features = ["std"] }
 mockall = "0.13.1"
 mockito = "1.7.0"
-openmls = { version = "0.8.1", features = ["draft-ietf-mls-pq-ciphersuites", "unchecked-conversions", "0-8-1-storage-format", "virtual-clients-draft"] }
-openmls_basic_credential = { version = "0.5.0", features = ["clonable"] }
-openmls_memory_storage = { version = "0.5.0", features = ["draft-ietf-mls-pq-ciphersuites", "virtual-clients-draft"] }
-openmls_rust_crypto = { version = "0.5.1", features = ["draft-ietf-mls-pq-ciphersuites", "virtual-clients-draft"] }
-openmls_sqlite_storage = { version = "0.2.0", features = ["draft-ietf-mls-pq-ciphersuites", "virtual-clients-draft"] }
-openmls_traits = { version = "0.5.0", features = ["draft-ietf-mls-pq-ciphersuites", "virtual-clients-draft"] }
+openmls = { git = "https://github.com/openmls/openmls", rev = "17a17446f03715e61759febdca3792fc936df428", features = ["draft-ietf-mls-pq-ciphersuites", "unchecked-conversions", "0-8-1-storage-format", "virtual-clients-draft"] }
+openmls_basic_credential = { git = "https://github.com/openmls/openmls", rev = "17a17446f03715e61759febdca3792fc936df428", features = ["clonable"] }
+openmls_memory_storage = { git = "https://github.com/openmls/openmls", rev = "17a17446f03715e61759febdca3792fc936df428", features = ["draft-ietf-mls-pq-ciphersuites", "virtual-clients-draft"] }
+openmls_rust_crypto = { git = "https://github.com/openmls/openmls", rev = "17a17446f03715e61759febdca3792fc936df428", features = ["draft-ietf-mls-pq-ciphersuites", "virtual-clients-draft"] }
+openmls_sqlite_storage = { git = "https://github.com/openmls/openmls", rev = "17a17446f03715e61759febdca3792fc936df428", features = ["draft-ietf-mls-pq-ciphersuites", "virtual-clients-draft"] }
+openmls_traits = { git = "https://github.com/openmls/openmls", rev = "17a17446f03715e61759febdca3792fc936df428", features = ["draft-ietf-mls-pq-ciphersuites", "virtual-clients-draft"] }
 parking_lot = "0.12"
 pin-project = "1.1.10"
 png = "0.18.1"
@@ -139,13 +139,6 @@ zeroize = "1.8.2"
 
 
 [patch.crates-io]
-# Use unreleased post-quantum and virtual-clients features of openmls after the 0.8.1 release
-openmls = { git = "https://github.com/openmls/openmls", rev = "65396d8ed3121506d1b9c7d0e6ec9fce1bed486d" }
-openmls_rust_crypto = { git = "https://github.com/openmls/openmls", rev = "65396d8ed3121506d1b9c7d0e6ec9fce1bed486d" }
-openmls_traits = { git = "https://github.com/openmls/openmls", rev = "65396d8ed3121506d1b9c7d0e6ec9fce1bed486d" }
-openmls_memory_storage = { git = "https://github.com/openmls/openmls", rev = "65396d8ed3121506d1b9c7d0e6ec9fce1bed486d" }
-openmls_basic_credential = { git = "https://github.com/openmls/openmls", rev = "65396d8ed3121506d1b9c7d0e6ec9fce1bed486d" }
-openmls_sqlite_storage = { git = "https://github.com/openmls/openmls", rev = "65396d8ed3121506d1b9c7d0e6ec9fce1bed486d" }
 # openmls = { path = "../openmls/openmls" }
 # openmls_rust_crypto = { path = "../openmls/openmls_rust_crypto" }
 # openmls_traits = { path = "../openmls/traits" }

--- a/coreclient/src/groups/self_group_message_key.rs
+++ b/coreclient/src/groups/self_group_message_key.rs
@@ -425,6 +425,7 @@ mod derivation_tests {
         component::{AIR_COMPONENT_ID, AirComponent},
         self_group::{AppEphemeralPayload, SelfGroupMessage, SelfGroupMessages, SettingsUpdate},
     };
+    use openmls::group::{AppDataUpdateValidationError, CreateCommitError};
     use openmls::prelude::{AppEphemeralProposal, GroupId, Proposal};
     use openmls_traits::OpenMlsProvider;
     use uuid::Uuid;
@@ -639,14 +640,12 @@ mod derivation_tests {
         Ok(())
     }
 
-    /// A commit that flips the self-group flag is detectable: the live group
-    /// context still claims self-group, but the staged commit's provisional
-    /// context does not. This is exactly the difference the commit-time guard
-    /// in `post_process_staged_commit` rejects. The full guard runs against a
-    /// received commit and needs the client/DS stack, so it is covered by the
-    /// integration tests; here we exercise the helper on a real staged commit.
+    /// The group requires the AppDataUpdate proposal type, so a bare
+    /// GroupContextExtensions proposal must not touch the app data dictionary
+    /// (openmls/openmls#2125). The same validation runs on the receive path,
+    /// making the guard in `post_process_staged_commit` defense in depth.
     #[tokio::test(flavor = "multi_thread")]
-    async fn commit_flipping_self_group_flag_is_detectable() -> anyhow::Result<()> {
+    async fn commit_flipping_self_group_flag_is_rejected() -> anyhow::Result<()> {
         let pool = DbAccess::for_tests(open_db_in_memory().await?);
         let (_as_key, signer) = create_test_credentials(UserId::random("example.com".parse()?));
 
@@ -656,36 +655,29 @@ mod derivation_tests {
         let mut group = create_group(&mut txn, &signer, true)?;
         assert!(group.is_self_group());
 
-        // Build a group-context-extensions commit that clears the self-group
-        // flag by replacing the AIR component in the app data dictionary.
+        // Extensions that clear the self-group flag by replacing the AIR
+        // component in the app data dictionary.
         let mut flipped = group.mls_group().extensions().clone();
         flipped.add_or_replace(default_group_context_app_data_dictionary_extension(
             AirComponent::default_for_leaf_or_key_package(),
             None,
         ))?;
-        {
-            let provider = AirOpenMlsProvider::new(txn.as_mut());
-            let (t_mls_group, _pq_mls_group) = group.apq_mls_groups_mut()?;
-            t_mls_group
-                .commit_builder()
-                .propose_group_context_extensions(flipped)?
-                .load_psks(provider.storage())?
-                .build(provider.rand(), provider.crypto(), &signer, |_| true)?
-                .stage_commit(&provider)?;
-        }
+        assert!(!extensions_claim_self_group(&flipped));
 
-        let staged = group
-            .mls_group()
-            .pending_commit()
-            .expect("commit should be staged");
-        assert!(
-            extensions_claim_self_group(group.mls_group().extensions()),
-            "live context still claims self-group"
-        );
-        assert!(
-            !extensions_claim_self_group(staged.group_context().extensions()),
-            "staged commit context drops the self-group flag"
-        );
+        let provider = AirOpenMlsProvider::new(txn.as_mut());
+        let (t_mls_group, _pq_mls_group) = group.apq_mls_groups_mut()?;
+        let error = t_mls_group
+            .commit_builder()
+            .propose_group_context_extensions(flipped)?
+            .load_psks(provider.storage())?
+            .build(provider.rand(), provider.crypto(), &signer, |_| true)
+            .expect_err("building the flipped commit should fail");
+        assert!(matches!(
+            error,
+            CreateCommitError::AppDataUpdateValidationError(
+                AppDataUpdateValidationError::CannotUpdateDictionaryDirectly
+            )
+        ));
 
         txn.commit().await?;
         Ok(())


### PR DESCRIPTION
Also rewrite a test which was failing due to hardened openmls (openmls/openmls#2125).

The update is required for the new virtual client key packages upload protocol, because we have to be able to resolve own key material. The API was introduced in https://github.com/openmls/openmls/commit/17a17446f03715e61759febdca3792fc936df428.