### PR TITLE
chore(app): update Flutter to 3.44.8

### DIFF
--- a/.github/actions/setup-buildenv/action.yml
+++ b/.github/actions/setup-buildenv/action.yml
@@ -192,7 +192,7 @@ runs:
       uses: gferon/setup-flutter@1d849067b1961950d28aa76b231a2a88ce045b2e
       with:
         channel: stable
-        version: 3.44.0
+        version: 3.44.8
         cache: true
         cache-sdk: true
 

--- a/app/.fvmrc
+++ b/app/.fvmrc
@@ -1,5 +1,5 @@
 {
-  "flutter": "3.44.0",
+  "flutter": "3.44.8",
   "runPubGetOnSdkChanges": true,
   "updateVscodeSettings": true,
   "updateGitIgnore": true

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -1225,5 +1225,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.12.0 <4.0.0"
-  flutter: ">=3.38.4"
+  dart: ">=3.12.2 <4.0.0"
+  flutter: ">=3.44.8 <4.0.0"

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -655,10 +655,10 @@ packages:
     dependency: "direct main"
     description:
       name: mobile_scanner
-      sha256: c92c26bf2231695b6d3477c8dcf435f51e28f87b1745966b1fe4c47a286171ce
+      sha256: ce3f059ebd6dbfab7292bba0e893e354b46730636820d3c9ef69005ce2d55bce
       url: "https://pub.dev"
     source: hosted
-    version: "7.2.0"
+    version: "7.4.0"
   mocktail:
     dependency: "direct dev"
     description:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -22,7 +22,8 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 version: 0.20.0+1
 
 environment:
-  sdk: ">=3.12.0 <4.0.0"
+  sdk: ">=3.12.2 <4.0.0"
+  flutter: ">=3.44.8 <4.0.0"
 
 dependencies:
   flutter:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -54,7 +54,7 @@ dependencies:
   vector_graphics: ^1.1.19
   photo_view: ^0.15.0
   system_date_time_format: 1.4.0
-  mobile_scanner: ^7.2.0
+  mobile_scanner: ^7.4.0
 
 dev_dependencies:
   args: ^2.5.0


### PR DESCRIPTION
Fixes a combined issue with Android, Gradle, KGP and https://github.com/juliansteenbakker/mobile_scanner not compiling in the latest version, which is required to avoid a breakage due to Kotlin code obfuscation.

Manually tested on Android